### PR TITLE
user.Username not user.Name

### DIFF
--- a/pkg/bootstrap/os.go
+++ b/pkg/bootstrap/os.go
@@ -35,7 +35,7 @@ var registryCrt string
 
 func InitOS(mgr *manager.Manager) error {
 	user, _ := user.Current()
-	if user.Name != "root" {
+	if user.Username != "root" {
 		return errors.New(fmt.Sprintf("Current user is %s. Please use root!", user.Name))
 	}
 	mgr.Logger.Infoln("Init operating system")

--- a/pkg/bootstrap/os.go
+++ b/pkg/bootstrap/os.go
@@ -36,7 +36,7 @@ var registryCrt string
 func InitOS(mgr *manager.Manager) error {
 	user, _ := user.Current()
 	if user.Username != "root" {
-		return errors.New(fmt.Sprintf("Current user is %s. Please use root!", user.Name))
+		return errors.New(fmt.Sprintf("Current user is %s. Please use root!", user.Username))
 	}
 	mgr.Logger.Infoln("Init operating system")
 

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -38,7 +38,7 @@ func ParseClusterCfg(clusterCfgPath, k8sVersion, ksVersion string, ksEnabled boo
 	var clusterCfg *kubekeyapiv1alpha1.Cluster
 	if len(clusterCfgPath) == 0 {
 		user, _ := user.Current()
-		if user.Name != "root" {
+		if user.Username != "root" {
 			return nil, errors.New(fmt.Sprintf("Current user is %s. Please use root!", user.Name))
 		}
 		clusterCfg = AllinoneCfg(user, k8sVersion, ksVersion, ksEnabled, logger)


### PR DESCRIPTION
Please check golang source:
`go/src/os/user/user.go`
``` golang
        // Username is the login name.
	Username string
	// Name is the user's real or display name.
	// It might be blank.
	// On POSIX systems, this is the first (or only) entry in the GECOS field
	// list.
	// On Windows, this is the user's display name.
	// On Plan 9, this is the contents of /dev/user.
	Name string
```

The user.Name **might be blank**. And it is happening on my laptop `Linux version 5.8.6-1-MANJARO (builder@db927223e331)`

![image](https://user-images.githubusercontent.com/312404/94728863-77357500-0393-11eb-899f-a9f8d456f4aa.png)

It's better to user user.Username instead. 