### PR TITLE
Using a separate entry-point can reduce the size of the binary file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ LDFLAGS += -X github.com/kubesphere/kubekey/version.metadata=${VERSION_METADATA}
 LDFLAGS += -X github.com/kubesphere/kubekey/version.gitCommit=${GIT_COMMIT}
 LDFLAGS += -X github.com/kubesphere/kubekey/version.gitTreeState=${GIT_DIRTY}
 
+# see also kk-linux and kk-darwin
 binary:
 	docker run --rm \
 		-v $(shell pwd):/usr/src/myapp \
@@ -118,6 +119,12 @@ binary:
 		-w /usr/src/myapp golang:1.14 \
 		go build -ldflags '$(LDFLAGS)' -v -o output/linux/arm64/kk ./main.go  # linux
 	sha256sum output/linux/arm64/kk || shasum -a 256 output/linux/arm64/kk
+
+# build the binary file of kk
+kk-linux:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -ldflags '$(LDFLAGS)' -o bin/linux/amd64/kk ./cmd/kk/main.go
+kk-darwin:
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -ldflags '$(LDFLAGS)' -o bin/darwin/amd64/kk ./cmd/kk/main.go
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ KubeKey can install Kubernetes and KubeSphere together. The dependency that need
 
 ## Usage
 
-### Get the Installer Excutable File
+### Get the Installer Executable File
 
 * Binary downloads of the KubeKey can be found on the [Releases page](https://github.com/kubesphere/kubekey/releases).
   Unpack the binary and you are good to go!

--- a/cmd/kk/main.go
+++ b/cmd/kk/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/kubesphere/kubekey/cmd"
+
+// Using a separate entry-point can reduce the size of the binary file
+func main() {
+	cmd.Execute()
+}

--- a/main.go
+++ b/main.go
@@ -48,7 +48,9 @@ func init() {
 }
 
 func main() {
-
+	// This is fork flow of kk (aka kubekey)
+	// Please see also cmd/kk/main.go as an another main entry-point of kk
+	// In order to keep compatible, just remain the following code lines
 	if strings.Contains(os.Args[0], "kk") {
 		cmd.Execute()
 		os.Exit(0)


### PR DESCRIPTION
As we can see below, current PR could reduce about 3M of the binary file. But I don't know if it leads to new issues due to I haven't go through all the related code lines. So please don't hesitate to tell me if I missed anything.

```
-rwxr-xr-x  1 rick  staff    53M Nov  6 15:50 bin/darwin/amd64/kk
-rwxr-xr-x  1 rick  staff    56M Nov  6 15:50 bin/manager
```