### PR TITLE
Using goreleaser to publish deb and rpm package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.14
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Publish to Bintray
+        run: |
+          kkver=$(hub tag --list | sort -V | tail -n 1)
+          echo "start to upload rpm packages"
+          curl -T bin/kk-linux-64bit.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+            -H "X-Bintray-Package:kk" -H "X-Bintray-Version:${kkver}" \
+            https://api.bintray.com/content/kubesphere/rpm/kk/${kkver}/kk-linux-64bit.rpm
+          curl -T bin/kk-linux-arm64.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+            -H "X-Bintray-Package:kk" -H "X-Bintray-Version:$kkver" \
+            https://api.bintray.com/content/kubesphere/rpm/kk/$kkver/kk-linux-arm64.rpm
+          curl -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} -X POST https://api.bintray.com/content/kubesphere/rpm/kk/$kkver/publish
+
+          echo "start to upload deb packages"
+          curl -T bin/kk-linux-64bit.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+            -H "X-Bintray-Debian-Distribution:wheezy" -H "X-Bintray-Debian-Component:main" -H "X-Bintray-Debian-Architecture:amd64" \
+            https://api.bintray.com/content/kubesphere/deb/kk/$kkver/kk-linux-64bit.deb
+          curl -T bin/kk-linux-arm64.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+            -H "X-Bintray-Debian-Distribution:wheezy" -H "X-Bintray-Debian-Component:main" -H "X-Bintray-Debian-Architecture:amd64" \
+            https://api.bintray.com/content/kubesphere/deb/kk/$kkver/kk-linux-arm64.deb
+          curl -X POST -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} https://api.bintray.com/content/kubesphere/deb/kk/$kkver/publish

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,54 @@
+# Official documentation at http://goreleaser.com
+project_name: kk
+builds:
+- env:
+  - CGO_ENABLED=0
+  main: ./cmd/kk/main.go
+  binary: kk
+  goarch:
+    - amd64
+    - arm64
+  goos:
+    - linux
+    # only for test purpose currently
+    - darwin
+  ldflags:
+    - -X github.com/kubesphere/kubekey/version.version={{.Version}}
+    - -X github.com/kubesphere/kubekey/version.gitCommit={{.ShortCommit}}
+    - -X github.com/kubesphere/kubekey/version.metadata=unreleased
+dist: bin
+archives:
+- name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+  replacements:
+    linux: linux
+    amd64: amd64
+    arm64: arm64
+  files:
+    - README.md
+    - README_zh-CN.md
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next-{{.ShortCommit}}"
+changelog:
+  skip: true
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+nfpms:
+  - file_name_template: "{{ .Binary }}-{{.Os}}-{{.Arch}}"
+    homepage: https://github.com/kubesphere/kubekey
+    description: "The Next-gen Installer: Installing Kubernetes and KubeSphere v3.0.0 fastly, flexibly and easily"
+    maintainer: kubesphere authors
+    license: Apache-2.0
+    vendor: Kubesphere
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    replacements:
+      amd64: 64bit
+      arm64: arm64
+      linux: linux

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ kk-linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -ldflags '$(LDFLAGS)' -o bin/linux/amd64/kk ./cmd/kk/main.go
 kk-darwin:
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -ldflags '$(LDFLAGS)' -o bin/darwin/amd64/kk ./cmd/kk/main.go
+go-releaser-test:
+	goreleaser release --rm-dist --skip-publish --snapshot
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ KubeKey can install Kubernetes and KubeSphere together. The dependency that need
 > * Docker needs to be installed before building.
 > * If you have problem to access `https://proxy.golang.org/`, excute `build.sh -p` instead.
 
+<!--
 ### YUM
 
 Add YUM source repo by the following command:
@@ -124,7 +125,7 @@ sudo apt update
 ```
 
 then you can install it by: `sudo apt-get install kk`
-
+-->
 ### Create a Cluster
 
 #### Quick Start

--- a/README.md
+++ b/README.md
@@ -95,6 +95,36 @@ KubeKey can install Kubernetes and KubeSphere together. The dependency that need
 > * Docker needs to be installed before building.
 > * If you have problem to access `https://proxy.golang.org/`, excute `build.sh -p` instead.
 
+### YUM
+
+Add YUM source repo by the following command:
+
+```
+cat > bintray-kubesphere-rpm.repo <<EOF
+#bintraybintray-kubesphere-rpm - packages by kubesphere from Bintray
+[bintraybintray-kubesphere-rpm]
+name=bintray-kubesphere-rpm
+baseurl=https://dl.bintray.com/kubesphere/rpm
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+EOF
+sudo mv bintray-kubesphere-rpm.repo /etc/yum.repos.d/ && sudo yum update
+```
+
+then you can install it by: `yum install kk`
+
+### Debian
+
+Add deb source repo by the following command:
+
+```
+echo "deb [trusted=yes] https://dl.bintray.com/kubesphere/deb wheezy main" | sudo tee -a /etc/apt/sources.list
+sudo apt update
+```
+
+then you can install it by: `sudo apt-get install kk`
+
 ### Create a Cluster
 
 #### Quick Start


### PR DESCRIPTION
[goreleaser](https://github.com/goreleaser/goreleaser) is a very popular tool in the Golang CLI area. I provide the following things:
* goreleaser config file
* GitHub action for publishing rpm and deb package to bintray
* documentation about this feature

> Notice: As you can see, there're two secrets that are needed. They are `GH_TOKEN` and `BINTRAY_TOKEN`.

I already have finished the test work. You can find [the release binary files](https://github.com/LinuxSuRen/kubekey/releases) which for test purposes.

Here is the [Kubesphere home page](https://bintray.com/kubesphere) in bintray.com.

This PR can close #376 