### PR TITLE
update secret name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Bintray
         run: |
           kkver=$(hub tag --list | sort -V | tail -n 1)


### PR DESCRIPTION
GitHub automatically creates a `GITHUB_TOKEN` secret.

Signed-off-by: pixiake <guofeng@yunify.com>

