### PR TITLE
Reduce the binary file size by upx

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,9 @@ builds:
     - linux
     # only for test purpose currently
     - darwin
+  hooks:
+    post:
+      - upx "{{ .Path }}"
   ldflags:
     - -X github.com/kubesphere/kubekey/version.version={{.Version}}
     - -X github.com/kubesphere/kubekey/version.gitCommit={{.ShortCommit}}


### PR DESCRIPTION
Please see also a brother pull request which is similar to this.
https://github.com/kubesphere/kubesphere/pull/3160

Below is the comparision result:

Before using upx:
```
-rwxr-xr-x  1 rick  staff    54M Nov 28 22:51 kubekey/bin/kk_darwin_amd64/kk
```

After using upx:
```
-rwxr-xr-x  1 rick  staff    22M Nov 28 22:53 kubekey/bin/kk_darwin_amd64/kk
```