### PR TITLE
Use kubekey as the offical binary name instead of kk

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,19 +27,19 @@ jobs:
         run: |
           kkver=$(hub tag --list | sort -V | tail -n 1)
           echo "start to upload rpm packages"
-          curl -T bin/kk-linux-64bit.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+          curl -T bin/kubekey-${kkver}-linux-64bit.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
             -H "X-Bintray-Package:kk" -H "X-Bintray-Version:${kkver}" \
             https://api.bintray.com/content/kubesphere/rpm/kk/${kkver}/kk-linux-64bit.rpm
-          curl -T bin/kk-linux-arm64.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+          curl -T bin/kubekey-${kkver}-linux-arm64.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
             -H "X-Bintray-Package:kk" -H "X-Bintray-Version:$kkver" \
             https://api.bintray.com/content/kubesphere/rpm/kk/$kkver/kk-linux-arm64.rpm
           curl -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} -X POST https://api.bintray.com/content/kubesphere/rpm/kk/$kkver/publish
 
           echo "start to upload deb packages"
-          curl -T bin/kk-linux-64bit.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+          curl -T bin/kubekey-${kkver}-linux-64bit.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
             -H "X-Bintray-Debian-Distribution:wheezy" -H "X-Bintray-Debian-Component:main" -H "X-Bintray-Debian-Architecture:amd64" \
             https://api.bintray.com/content/kubesphere/deb/kk/$kkver/kk-linux-64bit.deb
-          curl -T bin/kk-linux-arm64.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
+          curl -T bin/kubekey-${kkver}-linux-arm64.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
             -H "X-Bintray-Debian-Distribution:wheezy" -H "X-Bintray-Debian-Component:main" -H "X-Bintray-Debian-Architecture:amd64" \
             https://api.bintray.com/content/kubesphere/deb/kk/$kkver/kk-linux-arm64.deb
           curl -X POST -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} https://api.bintray.com/content/kubesphere/deb/kk/$kkver/publish

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,17 +1,15 @@
 # Official documentation at http://goreleaser.com
-project_name: kk
+project_name: kubekey
 builds:
 - env:
   - CGO_ENABLED=0
   main: ./cmd/kk/main.go
-  binary: kk
+  binary: kubekey
   goarch:
     - amd64
     - arm64
   goos:
     - linux
-    # only for test purpose currently
-    - darwin
   hooks:
     post:
       - upx "{{ .Path }}"
@@ -19,9 +17,11 @@ builds:
     - -X github.com/kubesphere/kubekey/version.version={{.Version}}
     - -X github.com/kubesphere/kubekey/version.gitCommit={{.ShortCommit}}
     - -X github.com/kubesphere/kubekey/version.metadata=unreleased
+    - -w
+    - -s
 dist: bin
 archives:
-- name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+- name_template: "{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
   replacements:
     linux: linux
     amd64: amd64
@@ -41,7 +41,7 @@ changelog:
     - '^docs:'
     - '^test:'
 nfpms:
-  - file_name_template: "{{ .Binary }}-{{.Os}}-{{.Arch}}"
+  - file_name_template: "{{ .Binary }}-v{{ .Version }}-{{.Os}}-{{.Arch}}"
     homepage: https://github.com/kubesphere/kubekey
     description: "The Next-gen Installer: Installing Kubernetes and KubeSphere v3.0.0 fastly, flexibly and easily"
     maintainer: kubesphere authors


### PR DESCRIPTION
Align the binary name to the previous one.

I test this via `goreleaser release --skip-publish --rm-dist`

Below is the partial log output:
```
   • archives
      • creating                  archive=bin/kubekey-v1.1.4-linux-arm64.tar.gz
      • creating                  archive=bin/kubekey-v1.1.4-linux-amd64.tar.gz
   • creating source archive
      • pipe skipped              error=source pipe is disabled
   • linux packages
      • creating                  file=bin/kubekey-v1.1.4-linux-64bit.rpm
      • creating                  file=bin/kubekey-v1.1.4-linux-arm64.deb
      • creating                  file=bin/kubekey-v1.1.4-linux-arm64.rpm
      • creating                  file=bin/kubekey-v1.1.4-linux-64bit.deb
```

**Open Question**
* Do we need Linux Packages for kk?

I find there is no Linux package for kk on [the last release page](https://github.com/kubesphere/kubekey/releases/tag/v1.1.0-alpha.1). I'm not sure we want the Linux packages: .rpm and .deb.

If we think it's unnecessary I can remove it from the config file. But in my opinion, we should keep them.

* Take a concise name?
`kubekey` is the full name of this project. I know this is an official name. But in my opinion, `kk` is much more simple and easy to remember.
