### PR TITLE
Add nightly build support

### DIFF
--- a/cmd/kk/main.go
+++ b/cmd/kk/main.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/kubesphere/kubekey/cmd"
+import (
+	"github.com/kubesphere/kubekey/cmd"
+)
 
 // Using a separate entry-point can reduce the size of the binary file
 func main() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubesphere/kubekey/version"
 	"github.com/spf13/cobra"
 	"io"
+	"strings"
 )
 
 var shortVersion bool
@@ -59,23 +60,6 @@ func printVersion(short bool) error {
 }
 
 func printSupportedK8sVersionList(output io.Writer) (err error) {
-	_, err = output.Write([]byte(`v1.15.12
-v1.16.8
-v1.16.10
-v1.16.12
-v1.16.13
-v1.17.0
-v1.17.4
-v1.17.5
-v1.17.6
-v1.17.7
-v1.17.8
-v1.17.9
-v1.18.3
-v1.18.5
-v1.18.6
-v1.18.8
-v1.19.0
-`))
+	_, err = output.Write([]byte(fmt.Sprintln(strings.Join(version.SupportedK8sVersionList(), "\n"))))
 	return
 }

--- a/pkg/deploy/kubesphere.go
+++ b/pkg/deploy/kubesphere.go
@@ -39,15 +39,9 @@ func DeployKubeSphere(version, repo, kubeconfig string) error {
 	var kubesphereConfig, installerYaml string
 
 	switch version {
-	case "":
+	case "v3.0.0", "latest", "":
 		kubesphereConfig = kubesphere.V3_0_0
-		str, err := kubesphere.GenerateKubeSphereYaml(repo, "v3.0.0")
-		if err != nil {
-			return err
-		}
-		installerYaml = str
-	case "v3.0.0", "latest":
-		kubesphereConfig = kubesphere.V3_0_0
+		version = "v3.0.0"
 		str, err := kubesphere.GenerateKubeSphereYaml(repo, version)
 		if err != nil {
 			return err
@@ -61,7 +55,19 @@ func DeployKubeSphere(version, repo, kubeconfig string) error {
 		}
 		installerYaml = str
 	default:
-		return errors.New(fmt.Sprintf("Unsupported version: %s", strings.TrimSpace(version)))
+		// make it be convenient to have a nightly build of KubeSphere
+		if strings.HasPrefix(version, "nightly-") {
+			// this is not the perfect solution here, but it's not necessary to track down the exact version between the
+			// nightly build and a released. So please keep update it with the latest release here.
+			kubesphereConfig = kubesphere.V3_0_0
+			str, err := kubesphere.GenerateKubeSphereYaml(repo, version)
+			if err != nil {
+				return err
+			}
+			installerYaml = str
+		} else {
+			return errors.New(fmt.Sprintf("Unsupported version: %s", strings.TrimSpace(version)))
+		}
 	}
 
 	b1 := bufio.NewReader(bytes.NewReader([]byte(installerYaml)))

--- a/version/k8s.go
+++ b/version/k8s.go
@@ -1,0 +1,24 @@
+package version
+
+// SupportedK8sVersionList returns the supported list of Kubernetes
+func SupportedK8sVersionList() []string {
+	return []string{
+		"v1.15.12",
+		"v1.16.8",
+		"v1.16.10",
+		"v1.16.12",
+		"v1.16.13",
+		"v1.17.0",
+		"v1.17.4",
+		"v1.17.5",
+		"v1.17.6",
+		"v1.17.7",
+		"v1.17.8",
+		"v1.17.9",
+		"v1.18.3",
+		"v1.18.5",
+		"v1.18.6",
+		"v1.18.8",
+		"v1.19.0",
+	}
+}


### PR DESCRIPTION
# Nightly build version support
Nightly build is different from the latest version. For example, if the latest or the version from yesterday has some bugs, then users can have another choice instead of don't know how to deal with it.

# Completion feature
There's two completion support in this PR. With this feature, users don't need to remember the exact version anymore.

```
[root@i-vhxkszk5 kubekey]# kk create cluster --with-kubernetes [tab][tab]
v1.15.12  v1.16.10  v1.16.12  v1.16.13  v1.16.8   v1.17.0   v1.17.4   v1.17.5   v1.17.6   v1.17.7   v1.17.8   v1.17.9   v1.18.3   v1.18.5   v1.18.6   v1.18.8   v1.19.0

[root@i-vhxkszk5 kubekey]# kk create cluster --with-kubernetes v1.19.0 [tab][tab]
nightly-20201227  v2.1.1            v3.0.0
```