### PR TITLE
update calico manifests

### DIFF
--- a/pkg/plugins/network/calico/tmpl-v1.16+.go
+++ b/pkg/plugins/network/calico/tmpl-v1.16+.go
@@ -17,11 +17,12 @@ limitations under the License.
 package calico
 
 import (
+	"text/template"
+
 	"github.com/kubesphere/kubekey/pkg/cluster/preinstall"
 	"github.com/kubesphere/kubekey/pkg/util"
 	"github.com/kubesphere/kubekey/pkg/util/manager"
 	"github.com/lithammer/dedent"
-	"text/template"
 )
 
 var calicoTemplNew = template.Must(template.New("calico").Parse(
@@ -3844,6 +3845,12 @@ spec:
             - name: CLUSTER_TYPE
               value: "k8s,bgp"
             # Auto-detect the BGP IP address.
+            - name: NODEIP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: IP_AUTODETECTION_METHOD
+              value: "can-reach=$(NODEIP)"
             - name: IP
               value: "autodetect"
             # Enable IPIP
@@ -4048,6 +4055,7 @@ metadata:
 
     `)))
 
+// GenerateCalicoFilesNew is used to generate calico mainfests.
 func GenerateCalicoFilesNew(mgr *manager.Manager) (string, error) {
 	return util.Render(calicoTemplNew, util.Data{
 		"KubePodsCIDR":            mgr.Cluster.Network.KubePodsCIDR,


### PR DESCRIPTION
1. Specify `can-reach=$(NODEIP)` as the `IP_AUTODETECTION_METHOD`.
2. Add `typha` for old calico manifests.

Signed-off-by: pixiake <guofeng@yunify.com>