### PR TITLE
Add user defined tools download command option

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -37,7 +37,7 @@ var clusterCmd = &cobra.Command{
 			ksVersion = ""
 		}
 		logger := util.InitLogger(opt.Verbose)
-		return install.CreateCluster(opt.ClusterCfgFile, opt.Kubernetes, ksVersion, logger, opt.Kubesphere, opt.Verbose, opt.SkipCheck, opt.SkipPullImages, opt.InCluster)
+		return install.CreateCluster(opt.ClusterCfgFile, opt.Kubernetes, ksVersion, logger, opt.Kubesphere, opt.Verbose, opt.SkipCheck, opt.SkipPullImages, opt.InCluster, opt.DownloadCmd)
 	},
 }
 
@@ -49,6 +49,8 @@ func init() {
 	clusterCmd.Flags().BoolVarP(&opt.Kubesphere, "with-kubesphere", "", false, "Deploy a specific version of kubesphere (default v3.0.0)")
 	clusterCmd.Flags().BoolVarP(&opt.SkipCheck, "yes", "y", false, "Skip pre-check of the installation")
 	clusterCmd.Flags().BoolVarP(&opt.SkipPullImages, "skip-pull-images", "", false, "Skip pre pull images")
+	clusterCmd.Flags().StringVarP(&opt.DownloadCmd, "download-cmd", "", "curl -L -o %s %s",
+		`The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL`)
 
 	if err := setValidArgs(clusterCmd); err != nil {
 		panic(fmt.Sprintf("Got error with the completion setting"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ type Options struct {
 	SourcesDir     string
 	AddImagesRepo  bool
 	InCluster      bool
+	DownloadCmd    string
 }
 
 var (

--- a/pkg/util/executor/executor.go
+++ b/pkg/util/executor/executor.go
@@ -29,16 +29,17 @@ import (
 )
 
 type Executor struct {
-	ObjName        string
-	Cluster        *kubekeyapiv1alpha1.ClusterSpec
-	Logger         *log.Logger
-	SourcesDir     string
-	Debug          bool
-	SkipCheck      bool
-	SkipPullImages bool
-	AddImagesRepo  bool
-	InCluster      bool
-	ClientSet      *kubekeyclientset.Clientset
+	ObjName         string
+	Cluster         *kubekeyapiv1alpha1.ClusterSpec
+	Logger          *log.Logger
+	SourcesDir      string
+	Debug           bool
+	SkipCheck       bool
+	SkipPullImages  bool
+	AddImagesRepo   bool
+	InCluster       bool
+	ClientSet       *kubekeyclientset.Clientset
+	DownloadCommand func(path, url string) string
 }
 
 func NewExecutor(cluster *kubekeyapiv1alpha1.ClusterSpec, objName string, logger *log.Logger, sourcesDir string, debug, skipCheck, skipPullImages, addImagesRepo, inCluster bool, clientset *kubekeyclientset.Clientset) *Executor {
@@ -82,6 +83,7 @@ func (executor *Executor) CreateManager() (*manager.Manager, error) {
 	mgr.ObjName = executor.ObjName
 	mgr.InCluster = executor.InCluster
 	mgr.ClientSet = executor.ClientSet
+	mgr.DownloadCommand = executor.DownloadCommand
 	if executor.Cluster.Kubernetes.ContainerManager == "" || executor.Cluster.Kubernetes.ContainerManager == "docker" {
 		mgr.EtcdContainer = true
 	}

--- a/pkg/util/manager/manager.go
+++ b/pkg/util/manager/manager.go
@@ -26,30 +26,31 @@ import (
 
 // Manager defines all the parameters needed for the installation.
 type Manager struct {
-	ObjName        string
-	Cluster        *kubekeyapiv1alpha1.ClusterSpec
-	Logger         log.FieldLogger
-	Connector      *ssh.Dialer
-	Runner         *runner.Runner
-	AllNodes       []kubekeyapiv1alpha1.HostCfg
-	EtcdNodes      []kubekeyapiv1alpha1.HostCfg
-	MasterNodes    []kubekeyapiv1alpha1.HostCfg
-	WorkerNodes    []kubekeyapiv1alpha1.HostCfg
-	K8sNodes       []kubekeyapiv1alpha1.HostCfg
-	EtcdContainer  bool
-	ClusterHosts   []string
-	WorkDir        string
-	KsEnable       bool
-	KsVersion      string
-	Debug          bool
-	SkipCheck      bool
-	SkipPullImages bool
-	SourcesDir     string
-	AddImagesRepo  bool
-	InCluster      bool
-	Kubeconfig     string
-	Conditions     []kubekeyapiv1alpha1.Condition
-	ClientSet      *kubekeyclientset.Clientset
+	ObjName         string
+	Cluster         *kubekeyapiv1alpha1.ClusterSpec
+	Logger          log.FieldLogger
+	Connector       *ssh.Dialer
+	Runner          *runner.Runner
+	AllNodes        []kubekeyapiv1alpha1.HostCfg
+	EtcdNodes       []kubekeyapiv1alpha1.HostCfg
+	MasterNodes     []kubekeyapiv1alpha1.HostCfg
+	WorkerNodes     []kubekeyapiv1alpha1.HostCfg
+	K8sNodes        []kubekeyapiv1alpha1.HostCfg
+	EtcdContainer   bool
+	ClusterHosts    []string
+	WorkDir         string
+	KsEnable        bool
+	KsVersion       string
+	Debug           bool
+	SkipCheck       bool
+	SkipPullImages  bool
+	SourcesDir      string
+	AddImagesRepo   bool
+	InCluster       bool
+	Kubeconfig      string
+	Conditions      []kubekeyapiv1alpha1.Condition
+	ClientSet       *kubekeyclientset.Clientset
+	DownloadCommand func(path, url string) string
 }
 
 // Copy is used to create a copy for Manager.


### PR DESCRIPTION
This PR provider an extension point for downloading tools, for example, users can set the timeout, proxy, or retry under some poor network environment. Or users even can choose another cli, it might be wget. Perhaps we should have a build-in download function instead of totally rely on the external one.