### PR TITLE
Rename binary filename from kubekey to kk

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,23 +23,3 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Bintray
-        run: |
-          kkver=$(hub tag --list | sort -V | tail -n 1)
-          echo "start to upload rpm packages"
-          curl -T bin/kubekey-${kkver}-linux-64bit.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
-            -H "X-Bintray-Package:kk" -H "X-Bintray-Version:${kkver}" \
-            https://api.bintray.com/content/kubesphere/rpm/kk/${kkver}/kk-linux-64bit.rpm
-          curl -T bin/kubekey-${kkver}-linux-arm64.rpm -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
-            -H "X-Bintray-Package:kk" -H "X-Bintray-Version:$kkver" \
-            https://api.bintray.com/content/kubesphere/rpm/kk/$kkver/kk-linux-arm64.rpm
-          curl -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} -X POST https://api.bintray.com/content/kubesphere/rpm/kk/$kkver/publish
-
-          echo "start to upload deb packages"
-          curl -T bin/kubekey-${kkver}-linux-64bit.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
-            -H "X-Bintray-Debian-Distribution:wheezy" -H "X-Bintray-Debian-Component:main" -H "X-Bintray-Debian-Architecture:amd64" \
-            https://api.bintray.com/content/kubesphere/deb/kk/$kkver/kk-linux-64bit.deb
-          curl -T bin/kubekey-${kkver}-linux-arm64.deb -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} \
-            -H "X-Bintray-Debian-Distribution:wheezy" -H "X-Bintray-Debian-Component:main" -H "X-Bintray-Debian-Architecture:amd64" \
-            https://api.bintray.com/content/kubesphere/deb/kk/$kkver/kk-linux-arm64.deb
-          curl -X POST -ulinuxsuren:${{ secrets.BINTRAY_TOKEN }} https://api.bintray.com/content/kubesphere/deb/kk/$kkver/publish

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ builds:
 - env:
   - CGO_ENABLED=0
   main: ./cmd/kk/main.go
-  binary: kubekey
+  binary: kk
   goarch:
     - amd64
     - arm64
@@ -21,7 +21,7 @@ builds:
     - -s
 dist: bin
 archives:
-- name_template: "{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+- name_template: "kubekey-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
   replacements:
     linux: linux
     amd64: amd64
@@ -41,7 +41,7 @@ changelog:
     - '^docs:'
     - '^test:'
 nfpms:
-  - file_name_template: "{{ .Binary }}-v{{ .Version }}-{{.Os}}-{{.Arch}}"
+  - file_name_template: "kubekey-{{ .Version }}-{{.Os}}-{{.Arch}}"
     homepage: https://github.com/kubesphere/kubekey
     description: "KubeKey provides a flexible, rapid and convenient way to install Kubernetes only, both Kubernetes and KubeSphere, and related cloud-native add-ons. It is also an efficient tool to scale and upgrade your cluster."
     maintainer: kubesphere authors

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ builds:
     - -s
 dist: bin
 archives:
-- name_template: "kubekey-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+- name_template: "kubekey-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
   replacements:
     linux: linux
     amd64: amd64
@@ -32,7 +32,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next-{{.ShortCommit}}"
+  name_template: "{{ .Version }}-next-{{.ShortCommit}}"
 changelog:
   skip: true
   sort: asc
@@ -41,7 +41,7 @@ changelog:
     - '^docs:'
     - '^test:'
 nfpms:
-  - file_name_template: "kubekey-{{ .Version }}-{{.Os}}-{{.Arch}}"
+  - file_name_template: "kubekey-v{{ .Version }}-{{.Os}}-{{.Arch}}"
     homepage: https://github.com/kubesphere/kubekey
     description: "KubeKey provides a flexible, rapid and convenient way to install Kubernetes only, both Kubernetes and KubeSphere, and related cloud-native add-ons. It is also an efficient tool to scale and upgrade your cluster."
     maintainer: kubesphere authors

--- a/README.md
+++ b/README.md
@@ -95,37 +95,6 @@ KubeKey can install Kubernetes and KubeSphere together. The dependency that need
 > * Docker needs to be installed before building.
 > * If you have problem to access `https://proxy.golang.org/`, excute `build.sh -p` instead.
 
-<!--
-### YUM
-
-Add YUM source repo by the following command:
-
-```
-cat > bintray-kubesphere-rpm.repo <<EOF
-#bintraybintray-kubesphere-rpm - packages by kubesphere from Bintray
-[bintraybintray-kubesphere-rpm]
-name=bintray-kubesphere-rpm
-baseurl=https://dl.bintray.com/kubesphere/rpm
-gpgcheck=0
-repo_gpgcheck=0
-enabled=1
-EOF
-sudo mv bintray-kubesphere-rpm.repo /etc/yum.repos.d/ && sudo yum update
-```
-
-then you can install it by: `yum install kk`
-
-### Debian
-
-Add deb source repo by the following command:
-
-```
-echo "deb [trusted=yes] https://dl.bintray.com/kubesphere/deb wheezy main" | sudo tee -a /etc/apt/sources.list
-sudo apt update
-```
-
-then you can install it by: `sudo apt-get install kk`
--->
 ### Create a Cluster
 
 #### Quick Start


### PR DESCRIPTION
The target binary filename was changed from `kubekey` to `kk`. You can download it from [here](https://github.com/LinuxSuRen/kubekey/releases/tag/v1.0.13).
```
[root@i-credeh69 test]# wget https://github.com/LinuxSuRen/kubekey/releases/tag/v1.0.13
[root@i-credeh69 test]# tar xzvf kubekey-v1.0.13-linux-amd64.tar.gz
README.md
README_zh-CN.md
kk
```