### PR TITLE
Feature: Add internal LB haproxy for kubernetes.

### DIFF
--- a/apis/kubekey/v1alpha1/cluster_types.go
+++ b/apis/kubekey/v1alpha1/cluster_types.go
@@ -163,9 +163,10 @@ type HostGroups struct {
 
 // ControlPlaneEndpoint defines the control plane endpoint information for cluster.
 type ControlPlaneEndpoint struct {
-	Domain  string `yaml:"domain" json:"domain,omitempty"`
-	Address string `yaml:"address" json:"address,omitempty"`
-	Port    int    `yaml:"port" json:"port,omitempty"`
+	InternalLoadbalancer string `yaml:"internalLoadbalancer" json:"internalLoadbalancer,omitempty"`
+	Domain               string `yaml:"domain" json:"domain,omitempty"`
+	Address              string `yaml:"address" json:"address,omitempty"`
+	Port                 int    `yaml:"port" json:"port,omitempty"`
 }
 
 // RegistryConfig defines the configuration information of the image's repository.
@@ -366,4 +367,15 @@ func hostVerify(hostList map[string]string, hostName string, group string) error
 		return fmt.Errorf("[%s] is in [%s] group, but not in hosts list", hostName, group)
 	}
 	return nil
+}
+
+const (
+	Haproxy = "haproxy"
+)
+
+func (c ControlPlaneEndpoint) IsInternalLBEnabled() bool {
+	if c.InternalLoadbalancer == Haproxy {
+		return true
+	}
+	return false
 }

--- a/apis/kubekey/v1alpha1/default.go
+++ b/apis/kubekey/v1alpha1/default.go
@@ -150,13 +150,13 @@ func SetDefaultLBCfg(cfg *ClusterSpec, masterGroup []HostCfg, incluster bool) Co
 		}
 
 		//Check whether LB should be configured
-		if len(masterGroup) >= 3 && cfg.ControlPlaneEndpoint.Address == "" {
-			fmt.Println("When the environment has at least three masters, You must set the value of the LB address.")
+		if len(masterGroup) >= 3 && !cfg.ControlPlaneEndpoint.IsInternalLBEnabled() && cfg.ControlPlaneEndpoint.Address == "" {
+			fmt.Println("When the environment has at least three masters, You must set the value of the LB address or enable the internal loadbalancer.")
 			os.Exit(0)
 		}
 	}
 
-	if cfg.ControlPlaneEndpoint.Address == "" {
+	if cfg.ControlPlaneEndpoint.Address == "" || cfg.ControlPlaneEndpoint.Address == "127.0.0.1" {
 		cfg.ControlPlaneEndpoint.Address = masterGroup[0].InternalAddress
 	}
 	if cfg.ControlPlaneEndpoint.Domain == "" {

--- a/config/crd/bases/kubekey.kubesphere.io_clusters.yaml
+++ b/config/crd/bases/kubekey.kubesphere.io_clusters.yaml
@@ -77,10 +77,14 @@ spec:
                 type: object
               type: array
             controlPlaneEndpoint:
+              description: ControlPlaneEndpoint defines the control plane endpoint
+                information for cluster.
               properties:
                 address:
                   type: string
                 domain:
+                  type: string
+                internalLoadbalancer:
                   type: string
                 port:
                   type: integer
@@ -89,6 +93,7 @@ spec:
               description: Foo is an example field of Cluster. Edit Cluster_types.go
                 to remove/update
               items:
+                description: HostCfg defines host information for cluster.
                 properties:
                   address:
                     type: string
@@ -118,6 +123,10 @@ spec:
               type: array
             kubernetes:
               properties:
+                apiserverArgs:
+                  items:
+                    type: string
+                  type: array
                 apiserverCertExtraSans:
                   items:
                     type: string
@@ -128,6 +137,10 @@ spec:
                   type: string
                 containerRuntimeEndpoint:
                   type: string
+                controllerManagerArgs:
+                  items:
+                    type: string
+                  type: array
                 etcdBackupDir:
                   type: string
                 etcdBackupPeriod:
@@ -136,6 +149,18 @@ spec:
                   type: string
                 keepBackupNumber:
                   type: integer
+                kubeProxyArgs:
+                  items:
+                    type: string
+                  type: array
+                kubeProxyConfiguration:
+                  type: object
+                kubeletArgs:
+                  items:
+                    type: string
+                  type: array
+                kubeletConfiguration:
+                  type: object
                 masqueradeAll:
                   type: boolean
                 maxPods:
@@ -144,10 +169,18 @@ spec:
                   type: integer
                 proxyMode:
                   type: string
+                schedulerArgs:
+                  items:
+                    type: string
+                  type: array
+                type:
+                  type: string
                 version:
                   type: string
               type: object
             kubesphere:
+              description: KubeSphere defines the configuration information of the
+                KubeSphere.
               properties:
                 configurations:
                   type: string
@@ -209,6 +242,8 @@ spec:
                   type: string
               type: object
             registry:
+              description: RegistryConfig defines the configuration information of
+                the image's repository.
               properties:
                 insecureRegistries:
                   items:
@@ -222,6 +257,8 @@ spec:
                   type: array
               type: object
             roleGroups:
+              description: RoleGroups defines the grouping of role for hosts (etcd
+                / master / worker).
               properties:
                 etcd:
                   items:
@@ -242,6 +279,7 @@ spec:
           properties:
             Conditions:
               items:
+                description: Condition defines the process information.
                 properties:
                   endTime:
                     format: date-time
@@ -258,6 +296,8 @@ spec:
             etcdCount:
               type: integer
             jobInfo:
+              description: JobInfo defines the job information to be used to create
+                a cluster or add a node.
               properties:
                 name:
                   type: string
@@ -265,9 +305,13 @@ spec:
                   type: string
                 pods:
                   items:
+                    description: PodInfo defines the pod information to be used to
+                      create a cluster or add a node.
                     properties:
                       containers:
                         items:
+                          description: ContainerInfo defines the container information
+                            to be used to create a cluster or add a node.
                           properties:
                             name:
                               type: string
@@ -284,6 +328,8 @@ spec:
               type: string
             nodes:
               items:
+                description: NodeStatus defines the status information of the nodes
+                  in the cluster.
                 properties:
                   hostname:
                     type: string

--- a/pkg/cluster/add/add.go
+++ b/pkg/cluster/add/add.go
@@ -87,6 +87,7 @@ func ExecTasks(mgr *manager.Manager) error {
 		{Task: install.GetClusterStatus, ErrMsg: "Failed to get cluster status"},
 		{Task: install.InstallKubeBinaries, ErrMsg: "Failed to install kube binaries"},
 		{Task: install.JoinNodesToCluster, ErrMsg: "Failed to join node"},
+		{Task: install.InstallInternalLoadbalancer, ErrMsg: "Failed to install internal load balancer", Skip: !mgr.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
 	}
 
 	for _, step := range addNodeTasks {

--- a/pkg/cluster/install/install.go
+++ b/pkg/cluster/install/install.go
@@ -100,6 +100,7 @@ func ExecTasks(mgr *manager.Manager) error {
 		{Task: InstallKubeBinaries, ErrMsg: "Failed to install kube binaries"},
 		{Task: InitKubernetesCluster, ErrMsg: "Failed to init kubernetes cluster"},
 		{Task: JoinNodesToCluster, ErrMsg: "Failed to join node"},
+		{Task: InstallInternalLoadbalancer, ErrMsg: "Failed to install internal load balancer", Skip: !mgr.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
 		{Task: network.DeployNetworkPlugin, ErrMsg: "Failed to deploy network plugin"},
 		{Task: addons.InstallAddons, ErrMsg: "Failed to deploy addons", Skip: noNetworkPlugin},
 		{Task: kubesphere.DeployLocalVolume, ErrMsg: "Failed to deploy localVolume", Skip: noNetworkPlugin || (!mgr.DeployLocalStorage && !mgr.KsEnable)},

--- a/pkg/cluster/install/tasks.go
+++ b/pkg/cluster/install/tasks.go
@@ -203,6 +203,16 @@ func InstallInternalLoadbalancer(mgr *manager.Manager) error {
 
 	switch mgr.Cluster.Kubernetes.Type {
 	case "k3s":
+		if err := mgr.RunTaskOnWorkerNodes(loadbalancer.DeployHaproxy, true); err != nil {
+			return err
+		}
+		if err := mgr.RunTaskOnWorkerNodes(k3s.UpdateK3sConfig, true); err != nil {
+			return err
+		}
+		if err := mgr.RunTaskOnK8sNodes(k3s.UpdateKubectlConfig, true); err != nil {
+			return err
+		}
+
 	default:
 		if err := mgr.RunTaskOnWorkerNodes(loadbalancer.DeployHaproxy, true); err != nil {
 			return err

--- a/pkg/cluster/install/tasks.go
+++ b/pkg/cluster/install/tasks.go
@@ -209,7 +209,7 @@ func InstallInternalLoadbalancer(mgr *manager.Manager) error {
 		if err := mgr.RunTaskOnWorkerNodes(k3s.UpdateK3sConfig, true); err != nil {
 			return err
 		}
-		if err := mgr.RunTaskOnK8sNodes(k3s.UpdateKubectlConfig, true); err != nil {
+		if err := mgr.RunTaskOnK8sNodes(kubernetes.UpdateHostsFile, true); err != nil {
 			return err
 		}
 
@@ -223,7 +223,7 @@ func InstallInternalLoadbalancer(mgr *manager.Manager) error {
 		if err := mgr.RunTaskOnMasterNodes(kubernetes.UpdateKubeproxyConfig, true); err != nil {
 			return err
 		}
-		if err := mgr.RunTaskOnK8sNodes(kubernetes.UpdateKubectlConfig, true); err != nil {
+		if err := mgr.RunTaskOnK8sNodes(kubernetes.UpdateHostsFile, true); err != nil {
 			return err
 		}
 	}

--- a/pkg/cluster/install/tasks.go
+++ b/pkg/cluster/install/tasks.go
@@ -9,6 +9,7 @@ import (
 	k3spreinstall "github.com/kubesphere/kubekey/pkg/k3s/preinstall"
 	"github.com/kubesphere/kubekey/pkg/kubernetes"
 	k8spreinstall "github.com/kubesphere/kubekey/pkg/kubernetes/preinstall"
+	"github.com/kubesphere/kubekey/pkg/loadbalancer"
 	"github.com/kubesphere/kubekey/pkg/util"
 	"github.com/kubesphere/kubekey/pkg/util/manager"
 	"github.com/pkg/errors"
@@ -193,5 +194,28 @@ func JoinNodesToCluster(mgr *manager.Manager) error {
 		}
 	}
 
+	return nil
+}
+
+// InstallInternalLoadbalancer is used to install a internal load balancer to cluster.
+func InstallInternalLoadbalancer(mgr *manager.Manager) error {
+	mgr.Logger.Infoln("Install internal load balancer to cluster")
+
+	switch mgr.Cluster.Kubernetes.Type {
+	case "k3s":
+	default:
+		if err := mgr.RunTaskOnWorkerNodes(loadbalancer.DeployHaproxy, true); err != nil {
+			return err
+		}
+		if err := mgr.RunTaskOnK8sNodes(kubernetes.UpdateKubeletConfig, true); err != nil {
+			return err
+		}
+		if err := mgr.RunTaskOnMasterNodes(kubernetes.UpdateKubeproxyConfig, true); err != nil {
+			return err
+		}
+		if err := mgr.RunTaskOnK8sNodes(kubernetes.UpdateKubectlConfig, true); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/cluster/upgrade/upgrade.go
+++ b/pkg/cluster/upgrade/upgrade.go
@@ -61,6 +61,7 @@ func ExecTasks(mgr *manager.Manager) error {
 		{Task: GetCurrentVersions, ErrMsg: "Failed to get current version"},
 		{Task: install.InitOS, ErrMsg: "Failed to download kube binaries"},
 		{Task: UpgradeKubeCluster, ErrMsg: "Failed to upgrade kube cluster"},
+		{Task: install.InstallInternalLoadbalancer, ErrMsg: "Failed to install internal load balancer", Skip: !mgr.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
 		{Task: SyncConfiguration, ErrMsg: "Failed to sync configuration"},
 		{Task: kubesphere.DeployKubeSphere, ErrMsg: "Failed to upgrade kubesphere"},
 	}

--- a/pkg/config/from_cluster.go
+++ b/pkg/config/from_cluster.go
@@ -45,7 +45,7 @@ metadata:
   name: {{ .Options.Name }}
 spec:
   hosts: 
-  # You should complete the ssh information of the hosts
+  ##You should complete the ssh information of the hosts
   {{- range .Options.Hosts }}
   - {{ . }}
   {{- end }}
@@ -61,7 +61,14 @@ spec:
     - {{ . }}
     {{- end }}
   controlPlaneEndpoint:
-    # If loadbalancer was used, 'address' should be set to loadbalancer's ip.
+    ##Internal loadbalancer for apiservers 
+    {{- if .Options.InternalLoadbalancer }}
+    internalLoadbalancer: {{ .Options.InternalLoadbalancer }}
+    {{- else }}
+    #internalLoadbalancer: haproxy
+    {{- end }}
+
+    ##If the external loadbalancer was used, 'address' should be set to loadbalancer's ip.
     domain: {{ .Options.ControlPlaneEndpointDomain }}
     address: {{ .Options.ControlPlaneEndpointAddress }}
     port: {{ .Options.ControlPlaneEndpointPort }}
@@ -108,6 +115,7 @@ type OptionsCluster struct {
 	ControlPlaneEndpointDomain  string
 	ControlPlaneEndpointAddress string
 	ControlPlaneEndpointPort    string
+	InternalLoadbalancer        string
 }
 
 // GetInfoFromCluster is used to fetch information from the existing cluster.
@@ -204,6 +212,9 @@ func GetInfoFromCluster(config, name string) (*OptionsCluster, error) {
 		}
 		if strings.Contains(pod.Name, "flannel") {
 			opt.NetworkPlugin = "flannel"
+		}
+		if strings.Contains(pod.Name, "haproxy-node") {
+			opt.InternalLoadbalancer = "haproxy"
 		}
 	}
 

--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -53,6 +53,9 @@ spec:
     - node1
     - node2
   controlPlaneEndpoint:
+    ##Internal loadbalancer for apiservers 
+    #internalLoadbalancer: haproxy
+
     domain: lb.kubesphere.local
     address: ""
     port: 6443

--- a/pkg/k3s/config/service.go
+++ b/pkg/k3s/config/service.go
@@ -46,8 +46,9 @@ EnvironmentFile=/etc/systemd/system/k3s.service.env
 {{ if .IsMaster }}
 Environment="K3S_ARGS= {{ range .CertSANs }} --tls-san={{ . }}{{- end }} {{ range .ApiserverArgs }} --kube-apiserver-arg={{ . }}{{- end }} {{ range .ControllerManager }} --kube-controller-manager-arg={{ . }}{{- end }} {{ range .SchedulerArgs }} --kube-scheduler-arg={{ . }}{{- end }} --cluster-cidr={{ .PodSubnet }} --service-cidr={{ .ServiceSubnet }} --cluster-dns={{ .ClusterDns }} --flannel-backend=none --disable-network-policy --disable-cloud-controller --disable=servicelb,traefik,metrics-server,local-storage"
 {{ end }}
-Environment="K3S_EXTRA_ARGS=--node-name={{ .HostName }}  --node-ip={{ .NodeIP }} {{ if .Server }}--server={{ .Server }}{{ end }} --pause-image={{ .PauseImage }} {{ range .KubeletArgs }} --kubelet-arg={{ . }}{{- end }} {{ range .KubeProxyArgs }} --kube-proxy-arg={{ . }}{{- end }}"
+Environment="K3S_EXTRA_ARGS=--node-name={{ .HostName }}  --node-ip={{ .NodeIP }}  --pause-image={{ .PauseImage }} {{ range .KubeletArgs }} --kubelet-arg={{ . }}{{- end }} {{ range .KubeProxyArgs }} --kube-proxy-arg={{ . }}{{- end }}"
 Environment="K3S_ROLE={{ if .IsMaster }}server{{ else }}agent{{ end }}"
+Environment="K3S_SERVER_ARGS={{ if .Server }}--server={{ .Server }}{{ end }}"
 KillMode=process
 Delegate=yes
 LimitNOFILE=1048576
@@ -59,7 +60,7 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s $K3S_ROLE $K3S_ARGS $K3S_EXTRA_ARGS
+ExecStart=/usr/local/bin/k3s $K3S_ROLE $K3S_ARGS $K3S_EXTRA_ARGS $K3S_SERVER_ARGS
     `)))
 
 	// K3sEnvTempl defines the template of kubelet's Env for the kubelet's systemd service.

--- a/pkg/k3s/nodes.go
+++ b/pkg/k3s/nodes.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	kubekeyapiv1alpha1 "github.com/kubesphere/kubekey/apis/kubekey/v1alpha1"
@@ -152,6 +153,50 @@ func setK3sSystemdConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg,
 	k3sServiceBase64 := base64.StdEncoding.EncodeToString([]byte(k3sService))
 	if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo -E /bin/sh -c \"echo %s | base64 -d > /etc/systemd/system/k3s.service\"", k3sServiceBase64), 5, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to generate kubelet service")
+	}
+	return nil
+}
+
+const LocalServer = "https://127.0.0.1"
+
+func UpdateK3sConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	output, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"[ -f /etc/systemd/system/k3s.service ] && echo 'k3s.service is exists.' || echo 'k3s.service is not exists.'\"", 0, true)
+	if strings.Contains(output, "k3s.service is exists.") {
+		// If the value is 'server: "https://127.0.0.1:6443"', return the function to avoid restart the kubelet.
+		if out, err := mgr.Runner.ExecuteCmd("sed -n '/--server=.*/p' /etc/systemd/system/k3s.service", 1, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to get /etc/systemd/system/k3s.service")
+		} else {
+			if strings.Contains(strings.TrimSpace(out), LocalServer) {
+				return nil
+			}
+		}
+
+		if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sed -i 's#--server=.*\"#--server=https://127.0.0.1:%s\"#g' /etc/systemd/system/k3s.service", strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)), 0, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to update /etc/systemd/system/k3s.service")
+		}
+	} else {
+		if err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to find /etc/systemd/system/k3s.service")
+		}
+		return errors.New("Failed to find /etc/systemd/system/k3s.service")
+	}
+	if _, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"systemctl restart k3s\"", 3, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to restart k3s after update k3s.service")
+	}
+	return nil
+}
+
+func UpdateKubectlConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	output2, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"[ -f ~/.kube/config ] && echo 'kubectl config is exists.' || echo 'kubectl config is not exists.'\"", 0, false)
+	if strings.Contains(output2, "kubectl config is exists.") {
+		if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sed -i 's#server:.*#server: https://127.0.0.1:%s#g' ~/.kube/config", strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)), 0, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to update ~/.kube/config")
+		}
+	} else {
+		if err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to find ~/.kube/config")
+		}
+		return errors.New("Failed to find ~/.kube/config")
 	}
 	return nil
 }

--- a/pkg/kubernetes/config/v1beta2/kubeadm.go
+++ b/pkg/kubernetes/config/v1beta2/kubeadm.go
@@ -63,9 +63,6 @@ networking:
   serviceSubnet: {{ .ServiceSubnet }}
 apiServer:
   extraArgs:
-    {{- if .InternalLBDisabled }}
-    advertise-address: {{ .AdvertiseAddress }}
-    {{- end }}
 {{ toYaml .ApiServerArgs | indent 4}}
   certSANs:
     {{- range .CertSANs }}

--- a/pkg/kubernetes/master.go
+++ b/pkg/kubernetes/master.go
@@ -202,6 +202,10 @@ func getJoinCmd(mgr *manager.Manager) error {
 	}
 
 	joinWorkerStrList := strings.Split(output, "kubeadm join")
+	// if "127.0.0.1" in the join command, replace it with the cluster config file's first internal address in master group
+	if strings.Contains(joinWorkerStrList[1], "127.0.0.1") {
+		joinWorkerStrList[1] = strings.Replace(joinWorkerStrList[1], "127.0.0.1", mgr.MasterNodes[0].InternalAddress, 1)
+	}
 	clusterStatus["joinWorkerCmd"] = fmt.Sprintf("/usr/local/bin/kubeadm join %s", joinWorkerStrList[1])
 	clusterStatus["joinMasterCmd"] = fmt.Sprintf("%s --control-plane --certificate-key %s", clusterStatus["joinWorkerCmd"], certificateKey)
 

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubesphere/kubekey/pkg/kubernetes/config"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	kubekeyapiv1alpha1 "github.com/kubesphere/kubekey/apis/kubekey/v1alpha1"
@@ -129,5 +130,95 @@ func SetKubelet(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
 		return errors.Wrap(errors.WithStack(err), "Failed to generate kubelet env")
 	}
 
+	return nil
+}
+
+const LocalServer = "server: https://127.0.0.1"
+
+// UpdateKubeletConfig Update server filed in kubelet.conf
+// When create a HA cluster by internal LB, we will set the server filed to 127.0.0.1:6443 (default) which in kubelet.conf.
+// Because of that, the control plone node's kubelet connect the local api-server.
+// And the work node's kubelet connect 127.0.0.1:6443 (default) that is proxy by the node's local nginx.
+func UpdateKubeletConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	output, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"[ -f /etc/kubernetes/kubelet.conf ] && echo 'kubelet.conf is exists.' || echo 'kubelet.conf is not exists.'\"", 0, true)
+	if strings.Contains(output, "kubelet.conf is exists.") {
+		// If the value is 'server: "https://127.0.0.1:6443"', return the function to avoid restart the kubelet.
+		if out, err := mgr.Runner.ExecuteCmd("sed -n '/server:.*/p' /etc/kubernetes/kubelet.conf", 1, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to get /etc/kubernetes/kubelet.conf")
+		} else {
+			if strings.Contains(strings.TrimSpace(out), LocalServer) {
+				return nil
+			}
+		}
+
+		if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sed -i 's#server:.*#server: https://127.0.0.1:%s#g' /etc/kubernetes/kubelet.conf", strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)), 0, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to update /etc/kubernetes/kubelet.conf")
+		}
+	} else {
+		if err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to find /etc/kubernetes/kubelet.conf")
+		}
+		return errors.New("Failed to find /etc/kubernetes/kubelet.conf")
+	}
+	if _, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"systemctl daemon-reload && systemctl restart kubelet\"", 3, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to restart kubelet after update kubelet.conf")
+	}
+	return nil
+}
+
+// UpdateKubeproxyConfig is used to update kube-proxy configmap and restart tge kube-proxy pod.
+func UpdateKubeproxyConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	if mgr.Runner.Index == 0 {
+		if out, err := mgr.Runner.ExecuteCmd("set -o pipefail && /usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get configmap kube-proxy -n kube-system -o yaml "+
+			"| sed -n '/server:.*/p' ", 1, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to get kube-proxy config")
+		} else {
+			if strings.Contains(strings.TrimSpace(out), LocalServer) {
+				return nil
+			}
+		}
+
+		if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("set -o pipefail && /usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get configmap kube-proxy -n kube-system -o yaml "+
+			"| sed 's#server:.*#server: https://127.0.0.1:%s#g' "+
+			"| /usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf replace -f -", strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)), 3, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to update kube-proxy config")
+		}
+	}
+
+	// Restart all kube-proxy pods to ensure that they load the new configmap.
+	if _, err := mgr.Runner.ExecuteCmd("/usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0", 3, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to restart kube-proxy pod")
+	}
+	return nil
+}
+
+// UpdateKubectlConfig is used to update the kubectl config. Make the value of field 'server' to set as 127.0.0.1:6443 (default).
+// And all of the 'admin.conf' will connect to 127.0.0.1:6443 (default)
+func UpdateKubectlConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	if node.IsMaster {
+		output, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"[ -f /etc/kubernetes/admin.conf ] && echo 'admin.conf is exists.' || echo 'admin.conf is not exists.'\"", 0, false)
+		if strings.Contains(output, "admin.conf is exists.") {
+			if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sed -i 's#server:.*#server: https://%s:%s#g' /etc/kubernetes/admin.conf", node.InternalAddress, strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)), 0, false); err != nil {
+				return errors.Wrap(errors.WithStack(err), "Failed to update /etc/kubernetes/kubelet.conf")
+			}
+		} else {
+			if err != nil {
+				return errors.Wrap(errors.WithStack(err), "Failed to find /etc/kubernetes/admin.conf")
+			}
+			return errors.New("Failed to find /etc/kubernetes/admin.conf")
+		}
+	}
+
+	output2, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"[ -f ~/.kube/config ] && echo 'kubectl config is exists.' || echo 'kubectl config is not exists.'\"", 0, false)
+	if strings.Contains(output2, "kubectl config is exists.") {
+		if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sed -i 's#server:.*#server: https://127.0.0.1:%s#g' ~/.kube/config", strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)), 0, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to update ~/.kube/config")
+		}
+	} else {
+		if err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to find ~/.kube/config")
+		}
+		return errors.New("Failed to find ~/.kube/config")
+	}
 	return nil
 }

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -183,11 +183,11 @@ func UpdateKubeproxyConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCf
 			"| /usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf replace -f -\"", strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)), 3, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "Failed to update kube-proxy config")
 		}
-	}
 
-	// Restart all kube-proxy pods to ensure that they load the new configmap.
-	if _, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"/usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0\"", 3, false); err != nil {
-		return errors.Wrap(errors.WithStack(err), "Failed to restart kube-proxy pod")
+		// Restart all kube-proxy pods to ensure that they load the new configmap.
+		if _, err := mgr.Runner.ExecuteCmd("sudo -E /bin/sh -c \"/usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0\"", 3, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to restart kube-proxy pod")
+		}
 	}
 	return nil
 }

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -222,3 +222,12 @@ func UpdateKubectlConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg)
 	}
 	return nil
 }
+
+// UpdateHostsFile is used to update the '/etc/hosts'. Make the 'lb.kubesphere.local' address to set as 127.0.0.1.
+// All of the 'admin.conf' and '/.kube/config' will connect to 127.0.0.1:6443.
+func UpdateHostsFile(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	if _, err := mgr.Runner.ExecuteCmd("sudo sed -i 's#.* lb.kubesphere.local#127.0.0.1 lb.kubesphere.local#g' /etc/hosts", 0, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to update /etc/hosts")
+	}
+	return nil
+}

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -226,7 +226,7 @@ func UpdateKubectlConfig(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg)
 // UpdateHostsFile is used to update the '/etc/hosts'. Make the 'lb.kubesphere.local' address to set as 127.0.0.1.
 // All of the 'admin.conf' and '/.kube/config' will connect to 127.0.0.1:6443.
 func UpdateHostsFile(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
-	if _, err := mgr.Runner.ExecuteCmd("sudo sed -i 's#.* lb.kubesphere.local#127.0.0.1 lb.kubesphere.local#g' /etc/hosts", 0, false); err != nil {
+	if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo sed -i 's#.* %s#127.0.0.1 %s#g' /etc/hosts", mgr.Cluster.ControlPlaneEndpoint.Domain, mgr.Cluster.ControlPlaneEndpoint.Domain), 0, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to update /etc/hosts")
 	}
 	return nil

--- a/pkg/kubernetes/preinstall/prepull_images.go
+++ b/pkg/kubernetes/preinstall/prepull_images.go
@@ -29,6 +29,7 @@ func PullImages(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
 		GetImage(mgr, "operator-generic"),
 		GetImage(mgr, "flannel"),
 		GetImage(mgr, "kubeovn"),
+		GetImage(mgr, "haproxy"),
 	}
 	if err := i.PullImages(mgr, node); err != nil {
 		return err
@@ -73,6 +74,9 @@ func GetImage(mgr *manager.Manager, name string) images.Image {
 		// storage
 		"provisioner-localpv": {RepoAddr: mgr.Cluster.Registry.PrivateRegistry, Namespace: "openebs", Repo: "provisioner-localpv", Tag: "2.10.1", Group: kubekeyapiv1alpha1.Worker, Enable: false},
 		"linux-utils":         {RepoAddr: mgr.Cluster.Registry.PrivateRegistry, Namespace: "openebs", Repo: "linux-utils", Tag: "2.10.0", Group: kubekeyapiv1alpha1.Worker, Enable: false},
+
+		// load balancer
+		"haproxy": {RepoAddr: mgr.Cluster.Registry.PrivateRegistry, Namespace: "library", Repo: "haproxy", Tag: "2.3", Group: kubekeyapiv1alpha1.Worker, Enable: mgr.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
 	}
 
 	image = ImageList[name]

--- a/pkg/loadbalancer/haproxy.go
+++ b/pkg/loadbalancer/haproxy.go
@@ -99,7 +99,7 @@ backend kube_api_backend
   mode tcp
   balance leastconn
   default-server inter 15s downinter 15s rise 2 fall 2 slowstart 60s maxconn 1000 maxqueue 256 weight 100
-  {{- if eq .KubernetesType "kubernetes"}}
+  {{- if ne .KubernetesType "k3s"}}
   option httpchk GET /healthz
   {{- end }}
   http-check expect status 200

--- a/pkg/loadbalancer/haproxy.go
+++ b/pkg/loadbalancer/haproxy.go
@@ -131,6 +131,9 @@ func GenerateHaproxyConf(mgr *manager.Manager) (string, error) {
 }
 
 func DeployHaproxy(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	if node.IsMaster {
+		return nil
+	}
 	fmt.Printf("[%s] generate haproxy manifest.\n", node.Name)
 
 	if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo -E /bin/sh -c \"mkdir -p %s\"", "/etc/kubekey/haproxy"),

--- a/pkg/loadbalancer/haproxy.go
+++ b/pkg/loadbalancer/haproxy.go
@@ -1,0 +1,203 @@
+package loadbalancer
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	kubekeyapiv1alpha1 "github.com/kubesphere/kubekey/apis/kubekey/v1alpha1"
+	"github.com/kubesphere/kubekey/pkg/kubernetes/preinstall"
+	"github.com/kubesphere/kubekey/pkg/util"
+	"github.com/kubesphere/kubekey/pkg/util/manager"
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"os/exec"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+var haproxyTemplate = template.Must(template.New("haproxy").Parse(
+	dedent.Dedent(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: haproxy
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    k8s-app: kube-haproxy
+  annotations:
+    cfg-checksum: "{{ .Checksum }}"
+spec:
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  nodeSelector:
+    kubernetes.io/os: linux
+  priorityClassName: system-node-critical
+  containers:
+  - name: haproxy
+    image: {{ .HaproxyImage }}
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 25m
+        memory: 32M
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: {{ .LoadbalancerApiserverHealthcheckPort }}
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: {{ .LoadbalancerApiserverHealthcheckPort }}
+    volumeMounts:
+    - mountPath: /usr/local/etc/haproxy/
+      name: etc-haproxy
+      readOnly: true
+  volumes:
+  - name: etc-haproxy
+    hostPath:
+      path: /etc/kubekey/haproxy
+`)))
+
+var haproxyConfig = template.Must(template.New("haproxy.cfg").Parse(
+	dedent.Dedent(`
+global
+    maxconn                 4000
+    log                     127.0.0.1 local0
+
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+    option                  http-server-close
+    option                  redispatch
+    retries                 5
+    timeout http-request    5m
+    timeout queue           5m
+    timeout connect         30s
+    timeout client          30s
+    timeout server          15m
+    timeout http-keep-alive 30s
+    timeout check           30s
+    maxconn                 4000
+
+frontend healthz
+  bind *:{{ .LoadbalancerApiserverHealthcheckPort }}
+  mode http
+  monitor-uri /healthz
+
+frontend kube_api_frontend
+  bind 127.0.0.1:{{ .LoadbalancerApiserverPort }}
+  mode tcp
+  option tcplog
+  default_backend kube_api_backend
+
+backend kube_api_backend
+  mode tcp
+  balance leastconn
+  default-server inter 15s downinter 15s rise 2 fall 2 slowstart 60s maxconn 1000 maxqueue 256 weight 100
+  {{- if eq .KubernetesType "kubernetes"}}
+  option httpchk GET /healthz
+  {{- end }}
+  http-check expect status 200
+  {{- range .MasterNodes }}
+  server {{ . }} check check-ssl verify none
+  {{- end }}
+`)))
+
+func GenerateHaproxyManifest(mgr *manager.Manager, checksum string) (string, error) {
+	return util.Render(haproxyTemplate, util.Data{
+		"HaproxyImage": preinstall.GetImage(mgr, "haproxy").ImageName(),
+		// todo: Consider whether need to customize the health check port
+		"LoadbalancerApiserverHealthcheckPort": 8081,
+		"Checksum":                             checksum,
+	})
+}
+
+func GenerateHaproxyConf(mgr *manager.Manager) (string, error) {
+	masterNodes := make([]string, len(mgr.MasterNodes))
+	for i, node := range mgr.MasterNodes {
+		masterNodes[i] = node.Name + " " + node.InternalAddress + ":" + strconv.Itoa(mgr.Cluster.ControlPlaneEndpoint.Port)
+	}
+	return util.Render(haproxyConfig, util.Data{
+		"MasterNodes":                          masterNodes,
+		"LoadbalancerApiserverPort":            mgr.Cluster.ControlPlaneEndpoint.Port,
+		"LoadbalancerApiserverHealthcheckPort": 8081,
+		"KubernetesType":                       mgr.Cluster.Kubernetes.Type,
+	})
+}
+
+func DeployHaproxy(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg) error {
+	fmt.Printf("[%s] generate haproxy manifest.\n", node.Name)
+
+	if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo -E /bin/sh -c \"mkdir -p %s\"", "/etc/kubekey/haproxy"),
+		2, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to make internal LB haproxy dir")
+	}
+
+	if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo -E /bin/sh -c \"chmod 700 %s\"", "/etc/kubekey/haproxy"),
+		1, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to chmod internal LB haproxy dir")
+	}
+
+	haproxyConf, err := GenerateHaproxyConf(mgr)
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("Faield to generate haproxy conf: %s", err))
+	}
+
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/haproxy.cfg", mgr.WorkDir), []byte(haproxyConf), 0755); err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("Failed to generate internal LB haproxy conf: %s/haproxy.cfg", mgr.WorkDir))
+	}
+
+	haproxyConfBase64, err := exec.Command("/bin/bash", "-c",
+		fmt.Sprintf("tar cfz - -C %s -T /dev/stdin <<< haproxy.cfg | base64 --wrap=0", mgr.WorkDir)).CombinedOutput()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to read internal LB haproxy conf")
+	}
+
+	if _, err = mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo -E /bin/bash -c \"base64 -d <<< '%s' | tar xz -C %s\"",
+		strings.TrimSpace(string(haproxyConfBase64)), "/etc/kubekey/haproxy"), 2, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to generate internal LB haproxy conf")
+	}
+
+	if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo -E /bin/sh -c \"chmod 755 %s\"", "/etc/kubekey/haproxy/haproxy.cfg"),
+		1, false); err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to chmod internal LB haproxy dir")
+	}
+
+	// Calculation config md5 as the checksum.
+	// It will make load balancer reload when config changes.
+	md5Obj := md5.New()
+	md5Obj.Write(haproxyConfBase64)
+	md5Str := hex.EncodeToString(md5Obj.Sum(nil))
+
+	haproxyManifest, err := GenerateHaproxyManifest(mgr, md5Str)
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("Faield to generate haproxy manifest: %s", err))
+	}
+
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/haproxy.yaml", mgr.WorkDir), []byte(haproxyManifest), 0644); err != nil {
+		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("Failed to generate internal LB haproxy manifests: %s/haproxy.yaml", mgr.WorkDir))
+	}
+
+	haproxyBase64, err := exec.Command("/bin/bash", "-c", fmt.Sprintf("tar cfz - -C %s -T /dev/stdin <<< haproxy.yaml | base64 --wrap=0", mgr.WorkDir)).CombinedOutput()
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to read internal LB haproxy manifests")
+	}
+
+	var path string
+	if mgr.Cluster.Kubernetes.Type == "k3s" {
+		path = "/var/lib/rancher/k3s/agent/pod-manifests"
+	} else {
+		path = "/etc/kubernetes/manifests"
+	}
+	_, err = mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo -E /bin/bash -c \"base64 -d <<< '%s' | tar xz -C %s\"",
+		strings.TrimSpace(string(haproxyBase64)), path), 2, false)
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "Failed to generate internal LB haproxy manifests")
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is to add a HA plan for creating cluster. This plan is the same as this repo [kubespray](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ha-mode.md). 

In short, the kubelet of each master nodes connects the local apiserver and the kubelet of each worker nodes connects the local haproxy server that proxy the traffic to every apiserver.

Now it's only support kubernetes, i will support the k3s as soon as possible.

