### PR TITLE
support KubeSphere v3.1.1

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -61,7 +61,7 @@ func init() {
 func setValidArgs(cmd *cobra.Command) (err error) {
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) (
 		strings []string, directive cobra.ShellCompDirective) {
-		versionArray := []string{"v2.1.1", "v3.0.0", "v3.1.0", time.Now().Add(-time.Hour * 24).Format("nightly-20060102")}
+		versionArray := []string{"v2.1.1", "v3.0.0", "v3.1.0", "v3.1.1", time.Now().Add(-time.Hour * 24).Format("nightly-20060102")}
 		return versionArray, cobra.ShellCompDirectiveNoFileComp
 	}
 

--- a/pkg/cluster/upgrade/precheck.go
+++ b/pkg/cluster/upgrade/precheck.go
@@ -32,6 +32,20 @@ import (
 )
 
 var versionCheck = map[string]map[string]map[string]bool{
+	"v3.1.1": {
+		"k8s": {
+			"v1.20": true,
+			"v1.19": true,
+			"v1.18": true,
+			"v1.17": true,
+			"v1.16": true,
+			"v1.15": true,
+		},
+		"ks": {
+			"v3.0.0": true,
+			"v3.1.0": true,
+		},
+	},
 	"v3.1.0": {
 		"k8s": {
 			"v1.20": true,

--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -117,7 +117,9 @@ func GenerateClusterObj(k8sVersion, ksVersion, name, kubeconfig, clusterCfgPath 
 
 	if ksEnabled {
 		switch strings.TrimSpace(ksVersion) {
-		case "v3.1.0", "latest":
+		case "v3.1.1", "latest":
+			opt.KubeSphereConfigMap = kubesphere.V3_1_1
+		case "v3.1.0":
 			opt.KubeSphereConfigMap = kubesphere.V3_1_0
 		case "v3.0.0":
 			opt.KubeSphereConfigMap = kubesphere.V3_0_0

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -103,6 +103,9 @@ func ParseCfg(clusterCfgPath, k8sVersion, ksVersion string, ksEnabled bool) (*ku
 			_, ok := labels["version"]
 			if ok {
 				switch labels["version"] {
+				case "v3.1.1":
+					clusterCfg.Spec.KubeSphere.Configurations = "---\n" + string(content)
+					clusterCfg.Spec.KubeSphere.Version = "v3.1.1"
 				case "v3.1.0":
 					clusterCfg.Spec.KubeSphere.Configurations = "---\n" + string(content)
 					clusterCfg.Spec.KubeSphere.Version = "v3.1.0"
@@ -122,7 +125,10 @@ func ParseCfg(clusterCfgPath, k8sVersion, ksVersion string, ksEnabled bool) (*ku
 	if ksEnabled {
 		clusterCfg.Spec.KubeSphere.Enabled = true
 		switch strings.TrimSpace(ksVersion) {
-		case "v3.1.0", "":
+		case "v3.1.1", "":
+			clusterCfg.Spec.KubeSphere.Version = "v3.1.1"
+			clusterCfg.Spec.KubeSphere.Configurations = kubesphere.V3_1_1
+		case "v3.1.0":
 			clusterCfg.Spec.KubeSphere.Version = "v3.1.0"
 			clusterCfg.Spec.KubeSphere.Configurations = kubesphere.V3_1_0
 		case "v3.0.0":
@@ -200,7 +206,10 @@ func AllinoneCfg(user *user.User, k8sVersion, ksVersion string, ksEnabled bool, 
 		allinoneCfg.Spec.KubeSphere.Enabled = true
 		ksVersion = strings.TrimSpace(ksVersion)
 		switch ksVersion {
-		case "v3.1.0", "":
+		case "v3.1.1", "":
+			allinoneCfg.Spec.KubeSphere.Version = "v3.1.1"
+			allinoneCfg.Spec.KubeSphere.Configurations = kubesphere.V3_1_1
+		case "v3.1.0":
 			allinoneCfg.Spec.KubeSphere.Version = "v3.1.0"
 			allinoneCfg.Spec.KubeSphere.Configurations = kubesphere.V3_1_0
 		case "v3.0.0":

--- a/pkg/kubesphere/kubesphere.go
+++ b/pkg/kubesphere/kubesphere.go
@@ -115,7 +115,11 @@ EOF
 		if err := generateKubeSphereManifests(mgr, ksVersion); err != nil {
 			return err
 		}
-	case "v3.1.0", "latest":
+	case "v3.1.0":
+		if err := generateKubeSphereManifests(mgr, ksVersion); err != nil {
+			return err
+		}
+	case "v3.1.1", "latest":
 		if err := generateKubeSphereManifests(mgr, ksVersion); err != nil {
 			return err
 		}
@@ -147,7 +151,8 @@ EOF
 		}
 	}
 
-	if ksVersion == "v3.1.0" && (os.Getenv("KKZONE") == "cn" || mgr.Cluster.Registry.PrivateRegistry == "registry.cn-beijing.aliyuncs.com") {
+	_, ok := mirrorVersionList[ksVersion]
+	if ok && (os.Getenv("KKZONE") == "cn" || mgr.Cluster.Registry.PrivateRegistry == "registry.cn-beijing.aliyuncs.com") {
 		if _, err := mgr.Runner.ExecuteCmd(fmt.Sprintf("sudo /bin/sh -c \"sed -i '/zone/s/\\:.*/\\: %s/g' /etc/kubernetes/addons/kubesphere.yaml\"", "cn"), 2, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("Failed to add private registry: %s", mgr.Cluster.Registry.PrivateRegistry))
 		}

--- a/pkg/kubesphere/manifests.go
+++ b/pkg/kubesphere/manifests.go
@@ -250,8 +250,123 @@ spec:
       type: none
     topology:
       type: none
-  notification:   
+  openpitrix:
+    store:
+      enabled: false
+  servicemesh:    
+    enabled: false  
+  kubeedge:
     enabled: false
+    cloudCore:
+      nodeSelector: {"node-role.kubernetes.io/worker": ""}
+      tolerations: []
+      cloudhubPort: "10000"
+      cloudhubQuicPort: "10001"
+      cloudhubHttpsPort: "10002"
+      cloudstreamPort: "10003"
+      tunnelPort: "10004"
+      cloudHub:
+        advertiseAddress: 
+          - ""           
+        nodeLimit: "100"
+      service:
+        cloudhubNodePort: "30000"
+        cloudhubQuicNodePort: "30001"
+        cloudhubHttpsNodePort: "30002"
+        cloudstreamNodePort: "30003"
+        tunnelNodePort: "30004"
+    edgeWatcher:
+      nodeSelector: {"node-role.kubernetes.io/worker": ""}
+      tolerations: []
+      edgeWatcherAgent:
+        nodeSelector: {"node-role.kubernetes.io/worker": ""}
+        tolerations: []
+`
+
+	V3_1_1 = `---
+apiVersion: installer.kubesphere.io/v1alpha1
+kind: ClusterConfiguration
+metadata:
+  name: ks-installer
+  namespace: kubesphere-system
+  labels:
+    version: v3.1.1
+spec:
+  persistence:
+    storageClass: ""       
+  authentication:
+    jwtSecret: ""
+  zone: ""
+  local_registry: ""        
+  etcd:
+    monitoring: false      
+    endpointIps: localhost  
+    port: 2379             
+    tlsEnable: true
+  common:
+    redis:
+      enabled: false
+    redisVolumSize: 2Gi 
+    openldap:
+      enabled: false
+    openldapVolumeSize: 2Gi  
+    minioVolumeSize: 20Gi
+    monitoring:
+      endpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090
+    es:  
+      elasticsearchMasterVolumeSize: 4Gi   
+      elasticsearchDataVolumeSize: 20Gi   
+      logMaxAge: 7          
+      elkPrefix: logstash
+      basicAuth:
+        enabled: false
+        username: ""
+        password: ""
+      externalElasticsearchUrl: ""
+      externalElasticsearchPort: ""  
+  console:
+    enableMultiLogin: true 
+    port: 30880
+  alerting:       
+    enabled: false
+    # thanosruler:
+    #   replicas: 1
+    #   resources: {}
+  auditing:    
+    enabled: false
+  devops:           
+    enabled: false
+    jenkinsMemoryLim: 2Gi     
+    jenkinsMemoryReq: 1500Mi 
+    jenkinsVolumeSize: 8Gi   
+    jenkinsJavaOpts_Xms: 512m  
+    jenkinsJavaOpts_Xmx: 512m
+    jenkinsJavaOpts_MaxRAM: 2g
+  events:          
+    enabled: false
+    ruler:
+      enabled: true
+      replicas: 2
+  logging:         
+    enabled: false
+    logsidecar:
+      enabled: true
+      replicas: 2
+  metrics_server:             
+    enabled: false
+  monitoring:
+    storageClass: ""
+    prometheusMemoryRequest: 400Mi  
+    prometheusVolumeSize: 20Gi  
+  multicluster:
+    clusterRole: none 
+  network:
+    networkpolicy:
+      enabled: false
+    ippool:
+      type: none
+    topology:
+      type: none
   openpitrix:
     store:
       enabled: false
@@ -303,23 +418,33 @@ metadata:
   namespace: kubesphere-system
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterconfigurations.installer.kubesphere.io
 spec:
   group: installer.kubesphere.io
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
   scope: Namespaced
   names:
     plural: clusterconfigurations
     singular: clusterconfiguration
     kind: ClusterConfiguration
     shortNames:
-    - cc
+      - cc
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -570,10 +695,16 @@ spec:
         name: host-time
 
     `)))
+
+	mirrorVersionList = map[string]bool{
+		"v3.1.0": true,
+		"v3.1.1": true,
+	}
 )
 
 func GenerateKubeSphereYaml(repo, version string) (string, error) {
-	if version == "v3.1.0" && os.Getenv("KKZONE") == "cn" {
+	_, ok := mirrorVersionList[version]
+	if ok && os.Getenv("KKZONE") == "cn" {
 		repo = "registry.cn-beijing.aliyuncs.com/kubesphereio"
 	} else {
 		if repo == "" {


### PR DESCRIPTION
Support installation and upgrade to KubeSphere v3.1.1

After KubeSphere v3.1.1 is released, the following commands can be used to install and upgrade:
```
# install
./kk create cluster --with-kubesphere v3.1.1

# upgrade 
./kk upgrade --with-kubesphere v3.1.1
```

Signed-off-by: pixiake <guofeng@yunify.com>