### PR TITLE
fix: the bug that the config file is different from the original order

### DIFF
--- a/apis/kubekey/v1alpha1/cluster_types.go
+++ b/apis/kubekey/v1alpha1/cluster_types.go
@@ -143,6 +143,9 @@ type HostCfg struct {
 	IsEtcd   bool              `json:"-"`
 	IsMaster bool              `json:"-"`
 	IsWorker bool              `json:"-"`
+
+	EtcdExist bool   `json:"-"`
+	EtcdName  string `json:"-"`
 }
 
 // RoleGroups defines the grouping of role for hosts (etcd / master / worker).

--- a/pkg/cluster/add/add.go
+++ b/pkg/cluster/add/add.go
@@ -78,6 +78,7 @@ func ExecTasks(mgr *manager.Manager) error {
 		{Task: install.InitOS, ErrMsg: "Failed to init OS"},
 		{Task: docker.InstallerDocker, ErrMsg: "Failed to install docker", Skip: skipCondition1},
 		{Task: install.PrePullImages, ErrMsg: "Failed to pre-pull images", Skip: skipCondition1},
+		{Task: etcd.GetEtcdStatus, ErrMsg: "Failed to get etcd status"},
 		{Task: etcd.GenerateEtcdCerts, ErrMsg: "Failed to generate etcd certs"},
 		{Task: etcd.SyncEtcdCertsToMaster, ErrMsg: "Failed to sync etcd certs"},
 		{Task: etcd.GenerateEtcdService, ErrMsg: "Failed to create etcd service"},

--- a/pkg/cluster/install/install.go
+++ b/pkg/cluster/install/install.go
@@ -90,6 +90,7 @@ func ExecTasks(mgr *manager.Manager) error {
 		{Task: InitOS, ErrMsg: "Failed to init OS"},
 		{Task: docker.InstallerDocker, ErrMsg: "Failed to install docker", Skip: isK3s},
 		{Task: PrePullImages, ErrMsg: "Failed to pre-pull images", Skip: isK3s},
+		{Task: etcd.GetEtcdStatus, ErrMsg: "Failed to get etcd status"},
 		{Task: etcd.GenerateEtcdCerts, ErrMsg: "Failed to generate etcd certs"},
 		{Task: etcd.SyncEtcdCertsToMaster, ErrMsg: "Failed to sync etcd certs"},
 		{Task: etcd.GenerateEtcdService, ErrMsg: "Failed to create etcd service"},

--- a/pkg/etcd/tmpl/etcd.go
+++ b/pkg/etcd/tmpl/etcd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tmpl
 
 import (
-	"fmt"
 	"strings"
 	"text/template"
 
@@ -126,30 +125,30 @@ ETCDCTL_CERT_FILE=/etc/ssl/etcd/ssl/admin-{{ .Hostname }}.pem
 )
 
 // GenerateEtcdBinary is used to generate etcd's container binary content.
-func GenerateEtcdBinary(mgr *manager.Manager, index int) (string, error) {
+func GenerateEtcdBinary(mgr *manager.Manager, name string) (string, error) {
 	return util.Render(EtcdTempl, util.Data{
-		"Name":      fmt.Sprintf("etcd%d", index+1),
+		"Name":      name,
 		"EtcdImage": preinstall.GetImage(mgr, "etcd").ImageName(),
 	})
 }
 
 // GenerateEtcdService is used to generate the etcd's service content for systemd.
-func GenerateEtcdService(index int, etcdContainer bool) (string, error) {
+func GenerateEtcdService(name string, etcdContainer bool) (string, error) {
 	return util.Render(EtcdServiceTempl, util.Data{
-		"Name":          fmt.Sprintf("etcd%d", index+1),
+		"Name":          name,
 		"EtcdContainer": etcdContainer,
 	})
 }
 
 // GenerateEtcdEnv is used to generate the etcd's env content.
-func GenerateEtcdEnv(node *kubekeyapiv1alpha1.HostCfg, index int, endpoints []string, state string) (string, error) {
+func GenerateEtcdEnv(node *kubekeyapiv1alpha1.HostCfg, endpoints []string, state string) (string, error) {
 	UnsupportedArch := false
 	if node.Arch != "amd64" {
 		UnsupportedArch = true
 	}
 	return util.Render(EtcdEnvTempl, util.Data{
 		"Tag":             kubekeyapiv1alpha1.DefaultEtcdVersion,
-		"Name":            fmt.Sprintf("etcd%d", index+1),
+		"Name":            node.EtcdName,
 		"Ip":              node.InternalAddress,
 		"Hostname":        node.Name,
 		"State":           state,


### PR DESCRIPTION
There is a bug in adding nodes when the hosts order is different from the original order.

The original config file:
```
hosts:
  - {name: node1, address: 192.168.0.3, internalAddress: 192.168.0.3, user: root, password: password}
  - {name: node2, address: 192.168.0.4, internalAddress: 192.168.0.4, user: root, password: password}
  - {name: node3, address: 192.168.0.5, internalAddress: 192.168.0.5, user: root, password: password}
  roleGroups:
    etcd:
    - node1
    - node2
    - node3
    master:
    - node1
    - node2
    - node3
    worker:
    - node1
```
When adding nodes, the config:
```
hosts:
  - {name: node4, address: 192.168.0.10, internalAddress: 192.168.0.10, user: root, password: password}
  - {name: node5, address: 192.168.0.11 internalAddress: 192.168.0.11, user: root, password: password}
  - {name: node1, address: 192.168.0.3, internalAddress: 192.168.0.3, user: root, password: password}
  - {name: node2, address: 192.168.0.4, internalAddress: 192.168.0.4, user: root, password: password}
  - {name: node3, address: 192.168.0.5, internalAddress: 192.168.0.5, user: root, password: password}
  roleGroups:
    etcd:
    - node4
    - node5
    - node1
    - node2
    - node3
    master:
    - node4
    - node5
    - node1
    - node2
    - node3
    worker:
    - node1
```

Then i add nodes by the new config file, the kk will get the wrong etcd status and wrong k8s status. After that, failed to add nodes.

I modify the check logic. First of all, the kk will serial get the etcd status and save the etcd nodes status in the `HostCfg struct`. And other functions are the same as before but they can use etcd nodes status directly by `HostCfg struct`. One more thing, the new etcd instance's name will be change. Now, it named as `etcd-<hostname>` unless the kk found the name of the node's old etcd.

The function of `GetClusterStatus` is also changed. Every master node will serial get the k8s status until the value of the `map["clusterInfo"]` is not a empty string.