### PR TITLE
Refine the verification of the lb configuration

### DIFF
--- a/apis/kubekey/v1alpha1/default.go
+++ b/apis/kubekey/v1alpha1/default.go
@@ -143,15 +143,9 @@ func SetDefaultHostsCfg(cfg *ClusterSpec) []HostCfg {
 
 func SetDefaultLBCfg(cfg *ClusterSpec, masterGroup []HostCfg, incluster bool) ControlPlaneEndpoint {
 	if !incluster {
-		//The detection is not an HA environment, and the address at LB does not need input
-		if len(masterGroup) == 1 && cfg.ControlPlaneEndpoint.Address != "" {
-			fmt.Println("When the environment is not HA, the LB address does not need to be entered, so delete the corresponding value.")
-			os.Exit(0)
-		}
-
 		//Check whether LB should be configured
-		if len(masterGroup) >= 3 && !cfg.ControlPlaneEndpoint.IsInternalLBEnabled() && cfg.ControlPlaneEndpoint.Address == "" {
-			fmt.Println("When the environment has at least three masters, You must set the value of the LB address or enable the internal loadbalancer.")
+		if len(masterGroup) >= 2 && !cfg.ControlPlaneEndpoint.IsInternalLBEnabled() && cfg.ControlPlaneEndpoint.Address == "" {
+			fmt.Println("The number of nodes in the ControlPlane is above 1, You must set the value of the LB address or enable the internal loadbalancer.")
 			os.Exit(0)
 		}
 


### PR DESCRIPTION
1. Remove the lb configuration limit for allinone. 
2. When the number of nodes in the ControlPlane is above 1, lb should be set up. 
 
Signed-off-by: pixiake <guofeng@yunify.com>