### PR TITLE
Remove the asNumber and peerIP dependencies

### DIFF
--- a/pkg/plugins/network/calico/tmpl-v1.16+.go
+++ b/pkg/plugins/network/calico/tmpl-v1.16+.go
@@ -308,9 +308,6 @@ spec:
                   remote AS number comes from the remote node鈥檚 NodeBGPSpec.ASNumber,
                   or the global default if that is not set.
                 type: string
-            required:
-            - asNumber
-            - peerIP
             type: object
         type: object
     served: true


### PR DESCRIPTION
Remove the asNumber and peerIP dependencies to keep in line with official calico, calicoctl will detect the dependencies