### PR TITLE
Add the requirement for Linux Kernel Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ There are three scenarios to use KubeKey.
 * **CentOS/RHEL**  *7*
 * **SUSE Linux Enterprise Server** *15*
 
+> Recommended Linux Kernel Version: `4.15 or later` \
+> You can run the `uname -srm` command to check the Linux Kernel Version.
 
 ### <span id = "KubernetesVersions">Kubernetes Versions</span> 
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -30,6 +30,8 @@
 * **CentOS/RHEL**  *7*
 * **SUSE Linux Enterprise Server** *15*
 
+> 建议使用 Linux Kernel 版本: `4.15 or later` \
+> 可以通过命令 `uname -srm` 查看 Linux Kernel 版本。
 
 ### <span id = "KubernetesVersions">Kubernetes 版本</span> 
 


### PR DESCRIPTION
Using the lower version of the Linux Kernel, the cluster can experience problems during the operation.

https://garyhuang123.github.io/kubernetes/2019/03/21/the-analysis-of-kernel-and-os-for-running-kubernetes.html

https://github.com/kubernetes/kubernetes/issues/61937

Signed-off-by: pixiake <guofeng@yunify.com>