### PR TITLE
fix: localAPIEndpoint of each master is set to master1's address

### DIFF
--- a/pkg/kubernetes/config/v1beta2/kubeadm.go
+++ b/pkg/kubernetes/config/v1beta2/kubeadm.go
@@ -181,13 +181,6 @@ func GenerateKubeadmCfg(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg, 
 		return "", err
 	}
 
-	var controlPlaneAddr string
-	if isInitCluster {
-		controlPlaneAddr = mgr.Cluster.ControlPlaneEndpoint.Address
-	} else {
-		controlPlaneAddr = node.InternalAddress
-	}
-
 	return util.Render(KubeadmCfgTempl, util.Data{
 		"IsInitCluster":          isInitCluster,
 		"ImageRepo":              strings.TrimSuffix(preinstall.GetImage(mgr, "kube-apiserver").ImageRepo(), "/kube-apiserver"),
@@ -195,7 +188,7 @@ func GenerateKubeadmCfg(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg, 
 		"CorednsTag":             preinstall.GetImage(mgr, "coredns").Tag,
 		"Version":                mgr.Cluster.Kubernetes.Version,
 		"ClusterName":            mgr.Cluster.Kubernetes.ClusterName,
-		"ControlPlanAddr":        controlPlaneAddr,
+		"ControlPlanAddr":        node.InternalAddress,
 		"ControlPlanPort":        mgr.Cluster.ControlPlaneEndpoint.Port,
 		"ControlPlaneEndpoint":   fmt.Sprintf("%s:%d", mgr.Cluster.ControlPlaneEndpoint.Domain, mgr.Cluster.ControlPlaneEndpoint.Port),
 		"PodSubnet":              mgr.Cluster.Network.KubePodsCIDR,
@@ -205,7 +198,6 @@ func GenerateKubeadmCfg(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg, 
 		"NodeCidrMaskSize":       mgr.Cluster.Kubernetes.NodeCidrMaskSize,
 		"CriSock":                mgr.ContainerRuntimeEndpoint,
 		"InternalLBDisabled":     !mgr.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled(),
-		"AdvertiseAddress":       node.InternalAddress,
 		"ApiServerArgs":          ApiServerArgs,
 		"ControllerManagerArgs":  ControllerManagerArgs,
 		"SchedulerArgs":          SchedulerArgs,

--- a/pkg/kubernetes/config/v1beta2/kubeadm.go
+++ b/pkg/kubernetes/config/v1beta2/kubeadm.go
@@ -181,6 +181,13 @@ func GenerateKubeadmCfg(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg, 
 		return "", err
 	}
 
+	var controlPlaneAddr string
+	if isInitCluster {
+		controlPlaneAddr = mgr.Cluster.ControlPlaneEndpoint.Address
+	} else {
+		controlPlaneAddr = node.InternalAddress
+	}
+
 	return util.Render(KubeadmCfgTempl, util.Data{
 		"IsInitCluster":          isInitCluster,
 		"ImageRepo":              strings.TrimSuffix(preinstall.GetImage(mgr, "kube-apiserver").ImageRepo(), "/kube-apiserver"),
@@ -188,7 +195,7 @@ func GenerateKubeadmCfg(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg, 
 		"CorednsTag":             preinstall.GetImage(mgr, "coredns").Tag,
 		"Version":                mgr.Cluster.Kubernetes.Version,
 		"ClusterName":            mgr.Cluster.Kubernetes.ClusterName,
-		"ControlPlanAddr":        mgr.Cluster.ControlPlaneEndpoint.Address,
+		"ControlPlanAddr":        controlPlaneAddr,
 		"ControlPlanPort":        mgr.Cluster.ControlPlaneEndpoint.Port,
 		"ControlPlaneEndpoint":   fmt.Sprintf("%s:%d", mgr.Cluster.ControlPlaneEndpoint.Domain, mgr.Cluster.ControlPlaneEndpoint.Port),
 		"PodSubnet":              mgr.Cluster.Network.KubePodsCIDR,

--- a/pkg/kubernetes/config/v1beta2/kubeadm.go
+++ b/pkg/kubernetes/config/v1beta2/kubeadm.go
@@ -87,7 +87,7 @@ scheduler:
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 localAPIEndpoint:
-  advertiseAddress: {{ .ControlPlanAddr }}
+  advertiseAddress: {{ .AdvertiseAddress }}
   bindPort: {{ .ControlPlanPort }}
 nodeRegistration:
 {{- if .CriSock }}
@@ -117,7 +117,7 @@ discovery:
 {{- if .IsControlPlane }}
 controlPlane:
   localAPIEndpoint:
-    advertiseAddress: {{ .ControlPlanAddr }}
+    advertiseAddress: {{ .AdvertiseAddress }}
     bindPort: {{ .ControlPlanPort }}
   certificateKey: {{ .CertificateKey }}
 {{- end }}
@@ -188,7 +188,7 @@ func GenerateKubeadmCfg(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg, 
 		"CorednsTag":             preinstall.GetImage(mgr, "coredns").Tag,
 		"Version":                mgr.Cluster.Kubernetes.Version,
 		"ClusterName":            mgr.Cluster.Kubernetes.ClusterName,
-		"ControlPlanAddr":        node.InternalAddress,
+		"AdvertiseAddress":       node.InternalAddress,
 		"ControlPlanPort":        mgr.Cluster.ControlPlaneEndpoint.Port,
 		"ControlPlaneEndpoint":   fmt.Sprintf("%s:%d", mgr.Cluster.ControlPlaneEndpoint.Domain, mgr.Cluster.ControlPlaneEndpoint.Port),
 		"PodSubnet":              mgr.Cluster.Network.KubePodsCIDR,
@@ -197,7 +197,6 @@ func GenerateKubeadmCfg(mgr *manager.Manager, node *kubekeyapiv1alpha1.HostCfg, 
 		"ExternalEtcd":           externalEtcd,
 		"NodeCidrMaskSize":       mgr.Cluster.Kubernetes.NodeCidrMaskSize,
 		"CriSock":                mgr.ContainerRuntimeEndpoint,
-		"InternalLBDisabled":     !mgr.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled(),
 		"ApiServerArgs":          ApiServerArgs,
 		"ControllerManagerArgs":  ControllerManagerArgs,
 		"SchedulerArgs":          SchedulerArgs,


### PR DESCRIPTION
The localAPIEndpoint of each master should be its own IP address.

Signed-off-by: 24sama <leo@kubesphere.io>