### PR TITLE
dev-v2.0.0: support operator mode by using hook

### DIFF
--- a/pkg/common/kube_hook.go
+++ b/pkg/common/kube_hook.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	kubekeycontroller "github.com/kubesphere/kubekey/controllers/kubekey"
 	"github.com/kubesphere/kubekey/pkg/core/hook"
 )
 
@@ -9,6 +10,22 @@ type UpdateCRStatusHook struct {
 }
 
 func (u *UpdateCRStatusHook) Try() error {
-	// todo: update cr status
+	kubeRuntime := u.Runtime.(*KubeRuntime)
+
+	if !kubeRuntime.Arg.InCluster {
+		return nil
+	}
+
+	conf := &KubeConf{
+		ClusterHosts: kubeRuntime.ClusterHosts,
+		Cluster:      kubeRuntime.Cluster,
+		Kubeconfig:   kubeRuntime.Kubeconfig,
+		Conditions:   kubeRuntime.Conditions,
+		ClientSet:    kubeRuntime.ClientSet,
+		Arg:          kubeRuntime.Arg,
+	}
+	if err := kubekeycontroller.UpdateClusterConditions(conf, u.Desc, u.Result); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/pipelines/add_nodes.go
+++ b/pkg/pipelines/add_nodes.go
@@ -43,8 +43,23 @@ func NewAddNodesPipeline(runtime *common.KubeRuntime) error {
 		Runtime: runtime,
 	}
 	if err := p.Start(); err != nil {
+		if runtime.Arg.InCluster {
+			if err := kubekeycontroller.PatchNodeImportStatus(runtime, kubekeycontroller.Failed); err != nil {
+				return err
+			}
+		}
 		return err
 	}
+
+	if runtime.Arg.InCluster {
+		if err := kubekeycontroller.PatchNodeImportStatus(runtime, kubekeycontroller.Success); err != nil {
+			return err
+		}
+		if err := kubekeycontroller.UpdateStatus(runtime); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -69,8 +84,23 @@ func NewK3sAddNodesPipeline(runtime *common.KubeRuntime) error {
 		Runtime: runtime,
 	}
 	if err := p.Start(); err != nil {
+		if runtime.Arg.InCluster {
+			if err := kubekeycontroller.PatchNodeImportStatus(runtime, kubekeycontroller.Failed); err != nil {
+				return err
+			}
+		}
 		return err
 	}
+
+	if runtime.Arg.InCluster {
+		if err := kubekeycontroller.PatchNodeImportStatus(runtime, kubekeycontroller.Success); err != nil {
+			return err
+		}
+		if err := kubekeycontroller.UpdateStatus(runtime); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -99,6 +129,12 @@ func AddNodes(args common.Argument, downloadCmd string) error {
 			return err
 		}
 		runtime.ClientSet = c
+	}
+
+	if runtime.Arg.InCluster {
+		if err := kubekeycontroller.CreateNodeForCluster(runtime); err != nil {
+			return err
+		}
 	}
 
 	switch runtime.Cluster.Kubernetes.Type {


### PR DESCRIPTION
### What does this PR do?
* Support operator mode

### Why we need this PR?
The architecture of KubeKey operator mode is a KubeKey controller reconcile CRs and then the controller will deploy a job to run a KubeKey pipeline. This architecture makes the job must to update CR's status which is related the job. So this PR use the hook mechanism to update the CR's status.