### PR TITLE
dev-v2.0.0: add ignore-err option

### DIFF
--- a/cmd/add_nodes.go
+++ b/cmd/add_nodes.go
@@ -30,6 +30,7 @@ var addNodesCmd = &cobra.Command{
 			FilePath:         opt.ClusterCfgFile,
 			KsEnable:         false,
 			Debug:            opt.Verbose,
+			IgnoreErr:        opt.IgnoreErr,
 			SkipConfirmCheck: opt.SkipConfirmCheck,
 			SkipPullImages:   opt.SkipPullImages,
 			InCluster:        opt.InCluster,

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -46,6 +46,7 @@ var clusterCmd = &cobra.Command{
 			InCluster:          opt.InCluster,
 			DeployLocalStorage: opt.LocalStorage,
 			Debug:              opt.Verbose,
+			IgnoreErr:          opt.IgnoreErr,
 			SkipConfirmCheck:   opt.SkipConfirmCheck,
 			ContainerManager:   opt.ContainerManager,
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 
 type Options struct {
 	Verbose          bool
+	IgnoreErr        bool
 	Addons           string
 	Name             string
 	ClusterCfgPath   string
@@ -75,6 +76,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&opt.InCluster, "in-cluster", false, "Running inside the cluster")
 	rootCmd.PersistentFlags().BoolVar(&opt.Verbose, "debug", true, "Print detailed information")
 	rootCmd.PersistentFlags().BoolVarP(&opt.SkipConfirmCheck, "yes", "y", false, "Skip confirm check")
+	rootCmd.PersistentFlags().BoolVar(&opt.IgnoreErr, "ignore-err", false, "Ignore the error message, remove the host which reported error and force to continue")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,10 +23,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - command:
-        - /manager
+        - ./manager
         args:
         - --leader-elect
         image: controller:latest

--- a/pkg/common/kube_action.go
+++ b/pkg/common/kube_action.go
@@ -16,7 +16,6 @@ func (k *KubeAction) AutoAssert(runtime connector.Runtime) {
 		ClusterHosts: kubeRuntime.ClusterHosts,
 		Cluster:      kubeRuntime.Cluster,
 		Kubeconfig:   kubeRuntime.Kubeconfig,
-		Conditions:   kubeRuntime.Conditions,
 		ClientSet:    kubeRuntime.ClientSet,
 		Arg:          kubeRuntime.Arg,
 	}

--- a/pkg/common/kube_module.go
+++ b/pkg/common/kube_module.go
@@ -11,7 +11,6 @@ type KubeConf struct {
 	ClusterName  string
 	Cluster      *kubekeyapiv1alpha2.ClusterSpec
 	Kubeconfig   string
-	Conditions   []kubekeyapiv1alpha2.Condition
 	ClientSet    *kubekeyclientset.Clientset
 	Arg          Argument
 }
@@ -32,7 +31,6 @@ func (k *KubeModule) AutoAssert() {
 		ClusterName:  kubeRuntime.ClusterName,
 		Cluster:      kubeRuntime.Cluster,
 		Kubeconfig:   kubeRuntime.Kubeconfig,
-		Conditions:   kubeRuntime.Conditions,
 		ClientSet:    kubeRuntime.ClientSet,
 		Arg:          kubeRuntime.Arg,
 	}
@@ -52,7 +50,6 @@ func (k *KubeCustomModule) AutoAssert() {
 		ClusterName:  kubeRuntime.ClusterName,
 		Cluster:      kubeRuntime.Cluster,
 		Kubeconfig:   kubeRuntime.Kubeconfig,
-		Conditions:   kubeRuntime.Conditions,
 		ClientSet:    kubeRuntime.ClientSet,
 		Arg:          kubeRuntime.Arg,
 	}

--- a/pkg/common/kube_prepare.go
+++ b/pkg/common/kube_prepare.go
@@ -16,7 +16,6 @@ func (k *KubePrepare) AutoAssert(runtime connector.Runtime) {
 		ClusterHosts: kubeRuntime.ClusterHosts,
 		Cluster:      kubeRuntime.Cluster,
 		Kubeconfig:   kubeRuntime.Kubeconfig,
-		Conditions:   kubeRuntime.Conditions,
 		ClientSet:    kubeRuntime.ClientSet,
 		Arg:          kubeRuntime.Arg,
 	}

--- a/pkg/common/kube_runtime.go
+++ b/pkg/common/kube_runtime.go
@@ -13,7 +13,6 @@ type KubeRuntime struct {
 	ClusterName  string
 	Cluster      *kubekeyapiv1alpha2.ClusterSpec
 	Kubeconfig   string
-	Conditions   []kubekeyapiv1alpha2.Condition
 	ClientSet    *kubekeyclientset.Clientset
 	Arg          Argument
 }
@@ -25,6 +24,7 @@ type Argument struct {
 	KsEnable           bool
 	KsVersion          string
 	Debug              bool
+	IgnoreErr          bool
 	SkipPullImages     bool
 	AddImagesRepo      bool
 	DeployLocalStorage bool
@@ -53,16 +53,7 @@ func NewKubeRuntime(flag string, arg Argument) (*KubeRuntime, error) {
 		defaultCluster.Kubernetes.ContainerManager = arg.ContainerManager
 	}
 
-	//var clientset *kubekeyclientset.Clientset
-	//if arg.InCluster {
-	//	c, err := kubekeycontroller.NewKubekeyClient()
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//	clientset = c
-	//}
-
-	base := connector.NewBaseRuntime(cluster.Name, connector.NewDialer(), arg.Debug)
+	base := connector.NewBaseRuntime(cluster.Name, connector.NewDialer(), arg.Debug, arg.IgnoreErr)
 	for _, v := range hostGroups.All {
 		host := ToHosts(v)
 		if v.IsMaster {
@@ -87,8 +78,7 @@ func NewKubeRuntime(flag string, arg Argument) (*KubeRuntime, error) {
 		ClusterHosts: generateHosts(hostGroups, defaultCluster),
 		Cluster:      defaultCluster,
 		ClusterName:  cluster.Name,
-		//ClientSet:    clientset,
-		Arg: arg,
+		Arg:          arg,
 	}
 	r.BaseRuntime = base
 

--- a/pkg/core/connector/host.go
+++ b/pkg/core/connector/host.go
@@ -19,9 +19,9 @@ type BaseHost struct {
 
 func NewHost() *BaseHost {
 	return &BaseHost{
-		Roles:           make([]string, 0, 0),
-		RoleTable:       make(map[string]bool),
-		Cache:           cache.NewCache(),
+		Roles:     make([]string, 0, 0),
+		RoleTable: make(map[string]bool),
+		Cache:     cache.NewCache(),
 	}
 }
 

--- a/pkg/core/connector/interface.go
+++ b/pkg/core/connector/interface.go
@@ -28,10 +28,12 @@ type ModuleRuntime interface {
 	GenerateWorkDir() error
 	GetHostWorkDir() string
 	GetWorkDir() string
+	GetIgnoreErr() bool
 	GetAllHosts() []Host
 	SetAllHosts([]Host)
 	GetHostsByRole(role string) []Host
 	DeleteHost(host Host)
+	HostIsDeprecated(host Host) bool
 	InitLogger() error
 }
 

--- a/pkg/core/task/remote_task.go
+++ b/pkg/core/task/remote_task.go
@@ -59,6 +59,9 @@ func (t *RemoteTask) Execute() *ending.TaskResult {
 	wg := &sync.WaitGroup{}
 
 	for i := range t.Hosts {
+		if t.Runtime.HostIsDeprecated(t.Hosts[i]) {
+			continue
+		}
 		selfRuntime := t.Runtime.Copy()
 		selfHost := t.Hosts[i].Copy()
 

--- a/pkg/pipelines/add_nodes.go
+++ b/pkg/pipelines/add_nodes.go
@@ -51,6 +51,9 @@ func NewAddNodesPipeline(runtime *common.KubeRuntime) error {
 			if err := kubekeycontroller.PatchNodeImportStatus(runtime, kubekeycontroller.Failed); err != nil {
 				return err
 			}
+			if err := kubekeycontroller.UpdateStatus(runtime); err != nil {
+				return err
+			}
 		}
 		return err
 	}
@@ -92,6 +95,9 @@ func NewK3sAddNodesPipeline(runtime *common.KubeRuntime) error {
 	if err := p.Start(); err != nil {
 		if runtime.Arg.InCluster {
 			if err := kubekeycontroller.PatchNodeImportStatus(runtime, kubekeycontroller.Failed); err != nil {
+				return err
+			}
+			if err := kubekeycontroller.UpdateStatus(runtime); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
### What does this PR do?
* Add ignore-err option

### Why we need this PR?
Sometimes we need to ignore the error host and make the pipeline force run. This PR i add a ignore-err option, can do this. When some hosts report error, kk will remove the host from runtime hosts array. After that, all of tasks will not execute actions on that host. And finally, the pipeline will still report an error `there are some error in your spec hosts` to display this pipeline run result is not fully successful.