### PR TITLE
Inconsistent versions

### DIFF
--- a/docs/kubernetes-versions.md
+++ b/docs/kubernetes-versions.md
@@ -23,7 +23,7 @@
 | v1.20.4   | :white_check_mark: |
 | v1.20.6   | :white_check_mark: |
 | v1.20.10   | :white_check_mark: |
-| v1.21.4   | :white_check_mark: |
+| v1.21.5   | :white_check_mark: |
 | v1.22.1   | :white_check_mark: |
 
 ## Kubernetes Versions(arm64)


### PR DESCRIPTION
https://github.com/kubesphere/kubekey/blob/master/README_zh-CN.md ,(v1.21:   v1.21.5 (default))
https://kubesphere.com.cn/en/docs/quick-start/all-in-one-on-linux/#step-3-get-started-with-installation，KubeKey installs Kubernetes v1.21.5 by default.