### PR TITLE
[release-1.2]: fix a bug that private registry can't be set when os env KKZONE is cn

### DIFF
--- a/pkg/kubesphere/manifests.go
+++ b/pkg/kubesphere/manifests.go
@@ -1070,7 +1070,11 @@ spec:
 func GenerateKubeSphereYaml(repo, version string) (string, error) {
 	_, ok := mirrorVersionList[version]
 	if ok && os.Getenv("KKZONE") == "cn" {
-		repo = "registry.cn-beijing.aliyuncs.com/kubesphereio"
+		if repo == "" {
+			repo = "registry.cn-beijing.aliyuncs.com/kubesphereio"
+		} else {
+			repo = fmt.Sprintf("%s/kubesphere", repo)
+		}
 	} else {
 		if repo == "" {
 			if strings.Contains(version, "latest") ||


### PR DESCRIPTION
### What does this PR do?
Fix a bug that private registry can't be set when os env `KKZONE` is `cn`