### PR TITLE
modify all-in-one cluster name

### DIFF
--- a/pkg/common/loader.go
+++ b/pkg/common/loader.go
@@ -127,7 +127,8 @@ func (d *DefaultLoader) Load() (*kubekeyapiv1alpha2.Cluster, error) {
 		}
 	}
 
-	allInOne.Name = AllInOne + time.Now().Format("2006-01-02")
+	// must be a lower case
+	allInOne.Name = "kubekey" + time.Now().Format("2006-01-02")
 
 	return &allInOne, nil
 }


### PR DESCRIPTION
### What does this PR do?
Modify the all-in-one cluster name.

### Why do we need this PR?
The cluster name will be used to create a configmap, and configmap's name needs to consist of lower case alphanumeric characters.