### PR TITLE
fix cp file text busy error

### DIFF
--- a/pkg/core/common/common.go
+++ b/pkg/core/common/common.go
@@ -33,4 +33,5 @@ const (
 
 	// command
 	CopyCmd = "cp -r %s %s"
+	MoveCmd = "mv -f %s %s"
 )

--- a/pkg/core/connector/runner.go
+++ b/pkg/core/connector/runner.go
@@ -133,7 +133,7 @@ func (r *Runner) SudoScp(local, remote string) error {
 		return err
 	}
 
-	if _, err := r.SudoCmd(fmt.Sprintf(common.CopyCmd, remoteTmp, remote), false); err != nil {
+	if _, err := r.SudoCmd(fmt.Sprintf(common.MoveCmd, remoteTmp, remote), false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?
Fix cp command report text busy error.

### Why do we need this PR?
If using a cp command to copy a file to a target path that the file existed, the Linux may report a `text file busy` error. That caused by the file is been used. I modify the `mv` command to replace the `cp` command, which will not change the old file and the old file still be used by the process. Linux will change the process to use the new file and delete the old file when the process restarts.