### PR TITLE
fix the default flag value makes kk can't create k3s cluster

### DIFF
--- a/cmd/ctl/create/cluster.go
+++ b/cmd/ctl/create/cluster.go
@@ -18,7 +18,6 @@ package create
 
 import (
 	"fmt"
-	"github.com/kubesphere/kubekey/apis/kubekey/v1alpha2"
 	"github.com/kubesphere/kubekey/cmd/ctl/options"
 	"github.com/kubesphere/kubekey/cmd/ctl/util"
 	"github.com/kubesphere/kubekey/pkg/common"
@@ -99,7 +98,7 @@ func (o *CreateClusterOptions) Run() error {
 
 func (o *CreateClusterOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
-	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", v1alpha2.DefaultKubeVersion, "Specify a supported version of kubernetes")
+	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", "", "Specify a supported version of kubernetes")
 	cmd.Flags().BoolVarP(&o.LocalStorage, "with-local-storage", "", false, "Deploy a local PV provisioner")
 	cmd.Flags().BoolVarP(&o.EnableKubeSphere, "with-kubesphere", "", false, "Deploy a specific version of kubesphere (default v3.2.0)")
 	cmd.Flags().BoolVarP(&o.SkipPullImages, "skip-pull-images", "", false, "Skip pre pull images")


### PR DESCRIPTION
### What does this PR do?
If the flag `--with-kubernetes` has a default value, the loader will think that the user set the `--with-kubernetes`, and the loader will override the `runtime.cluster.kubernetes.version` by the default k8s version.