### PR TITLE
fix(plugins): cilium should deloyed with new k8s(1.16+)

### DIFF
--- a/pkg/plugins/network/modules.go
+++ b/pkg/plugins/network/modules.go
@@ -176,7 +176,7 @@ func deployCilium(d *DeployNetworkPluginModule) []task.Interface {
 		Hosts: d.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			new(OldK8sVersion),
+			&OldK8sVersion{Not: true},
 		},
 		Action: &action.Template{
 			Template: templates.Cilium,


### PR DESCRIPTION
there is bug: cilium is skiped when use k8s 1.21.5;