### PR TITLE
should use masterGroup[0].Address as ControlPlaneEndpoint.Address in SetDefaultLBCfg

### DIFF
--- a/apis/kubekey/v1alpha1/default.go
+++ b/apis/kubekey/v1alpha1/default.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"fmt"
-	"github.com/kubesphere/kubekey/pkg/core/util"
 	"os"
 	"strings"
+
+	"github.com/kubesphere/kubekey/pkg/core/util"
 )
 
 const (
@@ -169,7 +170,7 @@ func SetDefaultLBCfg(cfg *ClusterSpec, masterGroup []HostCfg, incluster bool) Co
 	}
 
 	if cfg.ControlPlaneEndpoint.Address == "" || cfg.ControlPlaneEndpoint.Address == "127.0.0.1" {
-		cfg.ControlPlaneEndpoint.Address = masterGroup[0].InternalAddress
+		cfg.ControlPlaneEndpoint.Address = masterGroup[0].Address
 	}
 	if cfg.ControlPlaneEndpoint.Domain == "" {
 		cfg.ControlPlaneEndpoint.Domain = DefaultLBDomain

--- a/apis/kubekey/v1alpha2/default.go
+++ b/apis/kubekey/v1alpha2/default.go
@@ -18,9 +18,10 @@ package v1alpha2
 
 import (
 	"fmt"
-	"github.com/kubesphere/kubekey/pkg/core/util"
 	"os"
 	"strings"
+
+	"github.com/kubesphere/kubekey/pkg/core/util"
 )
 
 const (
@@ -171,7 +172,7 @@ func SetDefaultLBCfg(cfg *ClusterSpec, masterGroup []HostCfg, incluster bool) Co
 	}
 
 	if cfg.ControlPlaneEndpoint.Address == "" || cfg.ControlPlaneEndpoint.Address == "127.0.0.1" {
-		cfg.ControlPlaneEndpoint.Address = masterGroup[0].InternalAddress
+		cfg.ControlPlaneEndpoint.Address = masterGroup[0].Address
 	}
 	if cfg.ControlPlaneEndpoint.Domain == "" {
 		cfg.ControlPlaneEndpoint.Domain = DefaultLBDomain


### PR DESCRIPTION
 when the kk runing node can't not contect the inner ip of  k8s  master node ， there shoud use lb address  instead of InternalAddress。
tested  with tencent cloud cvm ok。