### PR TITLE
fix error file mode on $HOME/.kube

### DIFF
--- a/pkg/filesystem/module.go
+++ b/pkg/filesystem/module.go
@@ -1,0 +1,43 @@
+/*
+ Copyright 2021 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package filesystem
+
+import (
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/task"
+)
+
+type ChownModule struct {
+	common.KubeModule
+}
+
+func (c *ChownModule) Init() {
+	c.Name = "ChownModule"
+	c.Desc = "Change file and dir mode and owner"
+
+	userKubeDir := &task.RemoteTask{
+		Name:     "ChownUserKubeDir",
+		Desc:     "Chown user $HOME/.kube dir",
+		Hosts:    c.Runtime.GetHostsByRole(common.K8s),
+		Action:   new(ChownUserKubeDir),
+		Parallel: true,
+	}
+
+	c.Tasks = []task.Interface{
+		userKubeDir,
+	}
+}

--- a/pkg/filesystem/task.go
+++ b/pkg/filesystem/task.go
@@ -1,0 +1,53 @@
+/*
+ Copyright 2021 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package filesystem
+
+import (
+	"fmt"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/connector"
+	"github.com/pkg/errors"
+)
+
+type ChownUserKubeDir struct {
+	common.KubeAction
+}
+
+func (c *ChownUserKubeDir) Execute(runtime connector.Runtime) error {
+	exist, err := runtime.GetRunner().FileExist("$HOME/.kube")
+	if err != nil {
+		return errors.Wrap(errors.WithStack(err), "get user $HOME/.kube failed")
+	}
+
+	if exist {
+		userId, err := runtime.GetRunner().Cmd("echo $(id -u)", false)
+		if err != nil {
+			return errors.Wrap(errors.WithStack(err), "get user id failed")
+		}
+
+		userGroupId, err := runtime.GetRunner().Cmd("echo $(id -g)", false)
+		if err != nil {
+			return errors.Wrap(errors.WithStack(err), "get user group id failed")
+		}
+
+		chownKubeConfig := fmt.Sprintf("chown -R %s:%s $HOME/.kube", userId, userGroupId)
+		if _, err := runtime.GetRunner().SudoCmd(chownKubeConfig, false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "chown user kube config failed")
+		}
+	}
+	return nil
+}

--- a/pkg/pipelines/add_nodes.go
+++ b/pkg/pipelines/add_nodes.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubesphere/kubekey/pkg/core/module"
 	"github.com/kubesphere/kubekey/pkg/core/pipeline"
 	"github.com/kubesphere/kubekey/pkg/etcd"
+	"github.com/kubesphere/kubekey/pkg/filesystem"
 	"github.com/kubesphere/kubekey/pkg/hooks"
 	"github.com/kubesphere/kubekey/pkg/images"
 	"github.com/kubesphere/kubekey/pkg/k3s"
@@ -53,6 +54,7 @@ func NewAddNodesPipeline(runtime *common.KubeRuntime) error {
 		&kubernetes.InstallKubeBinariesModule{},
 		&kubernetes.JoinNodesModule{},
 		&loadbalancer.HaproxyModule{Skip: !runtime.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
+		&filesystem.ChownModule{},
 		&certs.AutoRenewCertsModule{},
 	}
 
@@ -99,6 +101,7 @@ func NewK3sAddNodesPipeline(runtime *common.KubeRuntime) error {
 		&k3s.InstallKubeBinariesModule{},
 		&k3s.JoinNodesModule{},
 		&loadbalancer.K3sHaproxyModule{Skip: !runtime.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
+		&filesystem.ChownModule{},
 		&certs.AutoRenewCertsModule{},
 	}
 

--- a/pkg/pipelines/create_cluster.go
+++ b/pkg/pipelines/create_cluster.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubesphere/kubekey/pkg/core/module"
 	"github.com/kubesphere/kubekey/pkg/core/pipeline"
 	"github.com/kubesphere/kubekey/pkg/etcd"
+	"github.com/kubesphere/kubekey/pkg/filesystem"
 	"github.com/kubesphere/kubekey/pkg/hooks"
 	"github.com/kubesphere/kubekey/pkg/images"
 	"github.com/kubesphere/kubekey/pkg/k3s"
@@ -67,6 +68,7 @@ func NewCreateClusterPipeline(runtime *common.KubeRuntime) error {
 		&kubernetes.JoinNodesModule{},
 		&loadbalancer.HaproxyModule{Skip: !runtime.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
 		&network.DeployNetworkPluginModule{},
+		&filesystem.ChownModule{},
 		&certs.AutoRenewCertsModule{},
 		&kubernetes.SaveKubeConfigModule{},
 		&addons.AddonsModule{Skip: noNetworkPlugin},
@@ -134,6 +136,7 @@ func NewK3sCreateClusterPipeline(runtime *common.KubeRuntime) error {
 		&k3s.JoinNodesModule{},
 		&loadbalancer.K3sHaproxyModule{Skip: !runtime.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
 		&network.DeployNetworkPluginModule{},
+		&filesystem.ChownModule{},
 		&k3s.SaveKubeConfigModule{},
 		&addons.AddonsModule{Skip: noNetworkPlugin},
 		&storage.DeployLocalVolumeModule{Skip: noNetworkPlugin || (!runtime.Arg.DeployLocalStorage && !runtime.Cluster.KubeSphere.Enabled)},

--- a/pkg/pipelines/upgrade_cluster.go
+++ b/pkg/pipelines/upgrade_cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubesphere/kubekey/pkg/common"
 	"github.com/kubesphere/kubekey/pkg/core/module"
 	"github.com/kubesphere/kubekey/pkg/core/pipeline"
+	"github.com/kubesphere/kubekey/pkg/filesystem"
 	"github.com/kubesphere/kubekey/pkg/kubernetes"
 	"github.com/kubesphere/kubekey/pkg/kubesphere"
 	"github.com/kubesphere/kubekey/pkg/loadbalancer"
@@ -44,6 +45,7 @@ func NewUpgradeClusterPipeline(runtime *common.KubeRuntime) error {
 		&kubesphere.CheckResultModule{},
 		&kubernetes.SetUpgradePlanModule{Step: kubernetes.ToV122},
 		&kubernetes.ProgressiveUpgradeModule{Step: kubernetes.ToV122},
+		&filesystem.ChownModule{},
 		&certs.AutoRenewCertsModule{},
 	}
 


### PR DESCRIPTION
### What does this PR do?
Add a `ChownModule` to make sure the owner of `$HOME/.kube` is the user that is defined on `.spec.hosts`. Besides, I modify the code related to managing `$HOME/.kube`.

### Why do we need this PR?
Before, the owner of `$HOME/.kube` is `root`, it will make a normal user get a response too long and get a throttling warning when the user uses the `kubectl` tools.