### PR TITLE
modify the github workflow and build using go 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       GO111MODULE: on
     steps:
 
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
 
       - name: Check out code into the Go module directory
@@ -42,8 +42,11 @@ jobs:
             exit 1
           fi
 
-      - name: Build
-        run: go build -v -o output/kk ./main.go
+      - name: Build operator manager
+        run: go build -v -o output/manager ./main.go
+
+      - name: Build command-line tool
+        run: go build -v -o output/kk ./cmd/main.go
 
       - uses: actions/upload-artifact@v2
         if: github.event_name == 'push'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,10 @@ jobs:
           fetch-depth: 1
       - name: Unshallow
         run: git fetch --prune --unshallow
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.8.0
         with:


### PR DESCRIPTION
### What does this PR do?
Modify the GitHub workflow and build using go 1.17

### Why do we need this PR?
When I upgrade the `k8s.io` package dependencies, I can build kk on my desktop (go version 1.17), but it can't build on GitHub CI action (go version 1.16).