### PR TITLE
fix install container runtime failed

### DIFF
--- a/pkg/container/module.go
+++ b/pkg/container/module.go
@@ -152,6 +152,7 @@ func InstallDocker(m *InstallContainerModule) []task.Interface {
 		Prepare: &prepare.PrepareCollection{
 			&kubernetes.NodeInCluster{Not: true},
 			&DockerExist{},
+			&PrivateRegistryAuth{},
 		},
 		Action:   new(DockerLoginRegistry),
 		Parallel: true,

--- a/pkg/container/prepares.go
+++ b/pkg/container/prepares.go
@@ -79,3 +79,14 @@ func (c *ContainerdExist) PreCheck(runtime connector.Runtime) (bool, error) {
 	}
 	return !c.Not, nil
 }
+
+type PrivateRegistryAuth struct {
+	common.KubePrepare
+}
+
+func (p *PrivateRegistryAuth) PreCheck(runtime connector.Runtime) (bool, error) {
+	if len(p.KubeConf.Cluster.Registry.Auths.Raw) == 0 {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
### What does this PR do?
Fix install container runtime failed.

### Why do we need this PR?
If the field `.spec.registry.auths` is an empty string, this module will still run, and report a `no such file` error. So we need a `prepare` to make sure to skip.