### PR TITLE
modify manifest's containerRuntime to a list

### DIFF
--- a/apis/kubekey/v1alpha2/manifest_types.go
+++ b/apis/kubekey/v1alpha2/manifest_types.go
@@ -72,11 +72,11 @@ type ContainerRuntime struct {
 }
 
 type Components struct {
-	Helm             Helm             `yaml:"helm" json:"helm"`
-	CNI              CNI              `yaml:"cni" json:"cni"`
-	ETCD             ETCD             `yaml:"etcd" json:"etcd"`
-	ContainerRuntime ContainerRuntime `yaml:"containerRuntime" json:"containerRuntime"`
-	Crictl           Crictl           `yaml:"crictl" json:"crictl,omitempty"`
+	Helm              Helm               `yaml:"helm" json:"helm"`
+	CNI               CNI                `yaml:"cni" json:"cni"`
+	ETCD              ETCD               `yaml:"etcd" json:"etcd"`
+	ContainerRuntimes []ContainerRuntime `yaml:"containerRuntimes" json:"containerRuntimes"`
+	Crictl            Crictl             `yaml:"crictl" json:"crictl,omitempty"`
 }
 
 // ManifestSpec defines the desired state of Manifest

--- a/apis/kubekey/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/kubekey/v1alpha2/zz_generated.deepcopy.go
@@ -222,7 +222,11 @@ func (in *Components) DeepCopyInto(out *Components) {
 	out.Helm = in.Helm
 	out.CNI = in.CNI
 	out.ETCD = in.ETCD
-	out.ContainerRuntime = in.ContainerRuntime
+	if in.ContainerRuntimes != nil {
+		in, out := &in.ContainerRuntimes, &out.ContainerRuntimes
+		*out = make([]ContainerRuntime, len(*in))
+		copy(*out, *in)
+	}
 	out.Crictl = in.Crictl
 }
 
@@ -701,7 +705,7 @@ func (in *ManifestSpec) DeepCopyInto(out *ManifestSpec) {
 		copy(*out, *in)
 	}
 	out.KubernetesDistribution = in.KubernetesDistribution
-	out.Components = in.Components
+	in.Components.DeepCopyInto(&out.Components)
 	if in.Images != nil {
 		in, out := &in.Images, &out.Images
 		*out = make([]string, len(*in))

--- a/config/crd/bases/kubekey.kubesphere.io_manifests.yaml
+++ b/config/crd/bases/kubekey.kubesphere.io_manifests.yaml
@@ -49,16 +49,18 @@ spec:
                     required:
                     - version
                     type: object
-                  containerRuntime:
-                    properties:
-                      type:
-                        type: string
-                      version:
-                        type: string
-                    required:
-                    - type
-                    - version
-                    type: object
+                  containerRuntimes:
+                    items:
+                      properties:
+                        type:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - type
+                      - version
+                      type: object
+                    type: array
                   crictl:
                     properties:
                       version:
@@ -82,7 +84,7 @@ spec:
                     type: object
                 required:
                 - cni
-                - containerRuntime
+                - containerRuntimes
                 - etcd
                 - helm
                 type: object

--- a/pkg/artifact/templates/manifest.go
+++ b/pkg/artifact/templates/manifest.go
@@ -27,7 +27,7 @@ import (
 var Manifest = template.Must(template.New("Spec").Parse(
 	dedent.Dedent(`
 apiVersion: kubekey.kubesphere.io/v1alpha2
-kind: Spec
+kind: Manifest
 metadata:
   name: {{ .Options.Name }}
 spec:
@@ -57,9 +57,13 @@ spec:
       version: {{ .Options.Components.CNI.Version }}
     etcd: 
       version: {{ .Options.Components.ETCD.Version }}
-    containerRuntime: 
-      type: {{ .Options.Components.ContainerRuntime.Type }}
-      version: {{ .Options.Components.ContainerRuntime.Version }}
+    # For now, if your cluster container runtime is containerd, KubeKey will add a docker 20.10.8 container runtime in the below list.
+    # The reason is KubeKey creates a cluster with containerd by installing a docker first and making kubelet connect the socket file of containerd which docker contained.
+    containerRuntimes:
+      {{- range $i, $v := .Options.Components.ContainerRuntimes }}
+      - type: {{ $v.Type }}
+        version: {{ $v.Version }}
+      {{- end}}
     crictl: 
       version: {{ .Options.Components.Crictl.Version }}
   images:

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -18,6 +18,7 @@ package files
 
 import (
 	"fmt"
+	"github.com/kubesphere/kubekey/pkg/core/logger"
 	"github.com/kubesphere/kubekey/pkg/core/util"
 )
 
@@ -44,7 +45,7 @@ type KubeBinary struct {
 	GetCmd  string
 }
 
-func NewKubeBinary(name, arch, version, prePath, zone string, getCmd func(path, url string) string) (KubeBinary, error) {
+func NewKubeBinary(name, arch, version, prePath, zone string, getCmd func(path, url string) string) KubeBinary {
 	var component KubeBinary
 	component.Arch = arch
 	component.Version = version
@@ -132,9 +133,9 @@ func NewKubeBinary(name, arch, version, prePath, zone string, getCmd func(path, 
 			component.Url = fmt.Sprintf("https://kubernetes-release.pek3b.qingstor.com/k3s/releases/download/%s+k3s1/linux/%s/k3s", version, arch)
 		}
 	default:
-		return component, fmt.Errorf("unsupported kube binaries %s", name)
+		logger.Log.Fatalf("unsupported kube binaries %s", name)
 	}
-	return component, nil
+	return component
 }
 
 var (


### PR DESCRIPTION
### What does this PR do?
Modify manifest's `containerRuntime` to a list. And it will make kk can detect and show multi-container runtimes from the cluster.