### PR TITLE
fix: generate kubesphere repo error

### DIFF
--- a/cmd/ctl/create/cluster.go
+++ b/cmd/ctl/create/cluster.go
@@ -121,7 +121,7 @@ func (o *CreateClusterOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
 	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", "", "Specify a supported version of kubernetes")
 	cmd.Flags().BoolVarP(&o.LocalStorage, "with-local-storage", "", false, "Deploy a local PV provisioner")
-	cmd.Flags().BoolVarP(&o.EnableKubeSphere, "with-kubesphere", "", false, "Deploy a specific version of kubesphere (default v3.2.0)")
+	cmd.Flags().BoolVarP(&o.EnableKubeSphere, "with-kubesphere", "", false, fmt.Sprintf("Deploy a specific version of kubesphere (default %s)", kubesphere.Latest().Version))
 	cmd.Flags().BoolVarP(&o.SkipPullImages, "skip-pull-images", "", false, "Skip pre pull images")
 	cmd.Flags().BoolVarP(&o.SkipPushImages, "skip-push-images", "", false, "Skip pre push images")
 	cmd.Flags().StringVarP(&o.ContainerManager, "container-manager", "", "docker", "Container runtime: docker, crio, containerd and isula.")

--- a/pkg/kubesphere/kubesphere_test.go
+++ b/pkg/kubesphere/kubesphere_test.go
@@ -1,0 +1,98 @@
+/*
+ Copyright 2021 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package kubesphere
+
+import (
+	"github.com/kubesphere/kubekey/pkg/version/kubesphere"
+	"reflect"
+	"testing"
+)
+
+func Test_mirrorRepo(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "test_latest",
+			version: "latest",
+			want:    "kubespheredev",
+		},
+		{
+			name:    "test_master",
+			version: "master",
+			want:    "kubespheredev",
+		},
+		{
+			name:    "test_v3.2.1-rc.1",
+			version: "v3.2.1-rc.1",
+			want:    "kubespheredev",
+		},
+		{
+			name:    "test_v3.2.1",
+			version: "v3.2.1",
+			want:    "kubesphere",
+		},
+		{
+			name:    "test_v3.2.0",
+			version: "v3.2.0",
+			want:    "kubesphere",
+		},
+		{
+			name:    "test_3.2.0",
+			version: "3.2.0",
+			want:    "kubespheredev",
+		},
+		{
+			name:    "test_v3.2.0-alpha.1",
+			version: "v3.2.0-alpha.1",
+			want:    "kubespheredev",
+		},
+		{
+			name:    "test_v1.2.0",
+			version: "v1.2.0",
+			want:    "kubesphere",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := repo(tt.version)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StabledVersionSupport() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func repo(version string) string {
+	var r string
+	_, latest := kubesphere.LatestRelease(version)
+	_, dev := kubesphere.DevRelease(version)
+	_, stable := kubesphere.StabledVersionSupport(version)
+	switch {
+	case stable:
+		r = "kubesphere"
+	case dev:
+		r = "kubespheredev"
+	case latest:
+		r = "kubespheredev"
+	default:
+		r = "kubesphere"
+	}
+	return r
+}

--- a/pkg/kubesphere/modules.go
+++ b/pkg/kubesphere/modules.go
@@ -133,9 +133,15 @@ func MirrorRepo(kubeConf *common.KubeConf) string {
 		if repo == "" {
 			_, latest := kubesphere.LatestRelease(version)
 			_, dev := kubesphere.DevRelease(version)
-			if latest || dev {
+			_, stable := kubesphere.StabledVersionSupport(version)
+			switch {
+			case stable:
+				repo = "kubesphere"
+			case dev:
 				repo = "kubespheredev"
-			} else {
+			case latest:
+				repo = "kubespheredev"
+			default:
 				repo = "kubesphere"
 			}
 		} else {

--- a/pkg/version/kubesphere/version_enum_test.go
+++ b/pkg/version/kubesphere/version_enum_test.go
@@ -29,6 +29,18 @@ func TestDevRelease(t *testing.T) {
 		ok      bool
 	}{
 		{
+			name:    "test_v3.2.1-rc.1",
+			version: "v3.2.1-rc.1",
+			want:    KsV321,
+			ok:      true,
+		},
+		{
+			name:    "test_v3.2.1",
+			version: "v3.2.1",
+			want:    nil,
+			ok:      false,
+		},
+		{
 			name:    "test_v3.2.0",
 			version: "v3.2.0",
 			want:    nil,
@@ -55,6 +67,24 @@ func TestDevRelease(t *testing.T) {
 		{
 			name:    "test_latest",
 			version: "latest",
+			want:    KsV321,
+			ok:      true,
+		},
+		{
+			name:    "test_master",
+			version: "master",
+			want:    KsV321,
+			ok:      true,
+		},
+		{
+			name:    "test_release-3.2",
+			version: "release-3.2",
+			want:    KsV321,
+			ok:      true,
+		},
+		{
+			name:    "test_v1.2.0",
+			version: "v1.2.0",
 			want:    nil,
 			ok:      false,
 		},
@@ -79,7 +109,7 @@ func TestLatest(t *testing.T) {
 	}{
 		{
 			name: "test_latest",
-			want: KsV320,
+			want: KsV321,
 		},
 	}
 	for _, tt := range tests {
@@ -101,26 +131,38 @@ func TestLatestRelease(t *testing.T) {
 		{
 			name:    "test_latest",
 			version: "latest",
-			want:    KsV320,
+			want:    KsV321,
 			ok:      true,
 		},
 		{
 			name:    "test_master",
 			version: "master",
-			want:    KsV320,
+			want:    KsV321,
 			ok:      true,
 		},
 		{
 			name:    "test_release-3.2",
 			version: "release-3.2",
-			want:    KsV320,
+			want:    KsV321,
+			ok:      true,
+		},
+		{
+			name:    "test_v3.2.1",
+			version: "v3.2.1",
+			want:    KsV321,
+			ok:      true,
+		},
+		{
+			name:    "test_v3.2.1-rc.1",
+			version: "v3.2.1-rc.1",
+			want:    KsV321,
 			ok:      true,
 		},
 		{
 			name:    "test_v3.2.0",
 			version: "v3.2.0",
-			want:    KsV320,
-			ok:      true,
+			want:    nil,
+			ok:      false,
 		},
 		{
 			name:    "test_v3.1.0",
@@ -156,6 +198,12 @@ func TestStabledVersionSupport(t *testing.T) {
 		ok      bool
 	}{
 		{
+			name:    "test_v3.2.1-rc.1",
+			version: "v3.2.1-rc.1",
+			want:    nil,
+			ok:      false,
+		},
+		{
 			name:    "test_v3.2.0",
 			version: "v3.2.0",
 			want:    KsV320,
@@ -164,8 +212,8 @@ func TestStabledVersionSupport(t *testing.T) {
 		{
 			name:    "test_3.2.0",
 			version: "3.2.0",
-			want:    KsV320,
-			ok:      true,
+			want:    nil,
+			ok:      false,
 		},
 		{
 			name:    "test_v3.2.0-alpha.1",


### PR DESCRIPTION
What does this PR do?
Fix: generate kubesphere repo error. Before, if the flag `--with-kubesphere v3.2.1`, kk will generate a yaml file with `image: kubespheredev/kubesphere:v3.2.1`