### PR TITLE
fix: upgrade cluster apply a wrong and default cc

### DIFF
--- a/pkg/kubesphere/modules.go
+++ b/pkg/kubesphere/modules.go
@@ -181,6 +181,26 @@ func (c *CheckResultModule) Init() {
 	}
 }
 
+type CleanClusterConfigurationModule struct {
+	common.KubeModule
+}
+
+func (c *CleanClusterConfigurationModule) Init() {
+	c.Name = "CleanClusterConfigurationModule"
+	c.Desc = "Clean redundant ClusterConfiguration config"
+
+	// ensure there is no cc config, and prevent to reset cc config when upgrade the cluster
+	clean := &task.LocalTask{
+		Name:   "CleanClusterConfiguration",
+		Desc:   "Clean redundant ClusterConfiguration config",
+		Action: new(CleanCC),
+	}
+
+	c.Tasks = []task.Interface{
+		clean,
+	}
+}
+
 type ConvertModule struct {
 	common.KubeModule
 }

--- a/pkg/kubesphere/tasks.go
+++ b/pkg/kubesphere/tasks.go
@@ -239,6 +239,15 @@ func CheckKubeSphereStatus(ctx context.Context, runtime connector.Runtime, stopC
 	}
 }
 
+type CleanCC struct {
+	common.KubeAction
+}
+
+func (c *CleanCC) Execute(runtime connector.Runtime) error {
+	c.KubeConf.Cluster.KubeSphere.Configurations = "\n"
+	return nil
+}
+
 type ConvertV2ToV3 struct {
 	common.KubeAction
 }
@@ -261,7 +270,7 @@ func (c *ConvertV2ToV3) Execute(runtime connector.Runtime) error {
 	if err != nil {
 		return err
 	}
-	c.KubeConf.Cluster.KubeSphere.Configurations = configV3
+	c.KubeConf.Cluster.KubeSphere.Configurations = "---\n" + configV3
 	return nil
 }
 

--- a/pkg/pipelines/upgrade_cluster.go
+++ b/pkg/pipelines/upgrade_cluster.go
@@ -40,6 +40,7 @@ func NewUpgradeClusterPipeline(runtime *common.KubeRuntime) error {
 		&kubernetes.SetUpgradePlanModule{Step: kubernetes.ToV121},
 		&kubernetes.ProgressiveUpgradeModule{Step: kubernetes.ToV121},
 		&loadbalancer.HaproxyModule{Skip: !runtime.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
+		&kubesphere.CleanClusterConfigurationModule{},
 		&kubesphere.ConvertModule{},
 		&kubesphere.DeployModule{},
 		&kubesphere.CheckResultModule{},


### PR DESCRIPTION
### What does this PR do?
Fix: upgrade cluster apply a wrong and default cc. Ensure there is no cc config, and prevent resetting cc config when upgrading the cluster.
