### PR TITLE
fix: no matches for kind "ClusterConfiguration" in version "installer…

### DIFF
--- a/pkg/kubesphere/modules.go
+++ b/pkg/kubesphere/modules.go
@@ -111,6 +111,8 @@ func (d *DeployModule) Init() {
 
 	d.Tasks = []task.Interface{
 		generateManifests,
+		// apply crd installer.kubesphere.io/v1alpha1
+		apply,
 		addConfig,
 		createNamespace,
 		setup,


### PR DESCRIPTION

To fix:
```
error: unable to recognize "/etc/kubernetes/addons/kubesphere.yaml": no matches for kind "ClusterConfiguration" in version "installer.kubesphere.io/v1alpha1"
10:34:57 CST message: [node1]
deploy /etc/kubernetes/addons/kubesphere.yaml failed: Failed to exec command: sudo -E /bin/bash -c "/usr/local/bin/kubectl apply -f /etc/kubernetes/addons/kubesphere.yaml --force" 
namespace/kubesphere-system unchanged
```
As crd may be not valid after  the yaml apply, it is better `kubectl apply ` first to make crd synced.