### PR TITLE
fix: kk will use the wrong binary's path in the multi-arch environment

### DIFF
--- a/pkg/binaries/k3s.go
+++ b/pkg/binaries/k3s.go
@@ -72,7 +72,7 @@ func K3sFilesDownloadHTTP(kubeConf *common.KubeConf, filepath, version, arch str
 	for _, binary := range binaries {
 		logger.Log.Messagef(common.LocalHost, "downloading %s ...", binary.Name)
 
-		binariesMap[binary.Name] = binary
+		binariesMap[fmt.Sprintf("%s-%s", binary.Name, arch)] = binary
 		if util.IsExist(binary.Path) {
 			// download it again if it's incorrect
 			if err := K3sSHA256Check(binary, version); err != nil {

--- a/pkg/binaries/kubernetes.go
+++ b/pkg/binaries/kubernetes.go
@@ -90,7 +90,7 @@ func K8sFilesDownloadHTTP(kubeConf *common.KubeConf, filepath, version, arch str
 	for _, binary := range binaries {
 		logger.Log.Messagef(common.LocalHost, "downloading %s ...", binary.Name)
 
-		binariesMap[binary.Name] = binary
+		binariesMap[fmt.Sprintf("%s-%s", binary.Name, arch)] = binary
 		if util.IsExist(binary.Path) {
 			// download it again if it's incorrect
 			if err := SHA256Check(binary); err != nil {

--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -42,7 +42,7 @@ func (s *SyncCrictlBinaries) Execute(runtime connector.Runtime) error {
 	}
 	binariesMap := binariesMapObj.(map[string]files.KubeBinary)
 
-	crictl, ok := binariesMap[common.Crictl]
+	crictl, ok := binariesMap[common.Crictl+"-"+runtime.RemoteHost().GetArch()]
 	if !ok {
 		return errors.New("get KubeBinary key crictl by pipeline cache failed")
 	}

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -44,7 +44,7 @@ func (s *SyncDockerBinaries) Execute(runtime connector.Runtime) error {
 	}
 	binariesMap := binariesMapObj.(map[string]files.KubeBinary)
 
-	docker, ok := binariesMap[common.Docker]
+	docker, ok := binariesMap[common.Docker+"-"+runtime.RemoteHost().GetArch()]
 	if !ok {
 		return errors.New("get KubeBinary key docker by pipeline cache failed")
 	}

--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -106,9 +106,10 @@ func SyncKubeBinaries(runtime connector.Runtime, binariesMap map[string]files.Ku
 		return err
 	}
 
+	host := runtime.RemoteHost()
 	binaryList := []string{"k3s", "helm", "kubecni"}
 	for _, name := range binaryList {
-		binary, ok := binariesMap[name]
+		binary, ok := binariesMap[fmt.Sprintf("%s-%s", name, host.GetArch())]
 		if !ok {
 			return fmt.Errorf("get kube binary %s info failed: no such key", name)
 		}

--- a/pkg/kubernetes/tasks.go
+++ b/pkg/kubernetes/tasks.go
@@ -119,9 +119,10 @@ func SyncKubeBinaries(runtime connector.Runtime, binariesMap map[string]files.Ku
 		return err
 	}
 
+	host := runtime.RemoteHost()
 	binaryList := []string{"kubeadm", "kubelet", "kubectl", "helm", "kubecni"}
 	for _, name := range binaryList {
-		binary, ok := binariesMap[name]
+		binary, ok := binariesMap[fmt.Sprintf("%s-%s", name, host.GetArch())]
 		if !ok {
 			return fmt.Errorf("get kube binary %s info failed: no such key", name)
 		}


### PR DESCRIPTION
### What does this PR do?
fix: kk will use the wrong binary's path in the multi-arch environment. Before, the map key is a binary's name, so that will be overridden when in the multi-arch environment.