### PR TITLE
fix: kk will use the wrong binary's path in the multi-arch environment

### DIFF
--- a/pkg/binaries/k3s.go
+++ b/pkg/binaries/k3s.go
@@ -70,7 +70,7 @@ func K3sFilesDownloadHTTP(kubeConf *common.KubeConf, filepath, version, arch str
 	binaries := []files.KubeBinary{k3s, helm, kubecni, etcd}
 	binariesMap := make(map[string]files.KubeBinary)
 	for _, binary := range binaries {
-		logger.Log.Messagef(common.LocalHost, "downloading %s ...", binary.Name)
+		logger.Log.Messagef(common.LocalHost, "downloading %s %s ...", arch, binary.Name)
 
 		binariesMap[binary.Name] = binary
 		if util.IsExist(binary.Path) {
@@ -122,7 +122,7 @@ func K3sFilesDownloadHTTP(kubeConf *common.KubeConf, filepath, version, arch str
 		}
 	}
 
-	pipelineCache.Set(common.KubeBinaries, binariesMap)
+	pipelineCache.Set(common.KubeBinaries+"-"+arch, binariesMap)
 	return nil
 }
 

--- a/pkg/binaries/kubernetes.go
+++ b/pkg/binaries/kubernetes.go
@@ -88,7 +88,7 @@ func K8sFilesDownloadHTTP(kubeConf *common.KubeConf, filepath, version, arch str
 	binaries := []files.KubeBinary{kubeadm, kubelet, kubectl, helm, kubecni, docker, crictl, etcd}
 	binariesMap := make(map[string]files.KubeBinary)
 	for _, binary := range binaries {
-		logger.Log.Messagef(common.LocalHost, "downloading %s ...", binary.Name)
+		logger.Log.Messagef(common.LocalHost, "downloading %s %s ...", arch, binary.Name)
 
 		binariesMap[binary.Name] = binary
 		if util.IsExist(binary.Path) {
@@ -151,7 +151,7 @@ func K8sFilesDownloadHTTP(kubeConf *common.KubeConf, filepath, version, arch str
 		}
 	}
 
-	pipelineCache.Set(common.KubeBinaries, binariesMap)
+	pipelineCache.Set(common.KubeBinaries+"-"+arch, binariesMap)
 	return nil
 }
 
@@ -185,7 +185,7 @@ func sha256sum(path string) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
 }
 
-func KubernetesArtifactBinariesDownload(manifest *common.ArtifactManifest, path, arch string, pipelineCache *cache.Cache) error {
+func KubernetesArtifactBinariesDownload(manifest *common.ArtifactManifest, path, arch string) error {
 	kkzone := os.Getenv("KKZONE")
 
 	m := manifest.Spec
@@ -220,11 +220,9 @@ func KubernetesArtifactBinariesDownload(manifest *common.ArtifactManifest, path,
 		binaries = append(binaries, crictl)
 	}
 
-	binariesMap := make(map[string]files.KubeBinary)
 	for _, binary := range binaries {
-		logger.Log.Messagef(common.LocalHost, "downloading %s ...", binary.Name)
+		logger.Log.Messagef(common.LocalHost, "downloading %s %s ...", arch, binary.Name)
 
-		binariesMap[binary.Name] = binary
 		if util.IsExist(binary.Path) {
 			// download it again if it's incorrect
 			if err := SHA256Check(binary); err != nil {
@@ -274,6 +272,5 @@ func KubernetesArtifactBinariesDownload(manifest *common.ArtifactManifest, path,
 		}
 	}
 
-	pipelineCache.Set(common.KubeBinaries, binariesMap)
 	return nil
 }

--- a/pkg/binaries/tasks.go
+++ b/pkg/binaries/tasks.go
@@ -129,7 +129,7 @@ func (a *ArtifactDownload) Execute(runtime connector.Runtime) error {
 			return errors.Wrap(err, "Failed to create download target dir")
 		}
 
-		if err := KubernetesArtifactBinariesDownload(a.Manifest, binariesDir, arch, a.PipelineCache); err != nil {
+		if err := KubernetesArtifactBinariesDownload(a.Manifest, binariesDir, arch); err != nil {
 			return err
 		}
 	}

--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -36,7 +36,7 @@ func (s *SyncCrictlBinaries) Execute(runtime connector.Runtime) error {
 		return err
 	}
 
-	binariesMapObj, ok := s.PipelineCache.Get(common.KubeBinaries)
+	binariesMapObj, ok := s.PipelineCache.Get(common.KubeBinaries + "-" + runtime.RemoteHost().GetArch())
 	if !ok {
 		return errors.New("get KubeBinary by pipeline cache failed")
 	}

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -38,7 +38,7 @@ func (s *SyncDockerBinaries) Execute(runtime connector.Runtime) error {
 		return err
 	}
 
-	binariesMapObj, ok := s.PipelineCache.Get(common.KubeBinaries)
+	binariesMapObj, ok := s.PipelineCache.Get(common.KubeBinaries + "-" + runtime.RemoteHost().GetArch())
 	if !ok {
 		return errors.New("get KubeBinary by pipeline cache failed")
 	}

--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -88,7 +88,7 @@ type SyncKubeBinary struct {
 }
 
 func (s *SyncKubeBinary) Execute(runtime connector.Runtime) error {
-	binariesMapObj, ok := s.PipelineCache.Get(common.KubeBinaries)
+	binariesMapObj, ok := s.PipelineCache.Get(common.KubeBinaries + "-" + runtime.RemoteHost().GetArch())
 	if !ok {
 		return errors.New("get KubeBinary by pipeline cache failed")
 	}

--- a/pkg/kubernetes/tasks.go
+++ b/pkg/kubernetes/tasks.go
@@ -101,7 +101,7 @@ type SyncKubeBinary struct {
 }
 
 func (i *SyncKubeBinary) Execute(runtime connector.Runtime) error {
-	binariesMapObj, ok := i.PipelineCache.Get(common.KubeBinaries)
+	binariesMapObj, ok := i.PipelineCache.Get(common.KubeBinaries + "-" + runtime.RemoteHost().GetArch())
 	if !ok {
 		return errors.New("get KubeBinary by pipeline cache failed")
 	}


### PR DESCRIPTION
### What does this PR do?
fix: kk will use the wrong binary's path in the multi-arch environment. Before, the map key is a binary's name, so that will be overridden when in the multi-arch environment.