### PR TITLE
artifact supports pulling images with skipping SSL certificate validation

### DIFF
--- a/pkg/artifact/containerd.go
+++ b/pkg/artifact/containerd.go
@@ -1,0 +1,45 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package artifact
+
+import (
+	"context"
+	"crypto/tls"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/remotes/docker/config"
+)
+
+// PushTracker returns a new InMemoryTracker which tracks the ref status
+var PushTracker = docker.NewInMemoryTracker()
+
+func GetResolver(ctx context.Context) remotes.Resolver {
+	options := docker.ResolverOptions{
+		Tracker: PushTracker,
+	}
+
+	hostOptions := config.HostOptions{}
+
+	defaultConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	hostOptions.DefaultTLS = defaultConfig
+
+	options.Hosts = config.ConfigureHosts(ctx, hostOptions)
+	return docker.NewResolver(options)
+}

--- a/pkg/artifact/tasks.go
+++ b/pkg/artifact/tasks.go
@@ -89,6 +89,7 @@ func (p *PullImages) Execute(_ connector.Runtime) error {
 		})
 
 		opts := []containerd.RemoteOpt{
+			containerd.WithResolver(GetResolver(ctx)),
 			containerd.WithImageHandler(h),
 			containerd.WithSchema1Conversion,
 		}


### PR DESCRIPTION
### What does this PR do?
Artifact supports pulling images with skipping SSL certificate validation.