### PR TITLE
Fix: wrong paths of registries' packages

### DIFF
--- a/pkg/binaries/tasks.go
+++ b/pkg/binaries/tasks.go
@@ -149,13 +149,24 @@ type RegistryPackageDownload struct {
 }
 
 func (k *RegistryPackageDownload) Execute(runtime connector.Runtime) error {
+	cfg := k.KubeConf.Cluster
+
+	var kubeVersion string
+	if cfg.Kubernetes.Version == "" {
+		kubeVersion = kubekeyapiv1alpha2.DefaultKubeVersion
+	} else {
+		kubeVersion = cfg.Kubernetes.Version
+	}
+
 	arch := runtime.GetHostsByRole(common.Registry)[0].GetArch()
 
-	packageDir := filepath.Join(runtime.GetWorkDir(), "registry", arch)
-	if err := util.CreateDir(packageDir); err != nil {
+	kubeBinariesDir := filepath.Join(runtime.GetWorkDir(), kubeVersion, arch)
+	registryPackageDir := filepath.Join(runtime.GetWorkDir(), "registry", arch)
+
+	if err := util.CreateDir(registryPackageDir); err != nil {
 		return errors.Wrap(err, "Failed to create download target dir")
 	}
-	if err := RegistryPackageDownloadHTTP(k.KubeConf, packageDir, arch, k.PipelineCache); err != nil {
+	if err := RegistryPackageDownloadHTTP(k.KubeConf, registryPackageDir, kubeBinariesDir, arch, k.PipelineCache); err != nil {
 		return err
 	}
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -26,13 +26,14 @@ const (
 	File     = "file"
 	Operator = "operator"
 
-	Master   = "master"
-	Worker   = "worker"
-	ETCD     = "etcd"
-	K8s      = "k8s"
-	Registry = "registry"
-	KubeKey  = "kubekey"
-	Harbor   = "harbor"
+	Master        = "master"
+	Worker        = "worker"
+	ETCD          = "etcd"
+	K8s           = "k8s"
+	Registry      = "registry"
+	KubeKey       = "kubekey"
+	Harbor        = "harbor"
+	DockerCompose = "compose"
 
 	KubeBinaries = "KubeBinaries"
 

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -400,6 +400,9 @@ var (
 			amd64: {
 				"2": "7706e46674fa2cf20f734dfb7e4dd7f1390710e9c0a2c520563e3c55f3e4b5c5",
 			},
+			arm64: {
+				"2": "a6e98123b850da5f6476c08b357e504de352a00f656279ec2636625d352abd5a",
+			},
 		},
 		compose: {
 			amd64: {

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -19,6 +19,7 @@ package images
 import (
 	"fmt"
 	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/container/templates"
 	"github.com/kubesphere/kubekey/pkg/core/connector"
 	"github.com/kubesphere/kubekey/pkg/core/logger"
 	"github.com/pkg/errors"
@@ -154,6 +155,8 @@ func CmdPush(fileName string, prePath string, kubeConf *common.KubeConf, arches 
 		Tag:       tag,
 	}
 
+	auths := templates.Auths(kubeConf)
+
 	fullPath := filepath.Join(prePath, fileName)
 	oldName := fmt.Sprintf("%s/%s/%s:%s", registry, namespace, imageName, tag)
 
@@ -166,6 +169,10 @@ func CmdPush(fileName string, prePath string, kubeConf *common.KubeConf, arches 
 		image.ImageName(), oldName, strings.Join(arches, " "))
 	if kubeConf.Cluster.Registry.PlainHTTP {
 		pushCmd = fmt.Sprintf("%s --plain-http", pushCmd)
+	}
+	if _, ok := auths[privateRegistry]; ok {
+		auth := auths[privateRegistry]
+		pushCmd = fmt.Sprintf("%s --user %s:%s", pushCmd, auth.Username, auth.Password)
 	}
 
 	if out, err := exec.Command("/bin/bash", "-c", pushCmd).CombinedOutput(); err != nil {


### PR DESCRIPTION
### What does this PR do?
1. Adjust the paths of registries‘ packages.
2. Push images to registry with auth is supported. 


Signed-off-by: pixiake <guofeng@yunify.com>