### PR TITLE
Add a rollback feature to support restoring something when a task failed

### DIFF
--- a/pkg/artifact/manifest.go
+++ b/pkg/artifact/manifest.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kubesphere/kubekey/pkg/core/util"
 	"github.com/pkg/errors"
 	"io/ioutil"
-	corev1 "k8s.io/api/core/v1"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"os"
 	"sort"
@@ -52,6 +51,7 @@ func CreateManifest(arg common.Argument, name string) error {
 
 	archSet := mapset.NewThreadUnsafeSet()
 	containerSet := mapset.NewThreadUnsafeSet()
+	imagesSet := mapset.NewThreadUnsafeSet()
 	osSet := mapset.NewThreadUnsafeSet()
 
 	maxKubeletVersion := versionutil.MustParseGeneric("v0.0.0")
@@ -65,6 +65,22 @@ func CreateManifest(arg common.Argument, name string) error {
 		containerSet.Add(containerRuntime)
 
 		archSet.Add(node.Status.NodeInfo.Architecture)
+		for _, image := range node.Status.Images {
+			for _, name := range image.Names {
+				if !strings.Contains(name, "@sha256") {
+					if containerRuntime.Type == kubekeyv1alpha2.Docker {
+						arr := strings.Split(name, "/")
+						switch len(arr) {
+						case 1:
+							name = fmt.Sprintf("docker.io/library/%s", name)
+						case 2:
+							name = fmt.Sprintf("docker.io/%s", name)
+						}
+					}
+					imagesSet.Add(name)
+				}
+			}
+		}
 
 		// todo: for now, the cases only have ubuntu, centos. Ant it need to check all linux distribution.
 		var (
@@ -105,37 +121,6 @@ func CreateManifest(arg common.Argument, name string) error {
 			kubernetesDistribution.Type = distribution
 		}
 
-	}
-
-	pods, err := client.CoreV1().Pods(corev1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-
-	imagesSet := mapset.NewThreadUnsafeSet()
-	for _, pod := range pods.Items {
-		for _, initContainer := range pod.Spec.InitContainers {
-			imageName := initContainer.Image
-			arr := strings.Split(imageName, "/")
-			switch len(arr) {
-			case 1:
-				imageName = fmt.Sprintf("docker.io/library/%s", imageName)
-			case 2:
-				imageName = fmt.Sprintf("docker.io/%s", imageName)
-			}
-			imagesSet.Add(imageName)
-		}
-		for _, container := range pod.Spec.Containers {
-			imageName := container.Image
-			arr := strings.Split(imageName, "/")
-			switch len(arr) {
-			case 1:
-				imageName = fmt.Sprintf("docker.io/library/%s", imageName)
-			case 2:
-				imageName = fmt.Sprintf("docker.io/%s", imageName)
-			}
-			imagesSet.Add(imageName)
-		}
 	}
 
 	archArr := make([]string, 0, archSet.Cardinality())

--- a/pkg/bootstrap/os/repository/repository_deb.go
+++ b/pkg/bootstrap/os/repository/repository_deb.go
@@ -34,11 +34,15 @@ func NewDeb(runtime connector.Runtime) Interface {
 }
 
 func (d *Debian) Backup() error {
-	if _, err := d.runtime.GetRunner().SudoCmd("mkdir -p /etc/apt/sources.list.d.kubekey.bak/", false); err != nil {
+	if _, err := d.runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list /etc/apt/sources.list.kubekey.bak", false); err != nil {
 		return err
 	}
 
-	if _, err := d.runtime.GetRunner().SudoCmd("cp -r /etc/apt/sources.list.d/* /etc/apt/sources.list.d.kubekey.bak/", false); err != nil {
+	if _, err := d.runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list.d /etc/apt/sources.list.d.kubekey.bak", false); err != nil {
+		return err
+	}
+
+	if _, err := d.runtime.GetRunner().SudoCmd("mkdir -p /etc/apt/sources.list.d", false); err != nil {
 		return err
 	}
 	d.backup = true
@@ -66,7 +70,7 @@ func (d *Debian) Add(path string) error {
 }
 
 func (d *Debian) Update() error {
-	if _, err := d.runtime.GetRunner().SudoCmd("apt-get update && apt-get upgrade -y", true); err != nil {
+	if _, err := d.runtime.GetRunner().Cmd("sudo apt-get update", true); err != nil {
 		return err
 	}
 	return nil
@@ -85,15 +89,15 @@ func (d *Debian) Install(pkg ...string) error {
 }
 
 func (d *Debian) Reset() error {
-	if _, err := d.runtime.GetRunner().SudoCmd("rm -f /etc/apt/sources.list.d/kubekey.list", false); err != nil {
+	if _, err := d.runtime.GetRunner().SudoCmd("rm -rf /etc/apt/sources.list.d", false); err != nil {
 		return err
 	}
 
-	if _, err := d.runtime.GetRunner().SudoCmd("cp -r /etc/apt/sources.list.d.kubekey.bak/* /etc/apt/sources.list.d/", false); err != nil {
+	if _, err := d.runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list.kubekey.bak /etc/apt/sources.list", false); err != nil {
 		return err
 	}
 
-	if _, err := d.runtime.GetRunner().SudoCmd("rm -rf /etc/apt/sources.list.d.kubekey.bak", false); err != nil {
+	if _, err := d.runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list.d.kubekey.bak /etc/apt/sources.list.d", false); err != nil {
 		return err
 	}
 

--- a/pkg/bootstrap/os/repository/repository_rpm.go
+++ b/pkg/bootstrap/os/repository/repository_rpm.go
@@ -34,11 +34,11 @@ func NewRPM(runtime connector.Runtime) Interface {
 }
 
 func (r *RedhatPackageManager) Backup() error {
-	if _, err := r.runtime.GetRunner().SudoCmd("mkdir -p /etc/yum.repos.d.kubekey.bak", false); err != nil {
+	if _, err := r.runtime.GetRunner().SudoCmd("mv /etc/yum.repos.d /etc/yum.repos.d.kubekey.bak", false); err != nil {
 		return err
 	}
 
-	if _, err := r.runtime.GetRunner().SudoCmd("cp -r /etc/yum.repos.d/* /etc/yum.repos.d.kubekey.bak/", false); err != nil {
+	if _, err := r.runtime.GetRunner().SudoCmd("mkdir -p /etc/yum.repos.d", false); err != nil {
 		return err
 	}
 	r.backup = true
@@ -97,16 +97,13 @@ func (r *RedhatPackageManager) Install(pkg ...string) error {
 }
 
 func (r *RedhatPackageManager) Reset() error {
-	if _, err := r.runtime.GetRunner().SudoCmd("rm -rf /etc/yum.repos.d/CentOS-local.repo", false); err != nil {
+	if _, err := r.runtime.GetRunner().SudoCmd("rm -rf /etc/yum.repos.d", false); err != nil {
 		return err
 	}
 
-	if _, err := r.runtime.GetRunner().SudoCmd("cp -r /etc/yum.repos.d.kubekey.bak/* /etc/yum.repos.d/", false); err != nil {
+	if _, err := r.runtime.GetRunner().SudoCmd("mv /etc/yum.repos.d.kubekey.bak /etc/yum.repos.d", false); err != nil {
 		return err
 	}
 
-	if _, err := r.runtime.GetRunner().SudoCmd("rm -rf /etc/yum.repos.d.kubekey.bak", false); err != nil {
-		return err
-	}
 	return nil
 }

--- a/pkg/bootstrap/os/rollback.go
+++ b/pkg/bootstrap/os/rollback.go
@@ -1,0 +1,75 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package os
+
+import (
+	"fmt"
+	"github.com/kubesphere/kubekey/pkg/bootstrap/os/repository"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/connector"
+	"github.com/kubesphere/kubekey/pkg/core/ending"
+	"github.com/pkg/errors"
+	"path/filepath"
+)
+
+type RollbackUmount struct {
+	common.KubeRollback
+}
+
+func (r *RollbackUmount) Execute(runtime connector.Runtime, result *ending.ActionResult) error {
+	if result.Status == ending.SUCCESS {
+		host := runtime.RemoteHost()
+		repo, ok := host.GetCache().Get("repo")
+		if !ok {
+			return errors.New("get repo failed by host cache")
+		}
+
+		re := repo.(repository.Interface)
+		if err := re.Reset(); err != nil {
+			return errors.Wrapf(errors.WithStack(err), "reset repository failed")
+		}
+	}
+
+	mountPath := filepath.Join(common.TmpDir, "iso")
+	umountCmd := fmt.Sprintf("umount %s", mountPath)
+	if _, err := runtime.GetRunner().SudoCmd(umountCmd, false); err != nil {
+		return errors.Wrapf(errors.WithStack(err), "umount %s failed", mountPath)
+	}
+	return nil
+}
+
+type RecoverRepository struct {
+	common.KubeRollback
+}
+
+func (r *RecoverRepository) Execute(runtime connector.Runtime, result *ending.ActionResult) error {
+	host := runtime.RemoteHost()
+	repo, ok := host.GetCache().Get("repo")
+	if !ok {
+		return errors.New("get repo failed by host cache")
+	}
+
+	re := repo.(repository.Interface)
+	_ = re.Reset()
+
+	mountPath := filepath.Join(common.TmpDir, "iso")
+	umountCmd := fmt.Sprintf("umount %s", mountPath)
+	if _, err := runtime.GetRunner().SudoCmd(umountCmd, false); err != nil {
+		return errors.Wrapf(errors.WithStack(err), "umount %s failed", mountPath)
+	}
+	return nil
+}

--- a/pkg/common/kube_rollback.go
+++ b/pkg/common/kube_rollback.go
@@ -1,5 +1,5 @@
 /*
- Copyright 2021 The KubeSphere Authors.
+ Copyright 2022 The KubeSphere Authors.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,17 +14,27 @@
  limitations under the License.
 */
 
-package task
+package common
 
 import (
-	"github.com/kubesphere/kubekey/pkg/core/cache"
 	"github.com/kubesphere/kubekey/pkg/core/connector"
-	"github.com/kubesphere/kubekey/pkg/core/ending"
+	"github.com/kubesphere/kubekey/pkg/core/rollback"
 )
 
-type Interface interface {
-	GetDesc() string
-	Init(runtime connector.Runtime, moduleCache *cache.Cache, pipelineCache *cache.Cache)
-	Execute() *ending.TaskResult
-	ExecuteRollback()
+type KubeRollback struct {
+	rollback.BaseRollback
+	KubeConf *KubeConf
+}
+
+func (k *KubeRollback) AutoAssert(runtime connector.Runtime) {
+	kubeRuntime := runtime.(*KubeRuntime)
+	conf := &KubeConf{
+		Cluster:     kubeRuntime.Cluster,
+		ClusterName: kubeRuntime.ClusterName,
+		Kubeconfig:  kubeRuntime.Kubeconfig,
+		ClientSet:   kubeRuntime.ClientSet,
+		Arg:         kubeRuntime.Arg,
+	}
+
+	k.KubeConf = conf
 }

--- a/pkg/core/module/task_module.go
+++ b/pkg/core/module/task_module.go
@@ -68,6 +68,7 @@ func (b *BaseTaskModule) Run(result *ending.ModuleResult) {
 		}
 
 		if res.IsFailed() {
+			t.ExecuteRollback()
 			result.ErrResult(errors.Wrapf(res.CombineErr(), "Module[%s] exec failed", b.Name))
 			return
 		}

--- a/pkg/core/rollback/base.go
+++ b/pkg/core/rollback/base.go
@@ -1,5 +1,5 @@
 /*
- Copyright 2021 The KubeSphere Authors.
+ Copyright 2022 The KubeSphere Authors.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  limitations under the License.
 */
 
-package task
+package rollback
 
 import (
 	"github.com/kubesphere/kubekey/pkg/core/cache"
@@ -22,9 +22,20 @@ import (
 	"github.com/kubesphere/kubekey/pkg/core/ending"
 )
 
-type Interface interface {
-	GetDesc() string
-	Init(runtime connector.Runtime, moduleCache *cache.Cache, pipelineCache *cache.Cache)
-	Execute() *ending.TaskResult
-	ExecuteRollback()
+type BaseRollback struct {
+	ModuleCache   *cache.Cache
+	PipelineCache *cache.Cache
+}
+
+func (b *BaseRollback) Init(moduleCache *cache.Cache, pipelineCache *cache.Cache) {
+	b.ModuleCache = moduleCache
+	b.PipelineCache = pipelineCache
+}
+
+func (b *BaseRollback) Execute(runtime connector.Runtime, result *ending.ActionResult) error {
+	return nil
+}
+
+func (b *BaseRollback) AutoAssert(runtime connector.Runtime) {
+
 }

--- a/pkg/core/rollback/interface.go
+++ b/pkg/core/rollback/interface.go
@@ -1,5 +1,5 @@
 /*
- Copyright 2021 The KubeSphere Authors.
+ Copyright 2022 The KubeSphere Authors.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  limitations under the License.
 */
 
-package task
+package rollback
 
 import (
 	"github.com/kubesphere/kubekey/pkg/core/cache"
@@ -22,9 +22,8 @@ import (
 	"github.com/kubesphere/kubekey/pkg/core/ending"
 )
 
-type Interface interface {
-	GetDesc() string
-	Init(runtime connector.Runtime, moduleCache *cache.Cache, pipelineCache *cache.Cache)
-	Execute() *ending.TaskResult
-	ExecuteRollback()
+type Rollback interface {
+	Execute(runtime connector.Runtime, result *ending.ActionResult) (err error)
+	Init(cache *cache.Cache, rootCache *cache.Cache)
+	AutoAssert(runtime connector.Runtime)
 }

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -177,7 +177,7 @@ func CmdPush(fileName string, prePath string, kubeConf *common.KubeConf, arches 
 
 	logger.Log.Debugf("push command: %s", pushCmd)
 	if out, err := exec.Command("/bin/bash", "-c", pushCmd).CombinedOutput(); err != nil {
-		return errors.Wrapf(err, "push image %s failed: %s", oldName, out)
+		return errors.Wrapf(err, "push image %s failed: %s", image.ImageName(), out)
 	}
 
 	fmt.Printf("push %s success \n", image.ImageName())


### PR DESCRIPTION
### What does this PR do?
* Add a rollback feature to support restoring something when a task failed
* Revert #1012 

Sometimes, a task will do something on the os, like mounting an ISO file. But when the task failed, the ISO file is still mounted on the os. So, the `rollback` function makes us can do some custom things after the task failed.