### PR TITLE
add a GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,64 @@
+<!-- Thanks for sending a pull request! Here are some tips for you:
+
+1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
+2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
+3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
+-->
+
+### What type of PR is this?
+<!-- 
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+/kind dependencies
+/kind test
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+
+### What this PR does / why we need it:
+
+### Which issue(s) this PR fixes:
+<!--
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+-->
+Fixes #
+
+### Special notes for reviewers:
+```
+```
+
+### Does this PR introduced a user-facing change?
+<!--
+If no, just write "None" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
+-->
+```release-note
+
+```
+
+### Additional documentation, usage docs, etc.:
+<!--
+This section can be blank if this pull request does not require a release note.
+Please use the following format for linking documentation or pass the
+section below:
+- [KEP]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+```docs
+
+```


### PR DESCRIPTION
### What does this PR do?
Add a Github PR template that is the same as the one for KubeSphere.

![image](https://user-images.githubusercontent.com/43993589/153154974-5a2583b4-259f-4c3a-ac37-bee2d74e8d5d.png)
