### PR TITLE
fix image name parse err

### DIFF
--- a/pkg/artifact/tasks.go
+++ b/pkg/artifact/tasks.go
@@ -144,7 +144,7 @@ func (e *ExportImages) Execute(runtime connector.Runtime) error {
 	ctx := namespaces.WithNamespace(context.Background(), "kubekey")
 	is := client.ImageService()
 	for _, image := range e.Manifest.Spec.Images {
-		fileName := strings.ReplaceAll(image, "/", "-")
+		fileName := strings.ReplaceAll(image, "/", "#")
 		fileName = fmt.Sprintf("%s.tar", fileName)
 
 		filePath := filepath.Join(dir, fileName)

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -126,26 +126,7 @@ func (images *Images) PullImages(runtime connector.Runtime, kubeConf *common.Kub
 }
 
 func CmdPush(fileName string, prePath string, kubeConf *common.KubeConf, arches []string) error {
-	// just like: docker.io-calico-cni:v3.20.0.tar, docker.io-kubesphere-kube-apiserver:v1.21.5.tar
-	// docker.io-fluent-fluentd:v1.4.2-2.0.tar .e.g.
-	fullArr := strings.Split(fileName, ":")
-
-	// v3.20.0.tar, v1.21.5.tar or v1.4.2-2.0.tar
-	tag := fullArr[len(fullArr)-1]
-	// .tar
-	tagExt := path.Ext(tag)
-	// v3.20.0, v1.21.5 or v1.4.2-2.0
-	tag = strings.TrimSuffix(tag, tagExt)
-
-	// docker.io-calico-cni, docker.io-kubesphere-kube-apiserver or docker.io-fluent-fluentd
-	nameArr := strings.Split(strings.Join(fullArr[:len(fullArr)-1], ":"), "-")
-
-	// docker.io
-	registry := nameArr[0]
-	// calico, kubesphere or fluent
-	namespace := nameArr[1]
-	// cni, kube-apiserver or fluentd
-	imageName := strings.Join(nameArr[2:], "-")
+	registry, namespace, imageName, tag := parseImageName(fileName)
 
 	privateRegistry := kubeConf.Cluster.Registry.PrivateRegistry
 	image := Image{
@@ -182,4 +163,29 @@ func CmdPush(fileName string, prePath string, kubeConf *common.KubeConf, arches 
 
 	fmt.Printf("push %s success \n", image.ImageName())
 	return nil
+}
+
+func parseImageName(file string) (string, string, string, string) {
+	// just like: docker.io-calico-cni:v3.20.0.tar, docker.io-kubesphere-kube-apiserver:v1.21.5.tar
+	// docker.io-fluent-fluentd:v1.4.2-2.0.tar .e.g.
+	fullArr := strings.Split(file, ":")
+
+	// v3.20.0.tar, v1.21.5.tar or v1.4.2-2.0.tar
+	tag := fullArr[len(fullArr)-1]
+	// .tar
+	tagExt := path.Ext(tag)
+	// v3.20.0, v1.21.5 or v1.4.2-2.0
+	tag = strings.TrimSuffix(tag, tagExt)
+
+	// docker.io-calico-cni, docker.io-kubesphere-kube-apiserver or docker.io-fluent-fluentd
+	nameArr := strings.Split(strings.Join(fullArr[:len(fullArr)-1], ":"), "#")
+
+	// docker.io
+	registry := nameArr[0]
+	// calico, kubesphere or fluent
+	namespace := nameArr[1]
+	// cni, kube-apiserver or fluentd
+	imageName := nameArr[2]
+
+	return registry, namespace, imageName, tag
 }

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -1,0 +1,72 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package images
+
+import "testing"
+
+func Test_parseImageName(t *testing.T) {
+	tests := []struct {
+		name  string
+		file  string
+		want  string
+		want1 string
+		want2 string
+		want3 string
+	}{
+		{
+			name:  "docker.io#calico#cni:v3.20.0.tar",
+			file:  "docker.io#calico#cni:v3.20.0.tar",
+			want:  "docker.io",
+			want1: "calico",
+			want2: "cni",
+			want3: "v3.20.0",
+		},
+		{
+			name:  "docker.io#kubesphere#kube-apiserver:v1.21.5.tar",
+			file:  "docker.io#kubesphere#kube-apiserver:v1.21.5.tar",
+			want:  "docker.io",
+			want1: "kubesphere",
+			want2: "kube-apiserver",
+			want3: "v1.21.5",
+		},
+		{
+			name:  "registry.cn-beijing.aliyuncs.com#kubesphere#kube-apiserver:v1.21.5.tar",
+			file:  "registry.cn-beijing.aliyuncs.com#kubesphere#kube-apiserver:v1.21.5.tar",
+			want:  "registry.cn-beijing.aliyuncs.com",
+			want1: "kubesphere",
+			want2: "kube-apiserver",
+			want3: "v1.21.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got2, got3 := parseImageName(tt.file)
+			if got != tt.want {
+				t.Errorf("parseImageName() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("parseImageName() got1 = %v, want %v", got1, tt.want1)
+			}
+			if got2 != tt.want2 {
+				t.Errorf("parseImageName() got2 = %v, want %v", got2, tt.want2)
+			}
+			if got3 != tt.want3 {
+				t.Errorf("parseImageName() got3 = %v, want %v", got3, tt.want3)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: 24sama <leo@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Fix image name parse error.

Before, using the `-` to split the image name can not parse the following example:
```
registry.cn-beijing.aliyuncs.com-kubesphere-kube-apiserver:v1.21.5.tar
```
This PR, I change the image name policy to fix this bug, we use the `#` to split the image name
```
registry.cn-beijing.aliyuncs.com#kubesphere#kube-apiserver:v1.21.5.tar
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
The `artifact` need to re-export by kk command.

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
