### PR TITLE
Fix: LocalApiEndpoint's bindPort uses controlPlane's port

### DIFF
--- a/apis/kubekey/v1alpha2/default.go
+++ b/apis/kubekey/v1alpha2/default.go
@@ -29,6 +29,7 @@ const (
 	DefaultTmpDir               = "/tmp/kubekey"
 	DefaultSSHPort              = 22
 	DefaultLBPort               = 6443
+	DefaultApiserverPort        = 6443
 	DefaultLBDomain             = "lb.kubesphere.local"
 	DefaultNetworkPlugin        = "calico"
 	DefaultPodsCIDR             = "10.233.64.0/18"

--- a/pkg/kubernetes/tasks.go
+++ b/pkg/kubernetes/tasks.go
@@ -268,7 +268,7 @@ func (g *GenerateKubeadmConfig) Execute(runtime connector.Runtime) error {
 				"ClusterName":            g.KubeConf.Cluster.Kubernetes.ClusterName,
 				"DNSDomain":              g.KubeConf.Cluster.Kubernetes.DNSDomain,
 				"AdvertiseAddress":       host.GetInternalAddress(),
-				"ControlPlanPort":        g.KubeConf.Cluster.ControlPlaneEndpoint.Port,
+				"BindPort":               kubekeyv1alpha2.DefaultApiserverPort,
 				"ControlPlaneEndpoint":   fmt.Sprintf("%s:%d", g.KubeConf.Cluster.ControlPlaneEndpoint.Domain, g.KubeConf.Cluster.ControlPlaneEndpoint.Port),
 				"PodSubnet":              g.KubeConf.Cluster.Network.KubePodsCIDR,
 				"ServiceSubnet":          g.KubeConf.Cluster.Network.KubeServiceCIDR,

--- a/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -86,7 +86,7 @@ apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: {{ .AdvertiseAddress }}
-  bindPort: {{ .ControlPlanPort }}
+  bindPort: {{ .BindPort }}
 nodeRegistration:
 {{- if .CriSock }}
   criSocket: {{ .CriSock }}
@@ -116,7 +116,7 @@ discovery:
 controlPlane:
   localAPIEndpoint:
     advertiseAddress: {{ .AdvertiseAddress }}
-    bindPort: {{ .ControlPlanPort }}
+    bindPort: {{ .BindPort }}
   certificateKey: {{ .CertificateKey }}
 {{- end }}
 nodeRegistration:

--- a/pkg/loadbalancer/module.go
+++ b/pkg/loadbalancer/module.go
@@ -17,6 +17,7 @@
 package loadbalancer
 
 import (
+	kubekeyapiv1alpha2 "github.com/kubesphere/kubekey/apis/kubekey/v1alpha2"
 	"github.com/kubesphere/kubekey/pkg/common"
 	"github.com/kubesphere/kubekey/pkg/core/action"
 	"github.com/kubesphere/kubekey/pkg/core/connector"
@@ -50,7 +51,7 @@ func (h *HaproxyModule) Init() {
 			Dst:      filepath.Join(common.HaproxyDir, templates.HaproxyConfig.Name()),
 			Data: util.Data{
 				"MasterNodes":                          templates.MasterNodeStr(h.Runtime, h.KubeConf),
-				"LoadbalancerApiserverPort":            h.KubeConf.Cluster.ControlPlaneEndpoint.Port,
+				"LoadbalancerApiserverPort":            kubekeyapiv1alpha2.DefaultApiserverPort,
 				"LoadbalancerApiserverHealthcheckPort": 8081,
 				"KubernetesType":                       h.KubeConf.Cluster.Kubernetes.Type,
 			},

--- a/pkg/loadbalancer/templates/haproxyConfig.go
+++ b/pkg/loadbalancer/templates/haproxyConfig.go
@@ -17,6 +17,7 @@
 package templates
 
 import (
+	kubekeyapiv1alpha2 "github.com/kubesphere/kubekey/apis/kubekey/v1alpha2"
 	"github.com/kubesphere/kubekey/pkg/common"
 	"github.com/kubesphere/kubekey/pkg/core/connector"
 	"github.com/lithammer/dedent"
@@ -74,7 +75,7 @@ backend kube_api_backend
 func MasterNodeStr(runtime connector.ModuleRuntime, conf *common.KubeConf) []string {
 	masterNodes := make([]string, len(runtime.GetHostsByRole(common.Master)))
 	for i, node := range runtime.GetHostsByRole(common.Master) {
-		masterNodes[i] = node.GetName() + " " + node.GetAddress() + ":" + strconv.Itoa(conf.Cluster.ControlPlaneEndpoint.Port)
+		masterNodes[i] = node.GetName() + " " + node.GetAddress() + ":" + strconv.Itoa(kubekeyapiv1alpha2.DefaultApiserverPort)
 	}
 	return masterNodes
 }


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
LocalApiEndpoint and controlPlane should not share the same port in cluster. So this pr removes dependence of LocalApiEndpoint bindPort on the controlPlane's port.



### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
https://github.com/kubesphere/kubekey/issues/1061
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
