### PR TITLE
Add the support of NamespaceOverride for KubeSphere‘s images

### DIFF
--- a/pkg/kubesphere/modules.go
+++ b/pkg/kubesphere/modules.go
@@ -122,12 +122,15 @@ func (d *DeployModule) Init() {
 
 func MirrorRepo(kubeConf *common.KubeConf) string {
 	repo := kubeConf.Cluster.Registry.PrivateRegistry
+	namespaceOverride := kubeConf.Cluster.Registry.NamespaceOverride
 	version := kubeConf.Cluster.KubeSphere.Version
 
 	_, ok := kubesphere.CNSource[version]
 	if ok && os.Getenv("KKZONE") == "cn" {
 		if repo == "" {
 			repo = "registry.cn-beijing.aliyuncs.com/kubesphereio"
+		} else if len(namespaceOverride) != 0 {
+			repo = fmt.Sprintf("%s/%s", repo, namespaceOverride)
 		} else {
 			repo = fmt.Sprintf("%s/kubesphere", repo)
 		}
@@ -146,6 +149,8 @@ func MirrorRepo(kubeConf *common.KubeConf) string {
 			default:
 				repo = "kubesphere"
 			}
+		} else if len(namespaceOverride) != 0 {
+			repo = fmt.Sprintf("%s/%s", repo, namespaceOverride)
 		} else {
 			repo = fmt.Sprintf("%s/kubesphere", repo)
 		}

--- a/pkg/kubesphere/tasks.go
+++ b/pkg/kubesphere/tasks.go
@@ -103,6 +103,18 @@ func (s *Setup) Execute(runtime connector.Runtime) error {
 		}
 	}
 
+	if s.KubeConf.Cluster.Registry.NamespaceOverride != "" {
+		if _, err := runtime.GetRunner().SudoCmd(
+			fmt.Sprintf("sed -i '/namespace_override/s/\\:.*/\\: %s/g' %s", s.KubeConf.Cluster.Registry.NamespaceOverride, filePath),
+			false); err != nil {
+			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("add namespace override: %s failed", s.KubeConf.Cluster.Registry.NamespaceOverride))
+		}
+	} else {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("sed -i '/namespace_override/d' %s", filePath), false); err != nil {
+			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("remove namespace override failed"))
+		}
+	}
+
 	_, ok := kubesphere.CNSource[s.KubeConf.Cluster.KubeSphere.Version]
 	if ok && (os.Getenv("KKZONE") == "cn" || s.KubeConf.Cluster.Registry.PrivateRegistry == "registry.cn-beijing.aliyuncs.com") {
 		if _, err := runtime.GetRunner().SudoCmd(

--- a/pkg/version/kubesphere/templates/cc_v321.go
+++ b/pkg/version/kubesphere/templates/cc_v321.go
@@ -37,6 +37,7 @@ spec:
   authentication:
     jwtSecret: ""
   local_registry: ""
+  namespace_override: ""
   # dev_tag: ""
   etcd:
     monitoring: false


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
KubeKey supports `NamespaceOverride` and is only used for deploying kubenretes cluster. However, when deploying KubeSphere at the same time, this parameter has no effect on the images of KubeSphere. When all images use the same namespace, it will lead to the failure of installation.
Therefore, this pr adds the support of `NamespaceOverride` for KubeSphere‘s images.

```release-note
None
```
