### PR TITLE
Fix: CSIStorageCapacity cause the cluster to fail to start normally

### DIFF
--- a/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -18,6 +18,7 @@ package v1beta2
 
 import (
 	"fmt"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"regexp"
 	"strings"
 	"text/template"
@@ -155,6 +156,11 @@ var (
 )
 
 func UpdateFeatureGatesConfiguration(args map[string]string, kubeConf *common.KubeConf) map[string]string {
+	// When kubernetes version is less than 1.21,`CSIStorageCapacity` should not be set.
+	cmp, _ := versionutil.MustParseSemantic(kubeConf.Cluster.Kubernetes.Version).Compare("v1.21.0")
+	if cmp == -1 {
+		delete(FeatureGatesDefaultConfiguration, "CSIStorageCapacity")
+	}
 
 	var featureGates []string
 
@@ -174,6 +180,12 @@ func UpdateFeatureGatesConfiguration(args map[string]string, kubeConf *common.Ku
 }
 
 func GetKubeletConfiguration(runtime connector.Runtime, kubeConf *common.KubeConf, criSock string) map[string]interface{} {
+	// When kubernetes version is less than 1.21,`CSIStorageCapacity` should not be set.
+	cmp, _ := versionutil.MustParseSemantic(kubeConf.Cluster.Kubernetes.Version).Compare("v1.21.0")
+	if cmp == -1 {
+		delete(FeatureGatesDefaultConfiguration, "CSIStorageCapacity")
+	}
+
 	defaultKubeletConfiguration := map[string]interface{}{
 		"clusterDomain":      kubeConf.Cluster.Kubernetes.DNSDomain,
 		"clusterDNS":         []string{kubeConf.Cluster.ClusterDNS()},


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
When the kubernetes version is less than 1.21, setting `CSIStorageCapacity` in feature gates will cause the cluster to fail to start normally.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubekey/issues/1073

