### PR TITLE
Remove the login registry task in the installation harbor module

### DIFF
--- a/pkg/bootstrap/registry/module.go
+++ b/pkg/bootstrap/registry/module.go
@@ -237,18 +237,6 @@ func InstallHarbor(i *InstallRegistryModule) []task.Interface {
 		Parallel: true,
 	}
 
-	dockerLoginRegistry := &task.RemoteTask{
-		Name:  "Login PrivateRegistry",
-		Desc:  "Add auths to container runtime",
-		Hosts: i.Runtime.GetHostsByRole(common.Registry),
-		Prepare: &prepare.PrepareCollection{
-			&container.DockerExist{},
-			&container.PrivateRegistryAuth{},
-		},
-		Action:   new(container.DockerLoginRegistry),
-		Parallel: true,
-	}
-
 	// Install docker compose
 	installDockerCompose := &task.RemoteTask{
 		Name:     "InstallDockerCompose",
@@ -302,7 +290,6 @@ func InstallHarbor(i *InstallRegistryModule) []task.Interface {
 		generateDockerService,
 		generateDockerConfig,
 		enableDocker,
-		dockerLoginRegistry,
 		installDockerCompose,
 		syncHarborPackage,
 		generateHarborConfig,


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup


### What this PR does / why we need it:
When installing harbor, if the registry's authentication information is filled in the configuration file in advance, the login to the  registry will fail because the harbor has not been started.
Therefore, the task of logging into the registry is useless in the module of installing harbor.




### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```

```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Remove the login registry task in the installation harbor module
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
