### PR TITLE
support private registry custom domain, add to node hosts

### DIFF
--- a/apis/kubekey/v1alpha2/cluster_types.go
+++ b/apis/kubekey/v1alpha2/cluster_types.go
@@ -175,6 +175,7 @@ type RegistryConfig struct {
 	RegistryMirrors    []string             `yaml:"registryMirrors" json:"registryMirrors,omitempty"`
 	InsecureRegistries []string             `yaml:"insecureRegistries" json:"insecureRegistries,omitempty"`
 	PrivateRegistry    string               `yaml:"privateRegistry" json:"privateRegistry,omitempty"`
+	PrivateRegistryIp  string               `yaml:"privateRegistryIp" json:"privateRegistryIp,omitempty"`
 	NamespaceOverride  string               `yaml:"namespaceOverride" json:"namespaceOverride,omitempty"`
 	PlainHTTP          bool                 `yaml:"plainHTTP" json:"plainHTTP,omitempty"`
 	Auths              runtime.RawExtension `yaml:"auths" json:"auths,omitempty"`

--- a/config/crd/bases/kubekey.kubesphere.io_clusters.yaml
+++ b/config/crd/bases/kubekey.kubesphere.io_clusters.yaml
@@ -657,6 +657,8 @@ spec:
                     type: boolean
                   privateRegistry:
                     type: string
+                  privateRegistryIp:
+                    type: string
                   registryMirrors:
                     items:
                       type: string

--- a/docs/config-example.md
+++ b/docs/config-example.md
@@ -68,6 +68,7 @@ spec:
     registryMirrors: []
     insecureRegistries: []
     privateRegistry: ""
+    privateRegistryIp: ""   # if use inner private registry, auto add domain to hosts
     namespaceOverride: ""
     auths: # if docker add by `docker login`, if containerd append to `/etc/containerd/config.toml`
       "registry-1.docker.io":

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -52,6 +52,7 @@ KubeKey now allows users to create a container image registry ([Docker registry]
        ## `harbor` can be also set for type.
        # type: "harbor"  
        privateRegistry: dockerhub.kubekey.local
+       privateRegistryIp: ""
        auths:
          "dockerhub.kubekey.local":
            username: admin

--- a/manifests/deploy.yaml
+++ b/manifests/deploy.yaml
@@ -184,6 +184,8 @@ spec:
                   type: array
                 privateRegistry:
                   type: string
+                privateRegistryIp:
+                  type: string
                 registryMirrors:
                   items:
                     type: string

--- a/pkg/bootstrap/os/templates/init_script.go
+++ b/pkg/bootstrap/os/templates/init_script.go
@@ -161,6 +161,10 @@ func GenerateHosts(runtime connector.ModuleRuntime, kubeConf *common.KubeConf) [
 		lbHost = fmt.Sprintf("%s  %s", runtime.GetHostsByRole(common.Master)[0].GetInternalAddress(), kubeConf.Cluster.ControlPlaneEndpoint.Domain)
 	}
 
+	if kubeConf.Cluster.Registry.PrivateRegistryIp != "" && kubeConf.Cluster.Registry.PrivateRegistry != "" {
+		hostsList = append(hostsList, fmt.Sprintf("%s  %s", kubeConf.Cluster.Registry.PrivateRegistryIp, kubeConf.Cluster.Registry.PrivateRegistry))
+	}
+
 	for _, host := range runtime.GetAllHosts() {
 		if host.GetName() != "" {
 			hostsList = append(hostsList, fmt.Sprintf("%s  %s.%s %s",


### PR DESCRIPTION
### What type of PR is this?
/kind feature


### What this PR does / why we need it:

when use exists inner harbor registry custom domain, reduce manual config node hosts

add `privateRegistryIp` field in cluster registry config，when `GenerateHosts` auto add  private registry hosts



### Does this PR introduced a user-facing change?

```
  registry:
    type: harbor
    plainHTTP: false
    privateRegistry: harbor.ssl.example.com
    privateRegistryIp: 192.168.41.12            # option
    auths:
      "harbor.ssl.example.com":
         username: admin
         password: Harbor12345
    namespaceOverride: ""
    registryMirrors: []
    insecureRegistries: []

```

