### PR TITLE
fix: fix docker login failure when auths username or password is empt…

### DIFF
--- a/apis/kubekey/v1alpha2/cluster_types.go
+++ b/apis/kubekey/v1alpha2/cluster_types.go
@@ -177,7 +177,6 @@ type RegistryConfig struct {
 	InsecureRegistries []string             `yaml:"insecureRegistries" json:"insecureRegistries,omitempty"`
 	PrivateRegistry    string               `yaml:"privateRegistry" json:"privateRegistry,omitempty"`
 	NamespaceOverride  string               `yaml:"namespaceOverride" json:"namespaceOverride,omitempty"`
-	PlainHTTP          bool                 `yaml:"plainHTTP" json:"plainHTTP,omitempty"`
 	Auths              runtime.RawExtension `yaml:"auths" json:"auths,omitempty"`
 }
 

--- a/pkg/images/tasks.go
+++ b/pkg/images/tasks.go
@@ -332,7 +332,7 @@ func (p *PushManifest) Execute(_ connector.Runtime) error {
 		logger.Log.Infof("Push multi-arch manifest list: %s", imageName)
 		// todo: the function can't support specify a certs dir
 		digest, length, err := manifestregistry.PushManifestList(auth.Username, auth.Password, manifestSpec,
-			false, true, p.KubeConf.Cluster.Registry.PlainHTTP, "")
+			false, true, auth.SkipTLSVerify, "")
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("push image %s multi-arch manifest failed", imageName))
 		}


### PR DESCRIPTION
fix: fix docker login failure when auths username or password is empty which lead to create cluster failure

What type of PR is this?
/kind bug

What this PR does / why we need it:
Fix docker login failure when auths username or password is empty which lead to create cluster failure.
When auths username or password is empty, continue to do next repository's auth login. It means to ignore this repositry's auth.

Which issue(s) this PR fixes:
Fixes #1257 
#1257 