### PR TITLE
add a debug log print in the ssh runner

### DIFF
--- a/pkg/core/connector/runner.go
+++ b/pkg/core/connector/runner.go
@@ -38,35 +38,19 @@ func (r *Runner) Exec(cmd string, printOutput bool) (string, int, error) {
 		return "", 1, errors.New("no ssh connection available")
 	}
 
-	//stdout := NewTee(os.Stdout)
-	//defer stdout.Close()
-	//
-	//stderr := NewTee(os.Stderr)
-	//defer stderr.Close()
-	//
-	//code, err := r.Conn.PExec(cmd, nil, stdout, stderr)
-
-	//if printOutput {
-	//	if stdout.String() != "" {
-	//		logger.Log.Infof("[stdout]: %s", stdout.String())
-	//	}
-	//	if stderr.String() != "" {
-	//		logger.Log.Infof("[stderr]: %s", stderr.String())
-	//	}
-	//}
-	//if err != nil {
-	//	return "", err.Error(), code, err
-	//}
-	//
-	//return stdout.String(), stderr.String(), code, nil
 	stdout, code, err := r.Conn.Exec(cmd, r.Host)
+	logger.Log.Debugf("command: [%s]\n%s", r.Host.GetName(), cmd)
+	if stdout != "" {
+		logger.Log.Debugf("stdout: [%s]\n%s", r.Host.GetName(), stdout)
+	}
+	if err != nil {
+		logger.Log.Debugf("stderr: [%s]\n%s", r.Host.GetName(), err)
+	}
+
 	if printOutput {
 		if stdout != "" {
 			logger.Log.Infof("stdout: [%s]\n%s", r.Host.GetName(), stdout)
 		}
-		//if stderr != "" {
-		//	logger.Log.Infof("stderr: [%s]\n%s", r.Host.GetName(), stderr)
-		//}
 	}
 	return stdout, code, err
 }


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Add a debug log print in the ssh runner. That will allow kk to print every command executed in debug mode.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
