### PR TITLE
feat: show "WARN" and "ERRO" log level

### DIFF
--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -18,12 +18,14 @@ package logger
 
 import (
 	"fmt"
-	"github.com/kubesphere/kubekey/pkg/core/common"
+	"path/filepath"
+	"time"
+
 	rotatelogs "github.com/lestrrat-go/file-rotatelogs"
 	"github.com/rifflock/lfshook"
 	"github.com/sirupsen/logrus"
-	"path/filepath"
-	"time"
+
+	"github.com/kubesphere/kubekey/pkg/core/common"
 )
 
 var Log *KubeKeyLog
@@ -41,7 +43,7 @@ func NewLogger(outputPath string, verbose bool) *KubeKeyLog {
 		HideKeys:               true,
 		TimestampFormat:        "15:04:05 MST",
 		NoColors:               true,
-		ShowLevel:              logrus.FatalLevel,
+		ShowLevel:              logrus.WarnLevel,
 		FieldsDisplayWithOrder: []string{common.Pipeline, common.Module, common.Task, common.Node},
 	}
 	logger.SetFormatter(formatter)

--- a/pkg/core/logger/logger_test.go
+++ b/pkg/core/logger/logger_test.go
@@ -26,7 +26,6 @@ var log = NewLogger("", true)
 func TestKubeKey_Print(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	for i := 0; i < 5; i++ {
-		Log.Info("begin")
 
 		log.Info("empty fields")
 		l1 := *log


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
show "WARN" and "ERRO" log level

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
