### PR TITLE
feat: users can use "y" or "n" when confirming

### DIFF
--- a/pkg/bootstrap/confirm/tasks.go
+++ b/pkg/bootstrap/confirm/tasks.go
@@ -23,15 +23,16 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/mitchellh/mapstructure"
+	"github.com/modood/table"
+	"github.com/pkg/errors"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+
 	"github.com/kubesphere/kubekey/pkg/common"
 	"github.com/kubesphere/kubekey/pkg/core/action"
 	"github.com/kubesphere/kubekey/pkg/core/connector"
 	"github.com/kubesphere/kubekey/pkg/core/logger"
 	"github.com/kubesphere/kubekey/pkg/core/util"
-	"github.com/mitchellh/mapstructure"
-	"github.com/modood/table"
-	"github.com/pkg/errors"
-	versionutil "k8s.io/apimachinery/pkg/util/version"
 )
 
 // PreCheckResults defines the items to be checked.
@@ -131,10 +132,10 @@ func (i *InstallationConfirm) Execute(runtime connector.Runtime) error {
 		}
 		input = strings.TrimSpace(strings.ToLower(input))
 
-		switch input {
-		case "yes":
+		switch strings.ToLower(input) {
+		case "yes", "y":
 			confirmOK = true
-		case "no":
+		case "no", "n":
 			os.Exit(0)
 		default:
 			continue
@@ -151,24 +152,25 @@ type DeleteConfirm struct {
 func (d *DeleteConfirm) Execute(runtime connector.Runtime) error {
 	reader := bufio.NewReader(os.Stdin)
 
-	var res string
-	for {
+	confirmOK := false
+	for !confirmOK {
 		fmt.Printf("Are you sure to delete this %s? [yes/no]: ", d.Content)
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			return err
 		}
-		input = strings.TrimSpace(input)
+		input = strings.ToLower(strings.TrimSpace(input))
 
-		if input != "" && (input == "yes" || input == "no") {
-			res = input
-			break
+		switch strings.ToLower(input) {
+		case "yes", "y":
+			confirmOK = true
+		case "no", "n":
+			os.Exit(0)
+		default:
+			continue
 		}
 	}
 
-	if res == "no" {
-		os.Exit(0)
-	}
 	return nil
 }
 
@@ -271,12 +273,12 @@ Warning:
 		if err != nil {
 			return err
 		}
-		input = strings.TrimSpace(input)
+		input = strings.ToLower(strings.TrimSpace(input))
 
 		switch input {
-		case "yes":
+		case "yes", "y":
 			confirmOK = true
-		case "no":
+		case "no", "n":
 			os.Exit(0)
 		default:
 			continue
@@ -320,13 +322,13 @@ func (c *CheckFile) Execute(runtime connector.Runtime) error {
 			}
 			fmt.Printf("%s already exists. Are you sure you want to overwrite this file? [yes/no]: ", c.FileName)
 			input, _ := reader.ReadString('\n')
-			input = strings.TrimSpace(input)
+			input = strings.ToLower(strings.TrimSpace(input))
 
 			if input != "" {
 				switch input {
-				case "yes":
+				case "yes", "y":
 					stop = true
-				case "no":
+				case "no", "n":
 					os.Exit(0)
 				}
 			}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Users can use "y" or "n" when confirming

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
