### PR TITLE
fix: GreetingModule sometimes occurs a timeout error

### DIFF
--- a/apis/kubekey/v1alpha2/default.go
+++ b/apis/kubekey/v1alpha2/default.go
@@ -38,7 +38,7 @@ const (
 	DefaultClusterName          = "cluster.local"
 	DefaultDNSDomain            = "cluster.local"
 	DefaultArch                 = "amd64"
-	DefaultSSHTimeout           = 10
+	DefaultSSHTimeout           = 30
 	DefaultEtcdVersion          = "v3.4.13"
 	DefaultEtcdPort             = "2379"
 	DefaultDockerVersion        = "20.10.8"

--- a/pkg/bootstrap/precheck/module.go
+++ b/pkg/bootstrap/precheck/module.go
@@ -17,11 +17,12 @@
 package precheck
 
 import (
+	"time"
+
 	"github.com/kubesphere/kubekey/pkg/common"
 	"github.com/kubesphere/kubekey/pkg/core/module"
 	"github.com/kubesphere/kubekey/pkg/core/prepare"
 	"github.com/kubesphere/kubekey/pkg/core/task"
-	"time"
 )
 
 type GreetingsModule struct {
@@ -32,13 +33,18 @@ func (h *GreetingsModule) Init() {
 	h.Name = "GreetingsModule"
 	h.Desc = "Greetings"
 
+	var timeout int64
+	for _, v := range h.Runtime.GetAllHosts() {
+		timeout += v.GetTimeout()
+	}
+
 	hello := &task.RemoteTask{
 		Name:     "Greetings",
 		Desc:     "Greetings",
 		Hosts:    h.Runtime.GetAllHosts(),
 		Action:   new(GreetingsTask),
 		Parallel: true,
-		Timeout:  30 * time.Second,
+		Timeout:  time.Duration(timeout) * time.Second,
 	}
 
 	h.Tasks = []task.Interface{

--- a/pkg/core/task/local_task.go
+++ b/pkg/core/task/local_task.go
@@ -19,8 +19,9 @@ package task
 import (
 	"context"
 	"fmt"
-	"github.com/kubesphere/kubekey/pkg/core/rollback"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/kubesphere/kubekey/pkg/core/action"
 	"github.com/kubesphere/kubekey/pkg/core/cache"
@@ -29,7 +30,8 @@ import (
 	"github.com/kubesphere/kubekey/pkg/core/ending"
 	"github.com/kubesphere/kubekey/pkg/core/logger"
 	"github.com/kubesphere/kubekey/pkg/core/prepare"
-	"github.com/pkg/errors"
+	"github.com/kubesphere/kubekey/pkg/core/rollback"
+	"github.com/kubesphere/kubekey/pkg/core/util"
 )
 
 type LocalTask struct {
@@ -119,7 +121,7 @@ func (l *LocalTask) RunWithTimeout(runtime connector.Runtime, host connector.Hos
 	go l.Run(runtime, host, resCh)
 	select {
 	case <-ctx.Done():
-		l.TaskResult.AppendErr(host, fmt.Errorf("execute task timeout, Timeout=%d", l.Timeout))
+		l.TaskResult.AppendErr(host, fmt.Errorf("execute task timeout, Timeout=%s", util.ShortDur(l.Timeout)))
 	case e := <-resCh:
 		if e != nil {
 			l.TaskResult.AppendErr(host, e)

--- a/pkg/core/task/remote_task.go
+++ b/pkg/core/task/remote_task.go
@@ -19,9 +19,10 @@ package task
 import (
 	"context"
 	"fmt"
-	"github.com/kubesphere/kubekey/pkg/core/rollback"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/kubesphere/kubekey/pkg/core/action"
 	"github.com/kubesphere/kubekey/pkg/core/cache"
@@ -29,8 +30,8 @@ import (
 	"github.com/kubesphere/kubekey/pkg/core/ending"
 	"github.com/kubesphere/kubekey/pkg/core/logger"
 	"github.com/kubesphere/kubekey/pkg/core/prepare"
+	"github.com/kubesphere/kubekey/pkg/core/rollback"
 	"github.com/kubesphere/kubekey/pkg/core/util"
-	"github.com/pkg/errors"
 )
 
 type RemoteTask struct {
@@ -110,7 +111,7 @@ func (t *RemoteTask) RunWithTimeout(ctx context.Context, runtime connector.Runti
 
 	select {
 	case <-ctx.Done():
-		t.TaskResult.AppendErr(host, fmt.Errorf("execute task timeout, Timeout=%d", t.Timeout))
+		t.TaskResult.AppendErr(host, fmt.Errorf("execute task timeout, Timeout=%s", util.ShortDur(t.Timeout)))
 	case e := <-resCh:
 		if e != nil {
 			t.TaskResult.AppendErr(host, e)

--- a/pkg/core/util/time.go
+++ b/pkg/core/util/time.go
@@ -1,0 +1,33 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+	"time"
+)
+
+func ShortDur(d time.Duration) string {
+	s := d.String()
+	if strings.HasSuffix(s, "m0s") {
+		s = s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "h0m") {
+		s = s[:len(s)-2]
+	}
+	return s
+}

--- a/pkg/core/util/time_test.go
+++ b/pkg/core/util/time_test.go
@@ -1,0 +1,61 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShortDur(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{
+			d:    3 * time.Second,
+			want: "3s",
+		},
+		{
+			d:    60 * time.Second,
+			want: "1m",
+		},
+		{
+			d:    4 * time.Minute,
+			want: "4m",
+		},
+		{
+			d:    1*time.Hour + 3*time.Second,
+			want: "1h0m3s",
+		},
+		{
+			d:    1*time.Hour + 4*time.Minute,
+			want: "1h0m",
+		},
+		{
+			d:    1*time.Hour + 4*time.Minute + 3*time.Second,
+			want: "1h4m3s",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			if got := ShortDur(tt.d); got != tt.want {
+				t.Errorf("ShortDur() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
* Fix: GreetingModule sometimes occurs a timeout error. 
  For now, the `timeout` value of the `GreetingModule` will be calculated by adding up the `timeout` values of all hosts
* Print human-readable task timeout error message.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1288 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
