### PR TITLE
support docker's data-root config

### DIFF
--- a/apis/kubekey/v1alpha2/cluster_types.go
+++ b/apis/kubekey/v1alpha2/cluster_types.go
@@ -176,6 +176,7 @@ type RegistryConfig struct {
 	RegistryMirrors    []string             `yaml:"registryMirrors" json:"registryMirrors,omitempty"`
 	InsecureRegistries []string             `yaml:"insecureRegistries" json:"insecureRegistries,omitempty"`
 	PrivateRegistry    string               `yaml:"privateRegistry" json:"privateRegistry,omitempty"`
+	DataRoot           string               `yaml:"dataRoot" json:"dataRoot,omitempty"`
 	NamespaceOverride  string               `yaml:"namespaceOverride" json:"namespaceOverride,omitempty"`
 	Auths              runtime.RawExtension `yaml:"auths" json:"auths,omitempty"`
 }

--- a/pkg/container/module.go
+++ b/pkg/container/module.go
@@ -102,6 +102,7 @@ func InstallDocker(m *InstallContainerModule) []task.Interface {
 			Data: util.Data{
 				"Mirrors":            templates.Mirrors(m.KubeConf),
 				"InsecureRegistries": templates.InsecureRegistries(m.KubeConf),
+				"DataRoot":           templates.DataRoot(m.KubeConf),
 			},
 		},
 		Parallel: true,

--- a/pkg/container/templates/docker_config.go
+++ b/pkg/container/templates/docker_config.go
@@ -31,6 +31,9 @@ var DockerConfig = template.Must(template.New("daemon.json").Parse(
     "max-size": "5m",
     "max-file":"3"
   },
+  {{- if .DataRoot }}
+  "data-root": {{ .DataRoot }},
+  {{- end}}
   {{- if .Mirrors }}
   "registry-mirrors": [{{ .Mirrors }}],
   {{- end}}
@@ -63,4 +66,12 @@ func InsecureRegistries(kubeConf *common.KubeConf) string {
 		insecureRegistries = strings.Join(registriesArr, ", ")
 	}
 	return insecureRegistries
+}
+
+func DataRoot(kubeConf *common.KubeConf) string {
+	var dataRoot string
+	if kubeConf.Cluster.Registry.DataRoot != "" {
+		dataRoot = fmt.Sprintf("\"%s\"", kubeConf.Cluster.Registry.DataRoot)
+	}
+	return dataRoot
 }

--- a/pkg/kubernetes/module.go
+++ b/pkg/kubernetes/module.go
@@ -386,7 +386,7 @@ func (d *DeleteKubeNodeModule) Init() {
 		Hosts:   d.Runtime.GetHostsByRole(common.Master),
 		Prepare: new(common.OnlyFirstMaster),
 		Action:  new(DrainNode),
-		Retry:   5,
+		Retry:   2,
 	}
 
 	deleteNode := &task.RemoteTask{

--- a/pkg/kubernetes/tasks.go
+++ b/pkg/kubernetes/tasks.go
@@ -533,7 +533,7 @@ func (d *DrainNode) Execute(runtime connector.Runtime) error {
 		return errors.New("get dstNode failed by pipeline cache")
 	}
 	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
-		"/usr/local/bin/kubectl drain %s --delete-emptydir-data --ignore-daemonsets", nodeName),
+		"/usr/local/bin/kubectl drain %s --delete-emptydir-data --ignore-daemonsets --timeout=2m --force", nodeName),
 		true); err != nil {
 		return errors.Wrap(err, "drain the node failed")
 	}

--- a/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -287,7 +287,7 @@ func GetKubeletConfiguration(runtime connector.Runtime, kubeConf *common.KubeCon
 	}
 
 	if kubeConf.Arg.Debug {
-		logger.Log.Debug("Set kubeletConfiguration: %v", kubeletConfiguration)
+		logger.Log.Debugf("Set kubeletConfiguration: %v", kubeletConfiguration)
 	}
 
 	return kubeletConfiguration


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
This pr is to provide  data-root config when cni is docker and delete node add timeout for drain node
### Which issue(s) this PR fixes:
feature[#997](https://github.com/kubesphere/kubekey/issues/997)

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```
```
Additional documentation, usage docs, etc.:
```
```