### PR TITLE
feat: support k8s and kubesphere version without "v"

### DIFF
--- a/pkg/common/loader.go
+++ b/pkg/common/loader.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -35,6 +36,10 @@ import (
 	kubekeyapiv1alpha2 "github.com/kubesphere/kubekey/apis/kubekey/v1alpha2"
 	"github.com/kubesphere/kubekey/pkg/core/util"
 	"github.com/kubesphere/kubekey/pkg/version/kubesphere"
+)
+
+var (
+	kubeReleaseRegex = regexp.MustCompile(`^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
 )
 
 type Loader interface {
@@ -108,8 +113,8 @@ func (d *DefaultLoader) Load() (*kubekeyapiv1alpha2.Cluster, error) {
 		Worker:   {hostname},
 		Registry: {hostname},
 	}
-	if d.KubernetesVersion != "" {
-		s := strings.Split(d.KubernetesVersion, "-")
+	if ver := normalizedBuildVersion(d.KubernetesVersion); ver != "" {
+		s := strings.Split(ver, "-")
 		if len(s) > 1 {
 			allInOne.Spec.Kubernetes = kubekeyapiv1alpha2.Kubernetes{
 				Version: s[0],
@@ -117,7 +122,7 @@ func (d *DefaultLoader) Load() (*kubekeyapiv1alpha2.Cluster, error) {
 			}
 		} else {
 			allInOne.Spec.Kubernetes = kubekeyapiv1alpha2.Kubernetes{
-				Version: d.KubernetesVersion,
+				Version: ver,
 			}
 		}
 	} else {
@@ -127,7 +132,11 @@ func (d *DefaultLoader) Load() (*kubekeyapiv1alpha2.Cluster, error) {
 	}
 
 	if d.KubeSphereEnable {
-		if err := defaultKSConfig(&allInOne.Spec.KubeSphere, d.KubeSphereVersion); err != nil {
+		ver := normalizedBuildVersion(d.KubeSphereVersion)
+		if ver == "" {
+			return nil, errors.New(fmt.Sprintf("Unsupported Kubesphere Version: %v\n", d.KubeSphereVersion))
+		}
+		if err := defaultKSConfig(&allInOne.Spec.KubeSphere, ver); err != nil {
 			return nil, err
 		}
 	}
@@ -230,18 +239,22 @@ func (f FileLoader) Load() (*kubekeyapiv1alpha2.Cluster, error) {
 	}
 
 	if f.KubeSphereEnable {
-		if err := defaultKSConfig(&clusterCfg.Spec.KubeSphere, f.KubeSphereVersion); err != nil {
+		ver := normalizedBuildVersion(f.KubeSphereVersion)
+		if ver == "" {
+			return nil, errors.New(fmt.Sprintf("Unsupported Kubesphere Version: %v\n", f.KubeSphereVersion))
+		}
+		if err := defaultKSConfig(&clusterCfg.Spec.KubeSphere, ver); err != nil {
 			return nil, err
 		}
 	}
 
-	if f.KubernetesVersion != "" {
-		s := strings.Split(f.KubernetesVersion, "-")
+	if ver := normalizedBuildVersion(f.KubernetesVersion); ver != "" {
+		s := strings.Split(ver, "-")
 		if len(s) > 1 {
 			clusterCfg.Spec.Kubernetes.Version = s[0]
 			clusterCfg.Spec.Kubernetes.Type = s[1]
 		} else {
-			clusterCfg.Spec.Kubernetes.Version = f.KubernetesVersion
+			clusterCfg.Spec.Kubernetes.Version = ver
 		}
 	}
 
@@ -249,6 +262,8 @@ func (f FileLoader) Load() (*kubekeyapiv1alpha2.Cluster, error) {
 		clusterCfg.Spec.Kubernetes.ContainerManager = f.arg.ContainerManager
 	}
 
+	clusterCfg.Spec.Kubernetes.Version = normalizedBuildVersion(clusterCfg.Spec.Kubernetes.Version)
+	clusterCfg.Spec.KubeSphere.Version = normalizedBuildVersion(clusterCfg.Spec.KubeSphere.Version)
 	clusterCfg.Name = objName
 	return &clusterCfg, nil
 }
@@ -277,4 +292,16 @@ func defaultKSConfig(ks *kubekeyapiv1alpha2.KubeSphere, version string) error {
 		return errors.New(fmt.Sprintf("Unsupported KubeSphere version: %s", version))
 	}
 	return nil
+}
+
+// normalizedBuildVersion used to returns normalized build version (with "v" prefix if needed)
+// If input doesn't match known version pattern, returns empty string.
+func normalizedBuildVersion(version string) string {
+	if kubeReleaseRegex.MatchString(version) {
+		if strings.HasPrefix(version, "v") {
+			return version
+		}
+		return "v" + version
+	}
+	return ""
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
This makes kubekey more convenient to use and improves the user experience
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubekey/issues/1365

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Now, we can use both "1.23.6" and "v1.23.6" to create clusters.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
