### PR TITLE
feat: add artifact import for phase run

### DIFF
--- a/cmd/ctl/alpha/artifact.go
+++ b/cmd/ctl/alpha/artifact.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"errors"
+
+	"github.com/kubesphere/kubekey/cmd/ctl/options"
+	"github.com/kubesphere/kubekey/cmd/ctl/util"
+	"github.com/kubesphere/kubekey/pkg/alpha"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/spf13/cobra"
+)
+
+type ArtifactImportOptions struct {
+	CommonOptions *options.CommonOptions
+	Artifact      string
+}
+
+func NewArtifactImportOptions() *ArtifactImportOptions {
+	return &ArtifactImportOptions{
+		CommonOptions: options.NewCommonOptions(),
+	}
+}
+
+// NewCmdArtifactImport creates a new artifact import command
+func NewCmdArtifactImport() *cobra.Command {
+	o := NewArtifactImportOptions()
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import a KubeKey offline installation package",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Validate(args))
+			util.CheckErr(o.Run())
+		},
+	}
+
+	o.CommonOptions.AddCommonFlag(cmd)
+	o.AddFlags(cmd)
+	return cmd
+}
+
+func (o *ArtifactImportOptions) Run() error {
+	arg := common.Argument{
+		Debug:    o.CommonOptions.Verbose,
+		Artifact: o.Artifact,
+	}
+	return alpha.ArtifactImport(arg)
+}
+
+func (o *ArtifactImportOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Artifact, "artifact", "a", "", "Path to a artifact gzip")
+}
+
+func (o *ArtifactImportOptions) Validate(_ []string) error {
+	if o.Artifact == "" {
+		return errors.New("artifact path can not be empty")
+	}
+	return nil
+}

--- a/cmd/ctl/artifact/artifact.go
+++ b/cmd/ctl/artifact/artifact.go
@@ -17,6 +17,7 @@
 package artifact
 
 import (
+	"github.com/kubesphere/kubekey/cmd/ctl/alpha"
 	"github.com/kubesphere/kubekey/cmd/ctl/artifact/images"
 	"github.com/kubesphere/kubekey/cmd/ctl/options"
 	"github.com/spf13/cobra"
@@ -44,5 +45,6 @@ func NewCmdArtifact() *cobra.Command {
 
 	cmd.AddCommand(NewCmdArtifactExport())
 	cmd.AddCommand(images.NewCmdArtifactImages())
+	cmd.AddCommand(alpha.NewCmdArtifactImport())
 	return cmd
 }

--- a/cmd/ctl/root.go
+++ b/cmd/ctl/root.go
@@ -18,6 +18,12 @@ package ctl
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+
 	"github.com/kubesphere/kubekey/cmd/ctl/add"
 	"github.com/kubesphere/kubekey/cmd/ctl/artifact"
 	"github.com/kubesphere/kubekey/cmd/ctl/cert"
@@ -30,11 +36,6 @@ import (
 	"github.com/kubesphere/kubekey/cmd/ctl/upgrade"
 	"github.com/kubesphere/kubekey/cmd/ctl/version"
 	"github.com/spf13/cobra"
-	"os"
-	"os/exec"
-	"runtime"
-	"strings"
-	"syscall"
 )
 
 type KubeKeyOptions struct {

--- a/cmd/ctl/upgrade/phase.go
+++ b/cmd/ctl/upgrade/phase.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package upgrade
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewPhaseCommand() *cobra.Command {
+	cmds := &cobra.Command{
+		Use:   "phase",
+		Short: "KubeKey upgrade phase",
+		Long:  `This is the upgrade phase run cmd`,
+	}
+	return cmds
+}

--- a/cmd/ctl/upgrade/upgrade.go
+++ b/cmd/ctl/upgrade/upgrade.go
@@ -18,6 +18,8 @@ package upgrade
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/kubesphere/kubekey/cmd/ctl/options"
 	"github.com/kubesphere/kubekey/cmd/ctl/util"
 	"github.com/kubesphere/kubekey/pkg/common"
@@ -25,7 +27,6 @@ import (
 	"github.com/kubesphere/kubekey/pkg/version/kubernetes"
 	"github.com/kubesphere/kubekey/pkg/version/kubesphere"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 type UpgradeOptions struct {
@@ -56,9 +57,10 @@ func NewCmdUpgrade() *cobra.Command {
 			util.CheckErr(o.Run())
 		},
 	}
-
 	o.CommonOptions.AddCommonFlag(cmd)
 	o.AddFlags(cmd)
+	cmd.AddCommand(NewPhaseCommand())
+
 	if err := completionSetting(cmd); err != nil {
 		panic(fmt.Sprintf("Got error with the completion setting"))
 	}

--- a/pkg/alpha/artifact.go
+++ b/pkg/alpha/artifact.go
@@ -1,0 +1,64 @@
+/*
+ Copyright 2021 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package alpha
+
+import (
+	"errors"
+
+	"github.com/kubesphere/kubekey/pkg/artifact"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/module"
+	"github.com/kubesphere/kubekey/pkg/core/pipeline"
+)
+
+func NewArtifactImportPipeline(runtime *common.KubeRuntime) error {
+
+	m := []module.Module{
+		&artifact.UnArchiveModule{},
+	}
+
+	p := pipeline.Pipeline{
+		Name:    "ArtifactImportPipeline",
+		Modules: m,
+		Runtime: runtime,
+	}
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ArtifactImport(args common.Argument) error {
+	var loaderType string
+
+	loaderType = common.AllInOne
+
+	runtime, err := common.NewKubeRuntime(loaderType, args)
+	if err != nil {
+		return err
+	}
+	switch runtime.Cluster.Kubernetes.Type {
+	case common.Kubernetes:
+		if err := NewArtifactImportPipeline(runtime); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported cluster kubernetes type")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
This pr is to divide the artifact import from origin pipelines, which can be an independent phase cmd for phase run functions to use.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1389

### Special notes for reviewers:
```
1. I think artifact import should independent from those pipelines which will have phase run functions, so I put it in the artifact cmds which just use a more cmd "import" to achieve it.
2. Now the "phase.go" has no more cmd, but it can make the next work easily add other phase run cmds. So I decide to add it in this pr. 

```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
It provide user to use  " artifact import -g gzip_name " to import the artifact if needed as one step of the phase run. 
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Usage:
  kk artifact import [flags]

Flags:
      --debug              Print detailed information
  -g, --gzip string        Path to a artifact gzip
  -h, --help               help for import
```
