### PR TITLE
fix: etcd backup service does not work

### DIFF
--- a/pkg/etcd/templates/backup_service.go
+++ b/pkg/etcd/templates/backup_service.go
@@ -1,0 +1,71 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package templates
+
+import (
+	"fmt"
+	"strconv"
+	"text/template"
+
+	"github.com/lithammer/dedent"
+)
+
+var (
+	// BackupETCDService defines the template of backup-etcd service for systemd.
+	BackupETCDService = template.Must(template.New("backup-etcd.service").Parse(
+		dedent.Dedent(`[Unit]
+Description=Backup ETCD
+[Service]
+Type=oneshot
+ExecStart={{ .ScriptPath }}
+    `)))
+
+	// BackupETCDTimer defines the template of backup-etcd timer for systemd.
+	BackupETCDTimer = template.Must(template.New("backup-etcd.timer").Parse(
+		dedent.Dedent(`[Unit]
+Description=Timer to backup ETCD
+[Timer]
+{{- if .OnCalendarStr }}
+OnCalendar={{ .OnCalendarStr }}
+{{- else }}
+OnCalendar=*-*-* *:*/30:00
+{{- end }}
+Unit=backup-etcd.service
+[Install]
+WantedBy=multi-user.target
+    `)))
+)
+
+func BackupTimeOnCalendar(period int) string {
+	var onCalendar string
+	if period <= 0 {
+		onCalendar = "*-*-* *:00/30:00"
+	} else if period < 60 {
+		onCalendar = fmt.Sprintf("*-*-* *:00/%d:00", period)
+	} else if period >= 60 && period < 1440 {
+		hour := strconv.Itoa(period / 60)
+		minute := strconv.Itoa(period % 60)
+		if period%60 == 0 {
+			onCalendar = fmt.Sprintf("*-*-* 00/%s:00:00", hour)
+		} else {
+			onCalendar = fmt.Sprintf("*-*-* 00/%s:%s:00", hour, minute)
+		}
+	} else {
+		onCalendar = "*-*-* 00:00:00"
+	}
+	return onCalendar
+}

--- a/pkg/etcd/templates/backup_service_test.go
+++ b/pkg/etcd/templates/backup_service_test.go
@@ -1,0 +1,52 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package templates
+
+import (
+	"testing"
+)
+
+func TestBackupTimeOnCalendar(t *testing.T) {
+	tests := []struct {
+		period int
+		want   string
+	}{
+		{
+			30,
+			"*-*-* *:00/30:00",
+		},
+		{
+			60,
+			"*-*-* 00/1:00:00",
+		},
+		{
+			70,
+			"*-*-* 00/1:10:00",
+		},
+		{
+			1500,
+			"*-*-* 00:00:00",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			if got := BackupTimeOnCalendar(tt.period); got != tt.want {
+				t.Errorf("BackupTimeOnCalendar() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Fix: the old etcd backup service does not work.
This PR uses the `timer` that is a unit of `systemd` to run a backup script regularly.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
