### PR TITLE
feat: image pull of upgrade phase

### DIFF
--- a/cmd/ctl/alpha/artifact.go
+++ b/cmd/ctl/alpha/artifact.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/kubesphere/kubekey/cmd/ctl/options"
 	"github.com/kubesphere/kubekey/cmd/ctl/util"
-	"github.com/kubesphere/kubekey/pkg/alpha"
+	"github.com/kubesphere/kubekey/pkg/alpha/artifact"
 	"github.com/kubesphere/kubekey/pkg/common"
 	"github.com/spf13/cobra"
 )
@@ -59,7 +59,7 @@ func (o *ArtifactImportOptions) Run() error {
 		Debug:    o.CommonOptions.Verbose,
 		Artifact: o.Artifact,
 	}
-	return alpha.ArtifactImport(arg)
+	return artifact.ArtifactImport(arg)
 }
 
 func (o *ArtifactImportOptions) AddFlags(cmd *cobra.Command) {

--- a/cmd/ctl/alpha/binary.go
+++ b/cmd/ctl/alpha/binary.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"fmt"
+
+	"github.com/kubesphere/kubekey/cmd/ctl/options"
+	"github.com/kubesphere/kubekey/cmd/ctl/util"
+	"github.com/kubesphere/kubekey/pkg/alpha/binary"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/version/kubernetes"
+	"github.com/spf13/cobra"
+)
+
+type UpgradeBinaryOptions struct {
+	CommonOptions  *options.CommonOptions
+	ClusterCfgFile string
+	Kubernetes     string
+	DownloadCmd    string
+}
+
+func NewUpgradeBinaryOptions() *UpgradeBinaryOptions {
+	return &UpgradeBinaryOptions{
+		CommonOptions: options.NewCommonOptions(),
+	}
+}
+
+// NewCmdUpgradeBinary creates a new artifact import command
+func NewCmdUpgradeBinary() *cobra.Command {
+	o := NewUpgradeBinaryOptions()
+	cmd := &cobra.Command{
+		Use:   "binary",
+		Short: "download the binary and synchronize kubernetes binaries",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Run())
+		},
+	}
+
+	o.CommonOptions.AddCommonFlag(cmd)
+	o.AddFlags(cmd)
+	if err := completionSetting(cmd); err != nil {
+		panic(fmt.Sprintf("Got error with the completion setting"))
+	}
+	return cmd
+}
+
+func (o *UpgradeBinaryOptions) Run() error {
+	arg := common.Argument{
+		FilePath:          o.ClusterCfgFile,
+		KubernetesVersion: o.Kubernetes,
+		Debug:             o.CommonOptions.Verbose,
+	}
+	return binary.UpgradeBinary(arg, o.DownloadCmd)
+}
+
+func (o *UpgradeBinaryOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
+	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", "", "Specify a supported version of kubernetes")
+	cmd.Flags().StringVarP(&o.DownloadCmd, "download-cmd", "", "curl -L -o %s %s",
+		`The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL`)
+
+}
+
+func completionSetting(cmd *cobra.Command) (err error) {
+	err = cmd.RegisterFlagCompletionFunc("with-kubernetes", func(cmd *cobra.Command, args []string, toComplete string) (
+		strings []string, directive cobra.ShellCompDirective) {
+		return kubernetes.SupportedK8sVersionList(), cobra.ShellCompDirectiveNoFileComp
+	})
+	return
+}

--- a/cmd/ctl/alpha/images.go
+++ b/cmd/ctl/alpha/images.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"fmt"
+
+	"github.com/kubesphere/kubekey/cmd/ctl/options"
+	"github.com/kubesphere/kubekey/cmd/ctl/util"
+	"github.com/kubesphere/kubekey/pkg/alpha/images"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/spf13/cobra"
+)
+
+type UpgradeImagesOptions struct {
+	CommonOptions  *options.CommonOptions
+	ClusterCfgFile string
+	Kubernetes     string
+	DownloadCmd    string
+}
+
+func NewUpgradeImagesOptions() *UpgradeImagesOptions {
+	return &UpgradeImagesOptions{
+		CommonOptions: options.NewCommonOptions(),
+	}
+}
+
+// NewCmdUpgrade creates a new upgrade command
+func NewCmdUpgradeImages() *cobra.Command {
+	o := NewUpgradeImagesOptions()
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "pull the images before upgrading your cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Run())
+		},
+	}
+	o.CommonOptions.AddCommonFlag(cmd)
+	o.AddFlags(cmd)
+
+	if err := completionSetting(cmd); err != nil {
+		panic(fmt.Sprintf("Got error with the completion setting"))
+	}
+	return cmd
+}
+
+func (o *UpgradeImagesOptions) Run() error {
+	arg := common.Argument{
+		FilePath:          o.ClusterCfgFile,
+		KubernetesVersion: o.Kubernetes,
+		Debug:             o.CommonOptions.Verbose,
+	}
+	return images.UpgradeImages(arg, o.DownloadCmd)
+}
+
+func (o *UpgradeImagesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
+	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", "", "Specify a supported version of kubernetes")
+	cmd.Flags().StringVarP(&o.DownloadCmd, "download-cmd", "", "curl -L -o %s %s",
+		`The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL`)
+}

--- a/cmd/ctl/upgrade/phase.go
+++ b/cmd/ctl/upgrade/phase.go
@@ -16,6 +16,7 @@ limitations under the License.
 package upgrade
 
 import (
+	"github.com/kubesphere/kubekey/cmd/ctl/alpha"
 	"github.com/spf13/cobra"
 )
 
@@ -25,5 +26,6 @@ func NewPhaseCommand() *cobra.Command {
 		Short: "KubeKey upgrade phase",
 		Long:  `This is the upgrade phase run cmd`,
 	}
+	cmds.AddCommand(alpha.NewCmdUpgradeBinary())
 	return cmds
 }

--- a/cmd/ctl/upgrade/phase.go
+++ b/cmd/ctl/upgrade/phase.go
@@ -27,5 +27,6 @@ func NewPhaseCommand() *cobra.Command {
 		Long:  `This is the upgrade phase run cmd`,
 	}
 	cmds.AddCommand(alpha.NewCmdUpgradeBinary())
+	cmds.AddCommand(alpha.NewCmdUpgradeImages())
 	return cmds
 }

--- a/pkg/alpha/artifact/artifact.go
+++ b/pkg/alpha/artifact/artifact.go
@@ -14,7 +14,7 @@
  limitations under the License.
 */
 
-package alpha
+package artifact
 
 import (
 	"errors"

--- a/pkg/alpha/binary/binary.go
+++ b/pkg/alpha/binary/binary.go
@@ -1,0 +1,76 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package binary
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kubesphere/kubekey/pkg/alpha/precheck"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/module"
+	"github.com/kubesphere/kubekey/pkg/core/pipeline"
+)
+
+func NewUpgradeBinaryPipeline(runtime *common.KubeRuntime) error {
+
+	m := []module.Module{
+		&precheck.UprgadePreCheckModule{},
+		&UpgradeBinaryModule{},
+	}
+
+	p := pipeline.Pipeline{
+		Name:    "UpgradeBinaryPipeline",
+		Modules: m,
+		Runtime: runtime,
+	}
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpgradeBinary(args common.Argument, downloadCmd string) error {
+	args.DownloadCommand = func(path, url string) string {
+		// this is an extension point for downloading tools, for example users can set the timeout, proxy or retry under
+		// some poor network environment. Or users even can choose another cli, it might be wget.
+		// perhaps we should have a build-in download function instead of totally rely on the external one
+		return fmt.Sprintf(downloadCmd, path, url)
+	}
+	var loaderType string
+
+	if args.FilePath != "" {
+		loaderType = common.File
+	} else {
+		loaderType = common.AllInOne
+	}
+
+	runtime, err := common.NewKubeRuntime(loaderType, args)
+	if err != nil {
+		return err
+	}
+	switch runtime.Cluster.Kubernetes.Type {
+	case common.Kubernetes:
+		if err := NewUpgradeBinaryPipeline(runtime); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported cluster kubernetes type")
+	}
+
+	return nil
+}

--- a/pkg/alpha/binary/modules.go
+++ b/pkg/alpha/binary/modules.go
@@ -1,0 +1,55 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package binary
+
+import (
+	"github.com/kubesphere/kubekey/pkg/binaries"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/task"
+	"github.com/kubesphere/kubekey/pkg/kubernetes"
+)
+
+type UpgradeBinaryModule struct {
+	common.KubeModule
+}
+
+func (p *UpgradeBinaryModule) Init() {
+	p.Name = "UpgradeBinaryModule"
+	p.Desc = "Download the binary and synchronize kubernetes binaries"
+
+	download := &task.LocalTask{
+		Name:    "DownloadBinaries",
+		Desc:    "Download installation binaries",
+		Prepare: new(kubernetes.NotEqualPlanVersion),
+		Action:  new(binaries.Download),
+	}
+
+	syncBinary := &task.RemoteTask{
+		Name:     "SyncKubeBinary",
+		Desc:     "Synchronize kubernetes binaries",
+		Hosts:    p.Runtime.GetHostsByRole(common.K8s),
+		Prepare:  new(kubernetes.NotEqualPlanVersion),
+		Action:   new(kubernetes.SyncKubeBinary),
+		Parallel: true,
+		Retry:    2,
+	}
+
+	p.Tasks = []task.Interface{
+		download,
+		syncBinary,
+	}
+}

--- a/pkg/alpha/images/images.go
+++ b/pkg/alpha/images/images.go
@@ -1,0 +1,76 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package images
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kubesphere/kubekey/pkg/alpha/precheck"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/module"
+	"github.com/kubesphere/kubekey/pkg/core/pipeline"
+)
+
+func NewUpgradeImagesPipeline(runtime *common.KubeRuntime) error {
+
+	m := []module.Module{
+		&precheck.UprgadePreCheckModule{},
+		&UpgradeImagesModule{},
+	}
+
+	p := pipeline.Pipeline{
+		Name:    "UpgradeImagesPipeline",
+		Modules: m,
+		Runtime: runtime,
+	}
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpgradeImages(args common.Argument, downloadCmd string) error {
+	args.DownloadCommand = func(path, url string) string {
+		// this is an extension point for downloading tools, for example users can set the timeout, proxy or retry under
+		// some poor network environment. Or users even can choose another cli, it might be wget.
+		// perhaps we should have a build-in download function instead of totally rely on the external one
+		return fmt.Sprintf(downloadCmd, path, url)
+	}
+	var loaderType string
+
+	if args.FilePath != "" {
+		loaderType = common.File
+	} else {
+		loaderType = common.AllInOne
+	}
+
+	runtime, err := common.NewKubeRuntime(loaderType, args)
+	if err != nil {
+		return err
+	}
+	switch runtime.Cluster.Kubernetes.Type {
+	case common.Kubernetes:
+		if err := NewUpgradeImagesPipeline(runtime); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported cluster kubernetes type")
+	}
+
+	return nil
+}

--- a/pkg/alpha/images/modules.go
+++ b/pkg/alpha/images/modules.go
@@ -1,0 +1,46 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package images
+
+import (
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/task"
+	"github.com/kubesphere/kubekey/pkg/images"
+	"github.com/kubesphere/kubekey/pkg/kubernetes"
+)
+
+type UpgradeImagesModule struct {
+	common.KubeModule
+}
+
+func (p *UpgradeImagesModule) Init() {
+	p.Name = "UpgradeImagesModule"
+	p.Desc = "pull the images that cluster need"
+
+	pull := &task.RemoteTask{
+		Name:     "PullImages",
+		Desc:     "Start to pull images on all nodes",
+		Hosts:    p.Runtime.GetHostsByRole(common.K8s),
+		Prepare:  new(kubernetes.NotEqualPlanVersion),
+		Action:   new(images.PullImage),
+		Parallel: true,
+	}
+
+	p.Tasks = []task.Interface{
+		pull,
+	}
+}

--- a/pkg/alpha/precheck/modules.go
+++ b/pkg/alpha/precheck/modules.go
@@ -56,27 +56,27 @@ func (c *UprgadePreCheckModule) Init() {
 	}
 
 	calculateMinK8sVersion := &task.LocalTask{
-		Name:     "CalculateMinK8sVersion",
-		Desc:     "Calculate min Kubernetes version",
-		Action:   new(precheck.CalculateMinK8sVersion),
+		Name:   "CalculateMinK8sVersion",
+		Desc:   "Calculate min Kubernetes version",
+		Action: new(precheck.CalculateMinK8sVersion),
 	}
 
 	calculateMaxK8sVersion := &task.LocalTask{
-		Name:     "CalculateMaxK8sVersion",
-		Desc:     "Calculate max Kubernetes version",
-		Action:   new(CalculateMaxK8sVersion),
+		Name:   "CalculateMaxK8sVersion",
+		Desc:   "Calculate max Kubernetes version",
+		Action: new(CalculateMaxK8sVersion),
 	}
 
 	checkDesiredK8sVersion := &task.LocalTask{
-		Name:     "CheckDesiredK8sVersion",
-		Desc:     "Check desired Kubernetes version",
-		Action:   new(precheck.CheckDesiredK8sVersion),
+		Name:   "CheckDesiredK8sVersion",
+		Desc:   "Check desired Kubernetes version",
+		Action: new(precheck.CheckDesiredK8sVersion),
 	}
 
 	checkUpgradeK8sVersion := &task.LocalTask{
-		Name:     "checkUpgradeK8sVersion",
-		Desc:     "Check the Kubernetes version can correctly upgrade",
-		Action:   new(CheckUpgradeK8sVersion),
+		Name:   "checkUpgradeK8sVersion",
+		Desc:   "Check the Kubernetes version can correctly upgrade",
+		Action: new(CheckUpgradeK8sVersion),
 	}
 
 	ksVersionCheck := &task.RemoteTask{

--- a/pkg/alpha/precheck/modules.go
+++ b/pkg/alpha/precheck/modules.go
@@ -1,0 +1,124 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package precheck
+
+import (
+	"github.com/kubesphere/kubekey/pkg/bootstrap/precheck"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/prepare"
+	"github.com/kubesphere/kubekey/pkg/core/task"
+)
+
+type UprgadePreCheckModule struct {
+	common.KubeModule
+}
+
+func (c *UprgadePreCheckModule) Init() {
+	c.Name = "UprgadePreCheckModule"
+	c.Desc = "Do pre-check on for upgrade phase"
+
+	nodePreCheck := &task.RemoteTask{
+		Name:     "NodePreCheck",
+		Desc:     "A pre-check on nodes",
+		Hosts:    c.Runtime.GetAllHosts(),
+		Action:   new(precheck.NodePreCheck),
+		Parallel: true,
+	}
+
+	getKubeConfig := &task.RemoteTask{
+		Name:     "GetKubeConfig",
+		Desc:     "Get KubeConfig file",
+		Hosts:    c.Runtime.GetHostsByRole(common.Master),
+		Prepare:  new(common.OnlyFirstMaster),
+		Action:   new(precheck.GetKubeConfig),
+		Parallel: true,
+	}
+
+	getAllNodesK8sVersion := &task.RemoteTask{
+		Name:     "GetAllNodesK8sVersion",
+		Desc:     "Get all nodes Kubernetes version",
+		Hosts:    c.Runtime.GetHostsByRole(common.K8s),
+		Action:   new(precheck.GetAllNodesK8sVersion),
+		Parallel: true,
+	}
+
+	calculateMinK8sVersion := &task.LocalTask{
+		Name:     "CalculateMinK8sVersion",
+		Desc:     "Calculate min Kubernetes version",
+		Action:   new(precheck.CalculateMinK8sVersion),
+	}
+
+	calculateMaxK8sVersion := &task.LocalTask{
+		Name:     "CalculateMaxK8sVersion",
+		Desc:     "Calculate max Kubernetes version",
+		Action:   new(CalculateMaxK8sVersion),
+	}
+
+	checkDesiredK8sVersion := &task.LocalTask{
+		Name:     "CheckDesiredK8sVersion",
+		Desc:     "Check desired Kubernetes version",
+		Action:   new(precheck.CheckDesiredK8sVersion),
+	}
+
+	checkUpgradeK8sVersion := &task.LocalTask{
+		Name:     "checkUpgradeK8sVersion",
+		Desc:     "Check the Kubernetes version can correctly upgrade",
+		Action:   new(CheckUpgradeK8sVersion),
+	}
+
+	ksVersionCheck := &task.RemoteTask{
+		Name:     "KsVersionCheck",
+		Desc:     "Check KubeSphere version",
+		Hosts:    c.Runtime.GetHostsByRole(common.Master),
+		Prepare:  new(common.OnlyFirstMaster),
+		Action:   new(precheck.KsVersionCheck),
+		Parallel: true,
+	}
+
+	dependencyCheck := &task.RemoteTask{
+		Name:  "DependencyCheck",
+		Desc:  "Check dependency matrix for KubeSphere and Kubernetes",
+		Hosts: c.Runtime.GetHostsByRole(common.Master),
+		Prepare: &prepare.PrepareCollection{
+			new(common.OnlyFirstMaster),
+			new(precheck.KubeSphereExist),
+		},
+		Action:   new(precheck.DependencyCheck),
+		Parallel: true,
+	}
+
+	getKubernetesNodesStatus := &task.RemoteTask{
+		Name:     "GetKubernetesNodesStatus",
+		Desc:     "Get kubernetes nodes status",
+		Hosts:    c.Runtime.GetHostsByRole(common.Master),
+		Prepare:  new(common.OnlyFirstMaster),
+		Action:   new(precheck.GetKubernetesNodesStatus),
+		Parallel: true,
+	}
+
+	c.Tasks = []task.Interface{
+		nodePreCheck,
+		getKubeConfig,
+		getAllNodesK8sVersion,
+		calculateMinK8sVersion,
+		calculateMaxK8sVersion,
+		checkDesiredK8sVersion,
+		checkUpgradeK8sVersion,
+		ksVersionCheck,
+		dependencyCheck,
+		getKubernetesNodesStatus,
+	}
+}

--- a/pkg/alpha/precheck/task.go
+++ b/pkg/alpha/precheck/task.go
@@ -1,0 +1,103 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package precheck
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/connector"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+)
+
+type CheckUpgradeK8sVersion struct {
+	common.KubeAction
+}
+
+func compareVersionsForUpgrade(currentVersion *versionutil.Version, currentMaxVersion *versionutil.Version, desiredVersion *versionutil.Version) error {
+	if desiredVersion.LessThan(currentMaxVersion) {
+		return errors.New("desired version to upgrade is less than the max version in cluster")
+	}
+	if desiredVersion.Major()-currentVersion.Major() != 0 || desiredVersion.Minor()-currentVersion.Minor() > 1 {
+		return errors.New("skipping MINOR versions when upgrading is unsupported")
+	}
+	return nil
+}
+
+func (k *CheckUpgradeK8sVersion) Execute(_ connector.Runtime) error {
+	minK8sVersion, ok := k.PipelineCache.GetMustString(common.K8sVersion)
+	if !ok {
+		return errors.New("get current k8s version failed by pipeline cache")
+	}
+	minVersionObj, err := versionutil.ParseSemantic(minK8sVersion)
+	if err != nil {
+		return errors.Wrap(err, "parse min k8s version failed")
+	}
+
+	maxK8sVersion, ok := k.PipelineCache.GetMustString(common.MaxK8sVersion)
+	if !ok {
+		return errors.New("get max k8s version failed by pipeline cache")
+	}
+	maxVersionObj, err := versionutil.ParseSemantic(maxK8sVersion)
+	if err != nil {
+		return errors.Wrap(err, "parse max k8s version failed")
+	}
+
+	desiredVersion, ok := k.PipelineCache.GetMustString(common.DesiredK8sVersion)
+	if !ok {
+		return errors.New("get desired k8s version failed by pipeline cache")
+	}
+	desiredVersionObj, err := versionutil.ParseSemantic(desiredVersion)
+	if err != nil {
+		return errors.Wrap(err, "parse desired k8s version failed")
+	}
+
+	if err := compareVersionsForUpgrade(minVersionObj, maxVersionObj, desiredVersionObj); err != nil {
+		return err
+	}
+
+	k.PipelineCache.Set(common.PlanK8sVersion, desiredVersion)
+	return nil
+}
+
+type CalculateMaxK8sVersion struct {
+	common.KubeAction
+}
+
+func (g *CalculateMaxK8sVersion) Execute(runtime connector.Runtime) error {
+	versionList := make([]*versionutil.Version, 0, len(runtime.GetHostsByRole(common.K8s)))
+	for _, host := range runtime.GetHostsByRole(common.K8s) {
+		version, ok := host.GetCache().GetMustString(common.NodeK8sVersion)
+		if !ok {
+			return errors.Errorf("get node %s Kubernetes version failed by host cache", host.GetName())
+		}
+		if versionObj, err := versionutil.ParseSemantic(version); err != nil {
+			return errors.Wrap(err, "parse node version failed")
+		} else {
+			versionList = append(versionList, versionObj)
+		}
+	}
+
+	maxVersion := versionList[0]
+	for _, version := range versionList {
+		if maxVersion.LessThan(version) {
+			maxVersion = version
+		}
+	}
+	g.PipelineCache.Set(common.MaxK8sVersion, fmt.Sprintf("v%s", maxVersion))
+	return nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -70,6 +70,7 @@ const (
 	// PreCheckModule
 	NodePreCheck           = "nodePreCheck"
 	K8sVersion             = "k8sVersion"        // current k8s version
+	MaxK8sVersion          = "maxK8sVersion"     // max k8s version of nodes
 	KubeSphereVersion      = "kubeSphereVersion" // current KubeSphere version
 	ClusterNodeStatus      = "clusterNodeStatus"
 	ClusterNodeCRIRuntimes = "ClusterNodeCRIRuntimes"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1423 

### Special notes for reviewers:
```
This should be approval after the pr #1418 has been approval. 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
It provide user to use  "upgrade phase images " to pull the images as one step of the upgrade phase run. 

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Usage:
  kk upgrade phase images [flags]

Flags:
      --debug                    Print detailed information
      --download-cmd string      The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL (default "curl -L -o %s %s")
  -f, --filename string          Path to a configuration file
  -h, --help                     help for images
      --ignore-err               Ignore the error message, remove the host which reported error and force to continue
      --in-cluster               Running inside the cluster
      --namespace string         KubeKey namespace to use (default "kubekey-system")
      --with-kubernetes string   Specify a supported version of kubernetes
```
