### PR TITLE
feat: add images pull cmd for upgrade phase

### DIFF
--- a/cmd/ctl/alpha/images.go
+++ b/cmd/ctl/alpha/images.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"fmt"
+
+	"github.com/kubesphere/kubekey/cmd/ctl/options"
+	"github.com/kubesphere/kubekey/cmd/ctl/util"
+	"github.com/kubesphere/kubekey/pkg/alpha/images"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/spf13/cobra"
+)
+
+type UpgradeImagesOptions struct {
+	CommonOptions  *options.CommonOptions
+	ClusterCfgFile string
+	Kubernetes     string
+	DownloadCmd    string
+}
+
+func NewUpgradeImagesOptions() *UpgradeImagesOptions {
+	return &UpgradeImagesOptions{
+		CommonOptions: options.NewCommonOptions(),
+	}
+}
+
+// NewCmdUpgrade creates a new upgrade command
+func NewCmdUpgradeImages() *cobra.Command {
+	o := NewUpgradeImagesOptions()
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "pull the images before upgrading your cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Run())
+		},
+	}
+	o.CommonOptions.AddCommonFlag(cmd)
+	o.AddFlags(cmd)
+
+	if err := completionSetting(cmd); err != nil {
+		panic(fmt.Sprintf("Got error with the completion setting"))
+	}
+	return cmd
+}
+
+func (o *UpgradeImagesOptions) Run() error {
+	arg := common.Argument{
+		FilePath:          o.ClusterCfgFile,
+		KubernetesVersion: o.Kubernetes,
+		Debug:             o.CommonOptions.Verbose,
+	}
+	return images.UpgradeImages(arg, o.DownloadCmd)
+}
+
+func (o *UpgradeImagesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
+	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", "", "Specify a supported version of kubernetes")
+	cmd.Flags().StringVarP(&o.DownloadCmd, "download-cmd", "", "curl -L -o %s %s",
+		`The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL`)
+}

--- a/cmd/ctl/upgrade/phase.go
+++ b/cmd/ctl/upgrade/phase.go
@@ -27,5 +27,6 @@ func NewPhaseCommand() *cobra.Command {
 		Long:  `This is the upgrade phase run cmd`,
 	}
 	cmds.AddCommand(alpha.NewCmdUpgradeBinary())
+	cmds.AddCommand(alpha.NewCmdUpgradeImages())
 	return cmds
 }

--- a/pkg/alpha/images/images.go
+++ b/pkg/alpha/images/images.go
@@ -1,0 +1,76 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package images
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kubesphere/kubekey/pkg/alpha/precheck"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/module"
+	"github.com/kubesphere/kubekey/pkg/core/pipeline"
+)
+
+func NewUpgradeImagesPipeline(runtime *common.KubeRuntime) error {
+
+	m := []module.Module{
+		&precheck.UprgadePreCheckModule{},
+		&UpgradeImagesModule{},
+	}
+
+	p := pipeline.Pipeline{
+		Name:    "UpgradeImagesPipeline",
+		Modules: m,
+		Runtime: runtime,
+	}
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpgradeImages(args common.Argument, downloadCmd string) error {
+	args.DownloadCommand = func(path, url string) string {
+		// this is an extension point for downloading tools, for example users can set the timeout, proxy or retry under
+		// some poor network environment. Or users even can choose another cli, it might be wget.
+		// perhaps we should have a build-in download function instead of totally rely on the external one
+		return fmt.Sprintf(downloadCmd, path, url)
+	}
+	var loaderType string
+
+	if args.FilePath != "" {
+		loaderType = common.File
+	} else {
+		loaderType = common.AllInOne
+	}
+
+	runtime, err := common.NewKubeRuntime(loaderType, args)
+	if err != nil {
+		return err
+	}
+	switch runtime.Cluster.Kubernetes.Type {
+	case common.Kubernetes:
+		if err := NewUpgradeImagesPipeline(runtime); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported cluster kubernetes type")
+	}
+
+	return nil
+}

--- a/pkg/alpha/images/modules.go
+++ b/pkg/alpha/images/modules.go
@@ -1,0 +1,46 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package images
+
+import (
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/task"
+	"github.com/kubesphere/kubekey/pkg/images"
+	"github.com/kubesphere/kubekey/pkg/kubernetes"
+)
+
+type UpgradeImagesModule struct {
+	common.KubeModule
+}
+
+func (p *UpgradeImagesModule) Init() {
+	p.Name = "UpgradeImagesModule"
+	p.Desc = "pull the images that cluster need"
+
+	pull := &task.RemoteTask{
+		Name:     "PullImages",
+		Desc:     "Start to pull images on all nodes",
+		Hosts:    p.Runtime.GetHostsByRole(common.K8s),
+		Prepare:  new(kubernetes.NotEqualPlanVersion),
+		Action:   new(images.PullImage),
+		Parallel: true,
+	}
+
+	p.Tasks = []task.Interface{
+		pull,
+	}
+}

--- a/pkg/alpha/precheck/modules.go
+++ b/pkg/alpha/precheck/modules.go
@@ -56,27 +56,27 @@ func (c *UprgadePreCheckModule) Init() {
 	}
 
 	calculateMinK8sVersion := &task.LocalTask{
-		Name:     "CalculateMinK8sVersion",
-		Desc:     "Calculate min Kubernetes version",
-		Action:   new(precheck.CalculateMinK8sVersion),
+		Name:   "CalculateMinK8sVersion",
+		Desc:   "Calculate min Kubernetes version",
+		Action: new(precheck.CalculateMinK8sVersion),
 	}
 
 	calculateMaxK8sVersion := &task.LocalTask{
-		Name:     "CalculateMaxK8sVersion",
-		Desc:     "Calculate max Kubernetes version",
-		Action:   new(CalculateMaxK8sVersion),
+		Name:   "CalculateMaxK8sVersion",
+		Desc:   "Calculate max Kubernetes version",
+		Action: new(CalculateMaxK8sVersion),
 	}
 
 	checkDesiredK8sVersion := &task.LocalTask{
-		Name:     "CheckDesiredK8sVersion",
-		Desc:     "Check desired Kubernetes version",
-		Action:   new(precheck.CheckDesiredK8sVersion),
+		Name:   "CheckDesiredK8sVersion",
+		Desc:   "Check desired Kubernetes version",
+		Action: new(precheck.CheckDesiredK8sVersion),
 	}
 
 	checkUpgradeK8sVersion := &task.LocalTask{
-		Name:     "checkUpgradeK8sVersion",
-		Desc:     "Check the Kubernetes version can correctly upgrade",
-		Action:   new(CheckUpgradeK8sVersion),
+		Name:   "checkUpgradeK8sVersion",
+		Desc:   "Check the Kubernetes version can correctly upgrade",
+		Action: new(CheckUpgradeK8sVersion),
 	}
 
 	ksVersionCheck := &task.RemoteTask{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1423 

### Special notes for reviewers:
```
This should be approval after the pr #1418 has been approval. 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
It provide user to use  "upgrade phase images " to pull the images as one step of the upgrade phase run. 

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Usage:
  kk upgrade phase images [flags]

Flags:
      --debug                    Print detailed information
      --download-cmd string      The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL (default "curl -L -o %s %s")
  -f, --filename string          Path to a configuration file
  -h, --help                     help for images
      --ignore-err               Ignore the error message, remove the host which reported error and force to continue
      --in-cluster               Running inside the cluster
      --namespace string         KubeKey namespace to use (default "kubekey-system")
      --with-kubernetes string   Specify a supported version of kubernetes
```
