### PR TITLE
fix: delete k3s cluster with kubenetes version

### DIFF
--- a/cmd/ctl/delete/delete_cluster.go
+++ b/cmd/ctl/delete/delete_cluster.go
@@ -27,6 +27,7 @@ import (
 type DeleteClusterOptions struct {
 	CommonOptions  *options.CommonOptions
 	ClusterCfgFile string
+	Kubernetes     string
 }
 
 func NewDeleteClusterOptions() *DeleteClusterOptions {
@@ -53,12 +54,14 @@ func NewCmdDeleteCluster() *cobra.Command {
 
 func (o *DeleteClusterOptions) Run() error {
 	arg := common.Argument{
-		FilePath: o.ClusterCfgFile,
-		Debug:    o.CommonOptions.Verbose,
+		FilePath:          o.ClusterCfgFile,
+		Debug:             o.CommonOptions.Verbose,
+		KubernetesVersion: o.Kubernetes,
 	}
 	return pipelines.DeleteCluster(arg)
 }
 
 func (o *DeleteClusterOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
+	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", "", "Specify a supported version of kubernetes")
 }


### PR DESCRIPTION
fix issue: https://github.com/kubesphere/kubekey/issues/1148

let below cmd works
```
./kk delete cluster --with-kubenetes v1.21.6-k3s
```

Signed-off-by: Deshi Xiao <xiaods@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
