### PR TITLE
feat: add master and worker nodes upgrade cmd

### DIFF
--- a/cmd/ctl/alpha/nodes.go
+++ b/cmd/ctl/alpha/nodes.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"fmt"
+
+	"github.com/kubesphere/kubekey/cmd/ctl/options"
+	"github.com/kubesphere/kubekey/cmd/ctl/util"
+	"github.com/kubesphere/kubekey/pkg/alpha/nodes"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/spf13/cobra"
+)
+
+type UpgradeNodesOptions struct {
+	CommonOptions  *options.CommonOptions
+	ClusterCfgFile string
+	Kubernetes     string
+	DownloadCmd    string
+}
+
+func NewUpgradeNodesOptions() *UpgradeNodesOptions {
+	return &UpgradeNodesOptions{
+		CommonOptions: options.NewCommonOptions(),
+	}
+}
+
+// NewCmdUpgrade creates a new upgrade command
+func NewCmdUpgradeNodes() *cobra.Command {
+	o := NewUpgradeNodesOptions()
+	cmd := &cobra.Command{
+		Use:   "nodes",
+		Short: "upgrade cluster on master nodes and worker nodes to the version you input",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Run())
+		},
+	}
+	o.CommonOptions.AddCommonFlag(cmd)
+	o.AddFlags(cmd)
+
+	if err := completionSetting(cmd); err != nil {
+		panic(fmt.Sprintf("Got error with the completion setting"))
+	}
+	return cmd
+}
+
+func (o *UpgradeNodesOptions) Run() error {
+	arg := common.Argument{
+		FilePath:          o.ClusterCfgFile,
+		KubernetesVersion: o.Kubernetes,
+		Debug:             o.CommonOptions.Verbose,
+	}
+	return nodes.UpgradeNodes(arg, o.DownloadCmd)
+}
+
+func (o *UpgradeNodesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
+	cmd.Flags().StringVarP(&o.Kubernetes, "with-kubernetes", "", "", "Specify a supported version of kubernetes")
+	cmd.Flags().StringVarP(&o.DownloadCmd, "download-cmd", "", "curl -L -o %s %s",
+		`The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL`)
+}

--- a/cmd/ctl/upgrade/phase.go
+++ b/cmd/ctl/upgrade/phase.go
@@ -26,7 +26,9 @@ func NewPhaseCommand() *cobra.Command {
 		Short: "KubeKey upgrade phase",
 		Long:  `This is the upgrade phase run cmd`,
 	}
+
 	cmds.AddCommand(alpha.NewCmdUpgradeBinary())
 	cmds.AddCommand(alpha.NewCmdUpgradeImages())
+	cmds.AddCommand(alpha.NewCmdUpgradeNodes())
 	return cmds
 }

--- a/pkg/alpha/nodes/modules.go
+++ b/pkg/alpha/nodes/modules.go
@@ -1,0 +1,81 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package nodes
+
+import (
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/prepare"
+	"github.com/kubesphere/kubekey/pkg/core/task"
+	"github.com/kubesphere/kubekey/pkg/kubernetes"
+)
+
+type UpgradeNodesModule struct {
+	common.KubeModule
+}
+
+func (p *UpgradeNodesModule) Init() {
+	p.Name = "UpgradeNodesModule"
+	p.Desc = "Upgrade cluster on all nodes"
+
+	upgradeKubeMaster := &task.RemoteTask{
+		Name:     "UpgradeClusterOnMaster",
+		Desc:     "Upgrade cluster on master",
+		Hosts:    p.Runtime.GetHostsByRole(common.Master),
+		Prepare:  new(kubernetes.NotEqualPlanVersion),
+		Action:   &kubernetes.UpgradeKubeMaster{ModuleName: p.Name},
+		Parallel: false,
+	}
+
+	cluster := kubernetes.NewKubernetesStatus()
+	p.PipelineCache.GetOrSet(common.ClusterStatus, cluster)
+
+	clusterStatus := &task.RemoteTask{
+		Name:     "GetClusterStatus",
+		Desc:     "Get kubernetes cluster status",
+		Hosts:    p.Runtime.GetHostsByRole(common.Master),
+		Prepare:  new(kubernetes.NotEqualPlanVersion),
+		Action:   new(kubernetes.GetClusterStatus),
+		Parallel: false,
+	}
+
+	upgradeNodes := &task.RemoteTask{
+		Name:  "UpgradeClusterOnWorker",
+		Desc:  "Upgrade cluster on worker",
+		Hosts: p.Runtime.GetHostsByRole(common.Worker),
+		Prepare: &prepare.PrepareCollection{
+			new(kubernetes.NotEqualPlanVersion),
+			new(common.OnlyWorker),
+		},
+		Action:   &kubernetes.UpgradeKubeWorker{ModuleName: p.Name},
+		Parallel: false,
+	}
+
+	reconfigureDNS := &task.RemoteTask{
+		Name:     "ReconfigureCoreDNS",
+		Desc:     "Reconfigure CoreDNS",
+		Hosts:    p.Runtime.GetHostsByRole(common.Master),
+		Action:   &kubernetes.ReconfigureDNS{ModuleName: p.Name},
+		Parallel: false,
+	}
+
+	p.Tasks = []task.Interface{
+		upgradeKubeMaster,
+		clusterStatus,
+		upgradeNodes,
+		reconfigureDNS,
+	}
+}

--- a/pkg/alpha/nodes/nodes.go
+++ b/pkg/alpha/nodes/nodes.go
@@ -1,0 +1,76 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package nodes
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kubesphere/kubekey/pkg/alpha/precheck"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/module"
+	"github.com/kubesphere/kubekey/pkg/core/pipeline"
+)
+
+func NewUpgradeNodesPipeline(runtime *common.KubeRuntime) error {
+
+	m := []module.Module{
+		&precheck.UprgadePreCheckModule{},
+		&UpgradeNodesModule{},
+	}
+
+	p := pipeline.Pipeline{
+		Name:    "UpgradeNodesPipeline",
+		Modules: m,
+		Runtime: runtime,
+	}
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpgradeNodes(args common.Argument, downloadCmd string) error {
+	args.DownloadCommand = func(path, url string) string {
+		// this is an extension point for downloading tools, for example users can set the timeout, proxy or retry under
+		// some poor network environment. Or users even can choose another cli, it might be wget.
+		// perhaps we should have a build-in download function instead of totally rely on the external one
+		return fmt.Sprintf(downloadCmd, path, url)
+	}
+	var loaderType string
+
+	if args.FilePath != "" {
+		loaderType = common.File
+	} else {
+		loaderType = common.AllInOne
+	}
+
+	runtime, err := common.NewKubeRuntime(loaderType, args)
+	if err != nil {
+		return err
+	}
+	switch runtime.Cluster.Kubernetes.Type {
+	case common.Kubernetes:
+		if err := NewUpgradeNodesPipeline(runtime); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported cluster kubernetes type")
+	}
+
+	return nil
+}

--- a/pkg/alpha/precheck/modules.go
+++ b/pkg/alpha/precheck/modules.go
@@ -51,7 +51,7 @@ func (c *UprgadePreCheckModule) Init() {
 		Name:     "GetAllNodesK8sVersion",
 		Desc:     "Get all nodes Kubernetes version",
 		Hosts:    c.Runtime.GetHostsByRole(common.K8s),
-		Action:   new(precheck.GetAllNodesK8sVersion),
+		Action:   new(GetAllNodesK8sVersion),
 		Parallel: true,
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1429

### Special notes for reviewers:
```
I change the getAllnodesK8sVersion of precheck modules, which just use in upgrade phase run. I can't confirm it have no problem.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
It provide user to use  "upgrade phase master " to upgrade master node as one step of the upgrade phase run. 
It provide user to use  "upgrade phase workers " to upgrade worker nodes  as one step of the upgrade phase run. 

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Usage:
  kk upgrade phase master [flags]

Flags:
      --debug                    Print detailed information
      --download-cmd string      The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL (default "curl -L -o %s %s")
  -f, --filename string          Path to a configuration file
  -h, --help                     help for master
      --ignore-err               Ignore the error message, remove the host which reported error and force to continue
      --in-cluster               Running inside the cluster
      --namespace string         KubeKey namespace to use (default "kubekey-system")
      --with-kubernetes string   Specify a supported version of kubernetes


Usage:
  kk upgrade phase workers [flags]

Flags:
      --debug                    Print detailed information
      --download-cmd string      The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL (default "curl -L -o %s %s")
  -f, --filename string          Path to a configuration file
  -h, --help                     help for workers
      --ignore-err               Ignore the error message, remove the host which reported error and force to continue
      --in-cluster               Running inside the cluster
      --namespace string         KubeKey namespace to use (default "kubekey-system")
      --with-kubernetes string   Specify a supported version of kubernetes
```
