### PR TITLE
feat: add upgrade kubesphere cmd

### DIFF
--- a/cmd/ctl/alpha/kubesphere.go
+++ b/cmd/ctl/alpha/kubesphere.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kubesphere/kubekey/cmd/ctl/options"
+	"github.com/kubesphere/kubekey/cmd/ctl/util"
+	alpha "github.com/kubesphere/kubekey/pkg/alpha/kubesphere"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/version/kubesphere"
+	"github.com/spf13/cobra"
+)
+
+type UpgradeKubeSphereOptions struct {
+	CommonOptions    *options.CommonOptions
+	ClusterCfgFile   string
+	EnableKubeSphere bool
+	KubeSphere       string
+}
+
+func NewUpgradeKubeSphereOptions() *UpgradeKubeSphereOptions {
+	return &UpgradeKubeSphereOptions{
+		CommonOptions: options.NewCommonOptions(),
+	}
+}
+
+// NewCmdUpgradeKubeSphere creates a new UpgradeKubeSphere command
+func NewCmdUpgradeKubeSphere() *cobra.Command {
+	o := NewUpgradeKubeSphereOptions()
+	cmd := &cobra.Command{
+		Use:   "kubesphere",
+		Short: "upgrade your kubesphere to a newer version with this command",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Complete(cmd, args))
+			util.CheckErr(o.Run())
+		},
+	}
+	o.CommonOptions.AddCommonFlag(cmd)
+	o.AddFlags(cmd)
+
+	if err := ksCompletionSetting(cmd); err != nil {
+		panic(fmt.Sprintf("Got error with the completion setting"))
+	}
+	return cmd
+}
+
+func (o *UpgradeKubeSphereOptions) Complete(cmd *cobra.Command, args []string) error {
+	var ksVersion string
+	if o.EnableKubeSphere && len(args) > 0 {
+		ksVersion = args[0]
+	} else {
+		ksVersion = kubesphere.Latest().Version
+	}
+	o.KubeSphere = ksVersion
+	return nil
+}
+
+func (o *UpgradeKubeSphereOptions) Run() error {
+	arg := common.Argument{
+		FilePath:         o.ClusterCfgFile,
+		KsEnable:         o.EnableKubeSphere,
+		KsVersion:        o.KubeSphere,
+		SkipConfirmCheck: o.CommonOptions.SkipConfirmCheck,
+		Debug:            o.CommonOptions.Verbose,
+	}
+	return alpha.UpgradeKubeSphere(arg)
+}
+
+func (o *UpgradeKubeSphereOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.ClusterCfgFile, "filename", "f", "", "Path to a configuration file")
+	cmd.Flags().BoolVarP(&o.EnableKubeSphere, "with-kubesphere", "", false, fmt.Sprintf("Deploy a specific version of kubesphere (default %s)", kubesphere.Latest().Version))
+}
+
+func ksCompletionSetting(cmd *cobra.Command) (err error) {
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) (
+		strings []string, directive cobra.ShellCompDirective) {
+		versionArray := kubesphere.VersionsStringArr()
+		versionArray = append(versionArray, time.Now().Add(-time.Hour*24).Format("nightly-20060102"))
+		return versionArray, cobra.ShellCompDirectiveNoFileComp
+	}
+	return
+}

--- a/cmd/ctl/upgrade/phase.go
+++ b/cmd/ctl/upgrade/phase.go
@@ -30,5 +30,7 @@ func NewPhaseCommand() *cobra.Command {
 	cmds.AddCommand(alpha.NewCmdUpgradeBinary())
 	cmds.AddCommand(alpha.NewCmdUpgradeImages())
 	cmds.AddCommand(alpha.NewCmdUpgradeNodes())
+	cmds.AddCommand(alpha.NewCmdUpgradeKubeSphere())
+
 	return cmds
 }

--- a/pkg/alpha/confirm/confirm.go
+++ b/pkg/alpha/confirm/confirm.go
@@ -1,0 +1,30 @@
+package confirm
+
+import (
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/task"
+)
+
+type UpgradeKsConfirmModule struct {
+	common.KubeModule
+	Skip bool
+}
+
+func (u *UpgradeKsConfirmModule) IsSkip() bool {
+	return u.Skip
+}
+
+func (u *UpgradeKsConfirmModule) Init() {
+	u.Name = "UpgradeKsConfirmModule"
+	u.Desc = "Display upgrade kubesphere confirmation form"
+
+	display := &task.LocalTask{
+		Name:   "ConfirmForm",
+		Desc:   "Display confirmation form",
+		Action: new(UpgradeConfirm),
+	}
+
+	u.Tasks = []task.Interface{
+		display,
+	}
+}

--- a/pkg/alpha/confirm/task.go
+++ b/pkg/alpha/confirm/task.go
@@ -1,0 +1,57 @@
+package confirm
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/connector"
+)
+
+type UpgradeConfirm struct {
+	common.KubeAction
+}
+
+func (u *UpgradeConfirm) Execute(runtime connector.Runtime) error {
+	pre := make([]map[string]string, len(runtime.GetAllHosts()), len(runtime.GetAllHosts()))
+	for i, host := range runtime.GetAllHosts() {
+		if v, ok := host.GetCache().Get(common.NodePreCheck); ok {
+			pre[i] = v.(map[string]string)
+		} else {
+			return errors.New("get node check result failed by host cache")
+		}
+	}
+
+	if u.KubeConf.Cluster.KubeSphere.Enabled {
+		currentKsVersion, ok := u.PipelineCache.GetMustString(common.KubeSphereVersion)
+		if !ok {
+			return errors.New("get current KubeSphere version failed by pipeline cache")
+		}
+		fmt.Printf("kubesphere version: %s to %s\n", currentKsVersion, u.KubeConf.Cluster.KubeSphere.Version)
+	}
+	fmt.Println()
+
+	reader := bufio.NewReader(os.Stdin)
+	confirmOK := false
+	for !confirmOK {
+		fmt.Printf("Continue upgrading KubeSphere? [yes/no]: ")
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		input = strings.ToLower(strings.TrimSpace(input))
+
+		switch input {
+		case "yes", "y":
+			confirmOK = true
+		case "no", "n":
+			os.Exit(0)
+		default:
+			continue
+		}
+	}
+	return nil
+}

--- a/pkg/alpha/kubesphere/kubesphere.go
+++ b/pkg/alpha/kubesphere/kubesphere.go
@@ -1,0 +1,76 @@
+/*
+ Copyright 2022 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package alpha
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/kubesphere/kubekey/pkg/alpha/confirm"
+	"github.com/kubesphere/kubekey/pkg/alpha/precheck"
+	"github.com/kubesphere/kubekey/pkg/common"
+	"github.com/kubesphere/kubekey/pkg/core/module"
+	"github.com/kubesphere/kubekey/pkg/core/pipeline"
+	"github.com/kubesphere/kubekey/pkg/kubesphere"
+)
+
+func NewUpgradeKubeSpherePipeline(runtime *common.KubeRuntime) error {
+
+	m := []module.Module{
+		&precheck.UpgradeKubeSpherePreCheckModule{},
+		&confirm.UpgradeKsConfirmModule{},
+		&kubesphere.CleanClusterConfigurationModule{Skip: !runtime.Cluster.KubeSphere.Enabled},
+		&kubesphere.ConvertModule{Skip: !runtime.Cluster.KubeSphere.Enabled},
+		&kubesphere.DeployModule{Skip: !runtime.Cluster.KubeSphere.Enabled},
+		&kubesphere.CheckResultModule{Skip: !runtime.Cluster.KubeSphere.Enabled},
+	}
+
+	p := pipeline.Pipeline{
+		Name:    "UpgradeKubeSpherePipeline",
+		Modules: m,
+		Runtime: runtime,
+	}
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpgradeKubeSphere(args common.Argument) error {
+
+	var loaderType string
+	if args.FilePath != "" {
+		loaderType = common.File
+	} else {
+		loaderType = common.AllInOne
+	}
+
+	runtime, err := common.NewKubeRuntime(loaderType, args)
+	if err != nil {
+		return err
+	}
+
+	switch runtime.Cluster.Kubernetes.Type {
+	case common.Kubernetes:
+		if err := NewUpgradeKubeSpherePipeline(runtime); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported cluster kubernetes type")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1440 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
It provide user to use  "upgrade phase kubesphere " to upgrade worker nodes  as one step of the upgrade phase run.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Usage:
  kk upgrade phase kubesphere [flags]

Flags:
      --debug                    Print detailed information
      --download-cmd string      The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL (default "curl -L -o %s %s")
  -f, --filename string          Path to a configuration file
  -h, --help                     help for kubesphere
      --ignore-err               Ignore the error message, remove the host which reported error and force to continue
      --in-cluster               Running inside the cluster
      --namespace string         KubeKey namespace to use (default "kubekey-system")
      --with-kubernetes string   Specify a supported version of kubernetes
      --with-kubesphere          Deploy a specific version of kubesphere (default v3.3.0)
```
