### PR TITLE
[bug] add dataRoot configuration support for containerd

### DIFF
--- a/pkg/container/module.go
+++ b/pkg/container/module.go
@@ -201,6 +201,7 @@ func InstallContainerd(m *InstallContainerModule) []task.Interface {
 				"InsecureRegistries": m.KubeConf.Cluster.Registry.InsecureRegistries,
 				"SandBoxImage":       images.GetImage(m.Runtime, m.KubeConf, "pause").ImageName(),
 				"Auths":              registry.DockerRegistryAuthEntries(m.KubeConf.Cluster.Registry.Auths),
+				"DataRoot":           templates.DataRoot(m.KubeConf),
 			},
 		},
 		Parallel: true,

--- a/pkg/container/templates/containerd_config.go
+++ b/pkg/container/templates/containerd_config.go
@@ -24,7 +24,11 @@ import (
 
 var ContainerdConfig = template.Must(template.New("config.toml").Parse(
 	dedent.Dedent(`version = 2
+{{- if .DataRoot }}
+root = {{ .DataRoot }}
+{{ else }}
 root = "/var/lib/containerd"
+{{- end }}
 state = "/run/containerd"
 
 [grpc]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
DataRoot configuration in registry works for docker but not containerd.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1449 


### Special notes for reviewers:
```
```
@24sama 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
