### PR TITLE
fixed #1453 : invalid syntax of /etc/sysctl.conf after executing init os script

### DIFF
--- a/pkg/bootstrap/os/templates/init_script.go
+++ b/pkg/bootstrap/os/templates/init_script.go
@@ -83,7 +83,9 @@ sed -r -i  "s@#{0,}?vm.swappiness ?= ?([0-9]{1,})@vm.swappiness = 1@g" /etc/sysc
 sed -r -i  "s@#{0,}?fs.inotify.max_user_instances ?= ?([0-9]{1,})@fs.inotify.max_user_instances = 524288@g" /etc/sysctl.conf
 sed -r -i  "s@#{0,}?kernel.pid_max ?= ?([0-9]{1,})@kernel.pid_max = 65535@g" /etc/sysctl.conf
 
-awk ' !x[$0]++{print > "/etc/sysctl.conf"}' /etc/sysctl.conf
+tmpfile="$$.tmp"
+awk ' !x[$0]++{print > "'$tmpfile'"}' /etc/sysctl.conf
+mv $tmpfile /etc/sysctl.conf
 
 systemctl stop firewalld 1>/dev/null 2>/dev/null
 systemctl disable firewalld 1>/dev/null 2>/dev/null


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
Fixed invalid syntax of /etc/sysctl.conf after executing init os script. 

log output:
`sysctl: /etc/sysctl.conf(103): invalid syntax, continuing...`

When using "awk print" to write to a file and read the same file at the same time, and the file size exceeds 4Kbytes, it will cause the file content to be truncated.
`awk ' !x[$0]++{print > "/etc/sysctl.conf"}' /etc/sysctl.conf`

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1453

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
