### PR TITLE
Fix the permission problem of sftp for non-root users.

### DIFF
--- a/exp/cluster-api-provider-kubekey/Makefile
+++ b/exp/cluster-api-provider-kubekey/Makefile
@@ -357,4 +357,4 @@ $(SETUP_ENVTEST): # Build setup-envtest from tools folder.
 $(GOLANGCI_LINT): ../../.github/workflows/golangci-lint.yml # Download golangci-lint using hack script into tools folder.
 	hack/ensure-golangci-lint.sh \
 		-b $(TOOLS_BIN_DIR) \
-		$(shell cat .github/workflows/golangci-lint.yml | grep [[:space:]]version | sed 's/.*version: //')
+		$(shell cat ../../.github/workflows/golangci-lint.yml | grep [[:space:]]version | sed 's/.*version: //')

--- a/exp/cluster-api-provider-kubekey/main.go
+++ b/exp/cluster-api-provider-kubekey/main.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+// Package main
 package main
 
 import (

--- a/exp/cluster-api-provider-kubekey/pkg/service/bootstrap/bootstrap.go
+++ b/exp/cluster-api-provider-kubekey/pkg/service/bootstrap/bootstrap.go
@@ -95,7 +95,7 @@ func (s *Service) CreateDirectory() error {
 
 // ResetTmpDirectory resets the temporary "/tmp/kubekey" directory.
 func (s *Service) ResetTmpDirectory() error {
-	dirService := s.getDirectoryService(directory.TmpDir, os.FileMode(filesystem.FileMode0755))
+	dirService := s.getDirectoryService(directory.TmpDir, os.FileMode(filesystem.FileMode0777))
 	if err := dirService.Remove(); err != nil {
 		return err
 	}

--- a/exp/cluster-api-provider-kubekey/pkg/service/operation/file/binary.go
+++ b/exp/cluster-api-provider-kubekey/pkg/service/operation/file/binary.go
@@ -113,7 +113,7 @@ func (b *Binary) CompareChecksum() error {
 	}
 
 	if sum != b.checksum.Value() {
-		return errors.New(fmt.Sprintf("SHA256 no match. file: %s sha256: %s not equal checksum: %s", b.Name(), sum, b.checksum.Value()))
+		return errors.Errorf("SHA256 no match. file: %s sha256: %s not equal checksum: %s", b.Name(), sum, b.checksum.Value())
 	}
 	return nil
 }

--- a/exp/cluster-api-provider-kubekey/pkg/service/provisioning/cloudinit/action.go
+++ b/exp/cluster-api-provider-kubekey/pkg/service/provisioning/cloudinit/action.go
@@ -38,7 +38,7 @@ type actionFactory struct {
 }
 
 // NewActionFactory returns a new action factory.
-func NewActionFactory(sshClient ssh.Interface) *actionFactory {
+func NewActionFactory(sshClient ssh.Interface) *actionFactory { //nolint: golint
 	return &actionFactory{
 		sshClient: sshClient,
 	}

--- a/exp/cluster-api-provider-kubekey/pkg/util/filesystem/common.go
+++ b/exp/cluster-api-provider-kubekey/pkg/util/filesystem/common.go
@@ -22,6 +22,8 @@ const (
 )
 
 const (
+	// FileMode0777 represents the file mode 0755
+	FileMode0777 = 0777
 	// FileMode0755 represents the file mode 0755
 	FileMode0755 = 0755
 	// FileMode0644 represents the file mode 0644


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Fix the permission problem of SFTP for non-root users. 
The CAPKK uses the SFTP to `scp` files to the remote instance `/tmp/kubekey` directory and then uses `cp` command to copy them to their original remote path.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
