### PR TITLE
fix: failed to add labels to nodes

### DIFF
--- a/pkg/kubernetes/module.go
+++ b/pkg/kubernetes/module.go
@@ -19,6 +19,7 @@ package kubernetes
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -588,7 +589,8 @@ func (c *ConfigureKubernetesModule) Init() {
 		Desc:     "Configure kubernetes",
 		Hosts:    c.Runtime.GetHostsByRole(common.K8s),
 		Action:   new(ConfigureKubernetes),
-		Retry:    3,
+		Retry:    6,
+		Delay:    10 * time.Second,
 		Parallel: true,
 	}
 

--- a/pkg/kubernetes/tasks.go
+++ b/pkg/kubernetes/tasks.go
@@ -1064,7 +1064,10 @@ func (c *ConfigureKubernetes) Execute(runtime connector.Runtime) error {
 	kubeHost := host.(*kubekeyv1alpha2.KubeHost)
 	for k, v := range kubeHost.Labels {
 		labelCmd := fmt.Sprintf("/usr/local/bin/kubectl label --overwrite node %s %s=%s", host.GetName(), k, v)
-		_, _ = runtime.GetRunner().SudoCmd(labelCmd, true)
+		_, err := runtime.GetRunner().SudoCmd(labelCmd, true)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Add retry for adding nodes labels.

When the `internalLoadBalancer: haproxy` is used, before the `haproxy` is started, the labeling fails because kubectl cannot connect to the kube-apiserver.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
