### PR TITLE
 fix #1506: update k8s-certs-renew.timer to run each monday of every week

### DIFF
--- a/pkg/certs/templates/certs_renew_service.go
+++ b/pkg/certs/templates/certs_renew_service.go
@@ -36,7 +36,7 @@ ExecStart=/usr/local/bin/kube-scripts/k8s-certs-renew.sh
 		dedent.Dedent(`[Unit]
 Description=Timer to renew K8S control plane certificates
 [Timer]
-OnCalendar=Mon *-*-1,2,3,4,5,6,7 03:00:00
+OnCalendar=Mon *-*-* 03:00:00
 Unit=k8s-certs-renew.service
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
fix: registry node missing certs file

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug



### What this PR does / why we need it:
this PR update k8s-certs-renew.timer to run each monday of every week.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1506

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
