### PR TITLE
fix: add alpha cmd before phase run cmds

### DIFF
--- a/cmd/kk/cmd/alpha/alpha.go
+++ b/cmd/kk/cmd/alpha/alpha.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"github.com/spf13/cobra"
+
+)
+
+
+// NewAlphaCmd create a new Alpha command
+func NewAlphaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alpha",
+		Short: "Add alpha before the cmds to tag them for testing",
+	}
+
+	cmd.AddCommand(NewCmdCreate())
+	cmd.AddCommand(NewCmdUpgrade())
+	return cmd
+}

--- a/cmd/kk/cmd/alpha/create.go
+++ b/cmd/kk/cmd/alpha/create.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The KubeSphere Authors.
+Copyright 2022 The KubeSphere Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package create
+package alpha
 
 import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/options"
+	"github.com/kubesphere/kubekey/cmd/kk/cmd/create/phase"
 )
 
 type CreateOptions struct {
@@ -37,13 +38,10 @@ func NewCmdCreate() *cobra.Command {
 	o := NewCreateOptions()
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a cluster or a cluster configuration file",
+		Short: "Create a cluster by phase cmds for testing",
 	}
 
 	o.CommonOptions.AddCommonFlag(cmd)
-
-	cmd.AddCommand(NewCmdCreateCluster())
-	cmd.AddCommand(NewCmdCreateConfig())
-	cmd.AddCommand(NewCmdCreateManifest())
+    cmd.AddCommand(phase.NewPhaseCommand())
 	return cmd
 }

--- a/cmd/kk/cmd/alpha/upgrade.go
+++ b/cmd/kk/cmd/alpha/upgrade.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The KubeSphere Authors.
+Copyright 2022 The KubeSphere Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,36 +14,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package create
+package alpha
 
 import (
-	"github.com/spf13/cobra"
-
+	"github.com/kubesphere/kubekey/cmd/kk/cmd/upgrade/phase"
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/options"
+	"github.com/spf13/cobra"
 )
 
-type CreateOptions struct {
-	CommonOptions *options.CommonOptions
+type UpgradeOptions struct {
+	CommonOptions    *options.CommonOptions
 }
 
-func NewCreateOptions() *CreateOptions {
-	return &CreateOptions{
+func NewUpgradeOptions() *UpgradeOptions {
+	return &UpgradeOptions{
 		CommonOptions: options.NewCommonOptions(),
 	}
 }
 
-// NewCmdCreate creates a new create command
-func NewCmdCreate() *cobra.Command {
-	o := NewCreateOptions()
+// NewCmdUpgrade creates a new upgrade command
+func NewCmdUpgrade() *cobra.Command {
+	o := NewUpgradeOptions()
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a cluster or a cluster configuration file",
+		Use:   "upgrade",
+		Short: "Upgrade your cluster by phase cmd for testing",
 	}
-
 	o.CommonOptions.AddCommonFlag(cmd)
-
-	cmd.AddCommand(NewCmdCreateCluster())
-	cmd.AddCommand(NewCmdCreateConfig())
-	cmd.AddCommand(NewCmdCreateManifest())
+	cmd.AddCommand(phase.NewPhaseCommand())
 	return cmd
 }
+

--- a/cmd/kk/cmd/root.go
+++ b/cmd/kk/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/add"
+	"github.com/kubesphere/kubekey/cmd/kk/cmd/alpha"
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/artifact"
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/cert"
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/completion"
@@ -106,6 +107,8 @@ func NewKubeKeyCommand(o KubeKeyOptions) *cobra.Command {
 	}
 
 	cmds.AddCommand(initOs.NewCmdInit())
+
+	cmds.AddCommand(alpha.NewAlphaCmd())
 
 	cmds.AddCommand(create.NewCmdCreate())
 	cmds.AddCommand(delete.NewCmdDelete())

--- a/cmd/kk/cmd/upgrade/upgrade.go
+++ b/cmd/kk/cmd/upgrade/upgrade.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kubesphere/kubekey/cmd/kk/pkg/version/kubesphere"
 
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/options"
-	"github.com/kubesphere/kubekey/cmd/kk/cmd/upgrade/phase"
 	"github.com/kubesphere/kubekey/cmd/kk/cmd/util"
 )
 
@@ -62,7 +61,6 @@ func NewCmdUpgrade() *cobra.Command {
 	}
 	o.CommonOptions.AddCommonFlag(cmd)
 	o.AddFlags(cmd)
-	cmd.AddCommand(phase.NewPhaseCommand())
 
 	if err := completionSetting(cmd); err != nil {
 		panic(fmt.Sprintf("Got error with the completion setting"))

--- a/docs/commands/kk-create-phase.md
+++ b/docs/commands/kk-create-phase.md
@@ -1,5 +1,5 @@
 # NAME
-**kk create phase**: Create your cluster in phases to a newer version with this command, which is not enough and need to add phase cmds.
+**kk alpha create phase**: Create your cluster in phases to a newer version with this command, which is not enough and need to add phase cmds.
 
 # DESCRIPTION
 Create your cluster in phases to a newer version with this command,  which is not enough and need to add phase cmds.
@@ -8,13 +8,13 @@ Create your cluster in phases to a newer version with this command,  which is no
 
 | Command | Description |
 | - | - |
-| kk create phase binary | Download the binaries on the local. |
-| kk create phase os | Init the os configure. |
-| kk create phase images | Down the container and pull the images before creating your cluster. |
-| kk create phase etcd | Install the etcd on the master. |
-| kk create phase join | Join the control-plane nodes and worker nodes in the k8s cluster. |
-| kk create phase configure | Configure the k8s cluster with plugins, certs and PV. |
-| kk create phase kubesphere | Install the kubesphere with the input version. |
+| kk alpha create phase binary | Download the binaries on the local. |
+| kk alpha create phase os | Init the os configure. |
+| kk alpha create phase images | Down the container and pull the images before creating your cluster. |
+| kk alpha create phase etcd | Install the etcd on the master. |
+| kk alpha create phase join | Join the control-plane nodes and worker nodes in the k8s cluster. |
+| kk alpha create phase configure | Configure the k8s cluster with plugins, certs and PV. |
+| kk alpha create phase kubesphere | Install the kubesphere with the input version. |
 
 # OPTIONS
 
@@ -67,97 +67,97 @@ Skip confirm check. The default is `false`.
 ## Create an `all-in-one` pure Kubernetes cluster with default version
 Download the binarys of creating an `all-in-one` Kubernetes cluster from a default version.
 ```
-$ kk create phase binary
+$ kk alpha create phase binary
 ```
 Init the configure os of creating an `all-in-one` Kubernetes cluster from a default version.
 ```
-$ kk create phase os
+$ kk alpha create phase os
 ```
 Pull the images of creating an `all-in-one` Kubernetes cluster from a default version.
 ```
-$ kk create phase images
+$ kk alpha create phase images
 ```
 Install the etcd of creating an `all-in-one` Kubernetes cluster from a default version.
 ```
-$ kk create phase etcd
+$ kk alpha create phase etcd
 ```
 Init the k8s cluster of creating an `all-in-one` Kubernetes cluster from a default version.
 ```
-$ kk create phase init 
+$ kk alpha create phase init 
 ```
 Join the nodes to the k8s cluster of creating an `all-in-one` Kubernetes cluster from a default version.
 ```
-$ kk create phase join 
+$ kk alpha create phase join 
 ```
 Configure the k8s cluster of creating an `all-in-one` Kubernetes cluster from a default version.
 ```
-$ kk create phase configure
+$ kk alpha create phase configure
 ```
 ## Create an `all-in-one` pure Kubernetes cluster with specified version
 Download the binarys of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase binary --with-kubernetes v1.22.0
+$ kk alpha create phase binary --with-kubernetes v1.22.0
 ```
 Init the configure os of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase os
+$ kk alpha create phase os
 ```
 Pull the images of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase images --with-kubernetes v1.22.0
+$ kk alpha create phase images --with-kubernetes v1.22.0
 ```
 Install the etcd of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase etcd
+$ kk alpha create phase etcd
 ```
 Init the k8s cluster of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase init --with-kubernetes v1.22.0
+$ kk alpha create phase init --with-kubernetes v1.22.0
 ```
 Join the nodes to the k8s cluster of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase join --with-kubernetes v1.22.0
+$ kk alpha create phase join --with-kubernetes v1.22.0
 ```
 Configure the k8s cluster of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase configure --with-kubernetes v1.22.0
+$ kk alpha create phase configure --with-kubernetes v1.22.0
 ```
 Install the k8s cluster of creating an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk create phase kubesphere --with-kubesphere v3.3.0
+$ kk alpha create phase kubesphere --with-kubesphere v3.3.0
 ```
 ## Create a kubernetes cluster from a specified configuration file
 Download the binarys of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase binary -f config-sample.yaml
+$ kk alpha create phase binary -f config-sample.yaml
 ```
 Init the configure os of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase os
+$ kk alpha create phase os
 ```
 Pull the images of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase images -f config-sample.yaml
+$ kk alpha create phase images -f config-sample.yaml
 ```
 Install the etcd of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase etcd -f config-sample.yaml
+$ kk alpha create phase etcd -f config-sample.yaml
 ```
 Init the k8s cluster of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase init -f config-sample.yaml
+$ kk alpha create phase init -f config-sample.yaml
 ```
 Join the nodes to the k8s cluster of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase join -f config-sample.yaml
+$ kk alpha create phase join -f config-sample.yaml
 ```
 Configure the k8s cluster of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase configure -f config-sample.yaml
+$ kk alpha create phase configure -f config-sample.yaml
 ```
 Install the k8s cluster of creating a kubernetes cluster from a specified configuration file.
 ```
-$ kk create phase kubesphere -f config-sample.yaml
+$ kk alpha create phase kubesphere -f config-sample.yaml
 ```
 ## Create a cluster from the specified configuration file and use the artifact to install operating system packages.
 import a KubeKey artifact named `my-artifact.tar.gz`.
@@ -166,33 +166,33 @@ $ kk artifact import -a my-artifact.tar.gz --with-packages
 ```
 Download the binarys of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase binary -f config-sample.yaml
+$ kk alpha create phase binary -f config-sample.yaml
 ```
 Init the configure os of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase os
+$ kk alpha create phase os
 ```
 Pull the images of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase images -f config-sample.yaml
+$ kk alpha create phase images -f config-sample.yaml
 ```
 Install the etcd of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase etcd -f config-sample.yaml
+$ kk alpha create phase etcd -f config-sample.yaml
 ```
 Init the k8s cluster of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase init -f config-sample.yaml
+$ kk alpha create phase init -f config-sample.yaml
 ```
 Join the nodes to the k8s cluster of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase join -f config-sample.yaml
+$ kk alpha create phase join -f config-sample.yaml
 ```
 Configure the k8s cluster of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase configure -f config-sample.yaml
+$ kk alpha create phase configure -f config-sample.yaml
 ```
 Install the k8s cluster of creating a cluster from the specified configuration file and use the artifact to install operating system packages.
 ```
-$ kk create phase kubesphere -f config-sample.yaml
+$ kk alpha create phase kubesphere -f config-sample.yaml
 ```

--- a/docs/commands/kk-upgrade-phase.md
+++ b/docs/commands/kk-upgrade-phase.md
@@ -1,5 +1,5 @@
 # NAME
-**kk upgade phase**: Upgrade your cluster in phases to a newer version with this command, which is not enough and need to add phase cmds.
+**kk alpha upgade phase**: Upgrade your cluster in phases to a newer version with this command, which is not enough and need to add phase cmds.
 
 # DESCRIPTION
 Upgrade your cluster in phases to a newer version with this command,  which is not enough and need to add phase cmds.
@@ -8,10 +8,10 @@ Upgrade your cluster in phases to a newer version with this command,  which is n
 
 | Command | Description |
 | - | - |
-| kk upgrade phase binary | Download the binary and synchronize kubernetes binaries. |
-| kk upgrade phase images | Pull the images before create your cluster. |
-| kk upgrade phase nodes | Upgrade cluster on master nodes and worker nodes to the version you input. |
-| kk upgrade phase kubesphere | Upgrade your kubesphere to a newer version with this command. |
+| kk alpha upgrade phase binary | Download the binary and synchronize kubernetes binaries. |
+| kk alpha upgrade phase images | Pull the images before create your cluster. |
+| kk alpha upgrade phase nodes | Upgrade cluster on master nodes and worker nodes to the version you input. |
+| kk alpha upgrade phase kubesphere | Upgrade your kubesphere to a newer version with this command. |
 
 # OPTIONS
 
@@ -46,36 +46,36 @@ Skip confirm check. The default is `false`.
 ## Upgrade an `all-in-one` Kubernetes cluster from a specified version
 Upgrade the binarys of an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk upgrade phase binary --with-kubernetes v1.23.8
+$ kk alpha upgrade phase binary --with-kubernetes v1.23.8
 ```
 Upgrade the images of an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk upgrade phase images --with-kubernetes v1.23.8
+$ kk alpha upgrade phase images --with-kubernetes v1.23.8
 ```
 Upgrade the cluster nodes of an `all-in-one` Kubernetes cluster from a specified version.
 ```
-$ kk upgrade phase nodes --with-kubernetes v1.23.8
+$ kk alpha upgrade phase nodes --with-kubernetes v1.23.8
 ```
 Upgrade the kubesphere of an `all-in-one` Kubernetes cluster from a specified version if you need.
 ```
-$ kk upgrade phase kubesphere --with-kubesphere v3.3.0
+$ kk alpha upgrade phase kubesphere --with-kubesphere v3.3.0
 ```
 ## Upgrade an kubernetes cluster from a specified configuration file
 Upgrade the binarys from a specified configuration file.
 ```
-$ kk upgrade phase binary -f config-example.yaml
+$ kk alpha upgrade phase binary -f config-example.yaml
 ```
 Upgrade the images from a specified configuration file.
 ```
-$ kk upgrade phase images -f config-example.yaml
+$ kk alpha upgrade phase images -f config-example.yaml
 ```
 Upgrade the cluster nodes from a specified configuration file.
 ```
-$ kk upgrade phase nodes -f config-example.yaml
+$ kk alpha upgrade phase nodes -f config-example.yaml
 ```
 Upgrade the kubesphere from a specified configuration file if you need.
 ```
-$ kk upgrade phase kubesphere -f config-example.yaml
+$ kk alpha upgrade phase kubesphere -f config-example.yaml
 ```
 ## Upgrade a cluster using a KubeKey artifact (in an offline enviroment).
 import a KubeKey artifact named `my-artifact.tar.gz`.
@@ -84,17 +84,17 @@ $ kk artifact import -a my-artifact.tar.gz
 ```
 Upgrade the binarys from a specified configuration file.
 ```
-$ kk upgrade phase binary -f config-example.yaml
+$ kk alpha upgrade phase binary -f config-example.yaml
 ```
 Upgrade the images from a specified configuration file.
 ```
-$ kk upgrade phase images -f config-example.yaml
+$ kk alpha upgrade phase images -f config-example.yaml
 ```
 Upgrade the cluster nodes from a specified configuration file.
 ```
-$ kk upgrade phase nodes -f config-example.yaml
+$ kk alpha upgrade phase nodes -f config-example.yaml
 ```
 Upgrade the kubesphere from a specified configuration file if you need.
 ```
-$ kk upgrade phase kubesphere -f config-example.yaml
+$ kk alpha upgrade phase kubesphere -f config-example.yaml
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Add alpha before the phase run cmds to test and optimize them more easily and change the docs.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Usage:
  kk alpha create phase [command]

Available Commands:
  binary      Download the binaries on the local
  configure   Configure the k8s cluster with plugins, certs and PV
  etcd        Install the ETCD cluster on the master
  images      Down the container and pull the images before creating your cluster
  init        Init the k8s cluster
  join        Join the control-plane nodes and worker nodes in the k8s cluster
  kubesphere  Install the kubesphere with the input version
  os          Init the os configure



Usage:
  kk alpha upgrade phase [command]

Available Commands:
  binary      Download the binary and synchronize kubernetes binaries
  images      Pull the images before upgrading your cluster
  kubesphere  Upgrade your kubesphere to a newer version with this command
  nodes       Upgrade cluster on master nodes and worker nodes to the version you input


```
