### PR TITLE
fix the image name parsing panic

### DIFF
--- a/cmd/kk/pkg/images/tasks.go
+++ b/cmd/kk/pkg/images/tasks.go
@@ -156,6 +156,9 @@ func (s *SaveImages) Execute(runtime connector.Runtime) error {
 		return errors.Wrapf(errors.WithStack(err), "mkdir %s failed", dirName)
 	}
 	for _, image := range s.Manifest.Spec.Images {
+		if err := validateImageName(image); err != nil {
+			return err
+		}
 		imageFullName := strings.Split(image, "/")
 		repo := imageFullName[0]
 		auth := new(registry.DockerRegistryEntry)
@@ -171,8 +174,8 @@ func (s *SaveImages) Execute(runtime connector.Runtime) error {
 				variant = "-" + variant
 			}
 			// Ex:
-			// oci:./kubekey/artifact/images:kubesphere:kube-apiserver-amd64:v1.21.5
-			// oci:./kubekey/artifact/images:kubesphere:kube-apiserver-arm-v7:v1.21.5
+			// oci:./kubekey/artifact/images:kubesphere:kube-apiserver:v1.21.5-amd64
+			// oci:./kubekey/artifact/images:kubesphere:kube-apiserver:v1.21.5-arm-v7
 			destName := fmt.Sprintf("oci:%s:%s:%s-%s%s", dirName, imageFullName[1], imageFullName[2], arch, variant)
 			logger.Log.Infof("Source: %s", srcName)
 			logger.Log.Infof("Destination: %s", destName)

--- a/cmd/kk/pkg/images/utils.go
+++ b/cmd/kk/pkg/images/utils.go
@@ -18,12 +18,15 @@ package images
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/containerd/containerd/platforms"
 	"github.com/containers/image/v5/types"
 	manifesttypes "github.com/estesp/manifest-tool/v2/pkg/types"
-	"github.com/kubesphere/kubekey/cmd/kk/pkg/core/logger"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"strings"
+	"github.com/pkg/errors"
+
+	"github.com/kubesphere/kubekey/cmd/kk/pkg/core/logger"
 )
 
 var defaultUserAgent = "kubekey"
@@ -166,4 +169,15 @@ func NewManifestSpec(image string, entries []manifesttypes.ManifestEntry) manife
 		Image:     image,
 		Manifests: srcImages,
 	}
+}
+
+func validateImageName(imageFullName string) error {
+	image := strings.Split(imageFullName, "/")
+	if len(image) != 3 {
+		return errors.Errorf("image %s is invalid, only the format \"registry/namespace/name:tag\" is supported", imageFullName)
+	}
+	if len(strings.Split(image[2], ":")) != 2 {
+		return errors.Errorf("image %s is invalid, only the format \"registry/namespace/name:tag\" is supported", imageFullName)
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
fix the image name parsing panic
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/43993589/201003196-f10d714a-4112-4b1d-b3f9-27e6269aeeb9.png">


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#1581

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
