### PR TITLE
fix remove node check

### DIFF
--- a/cmd/kk/pkg/kubernetes/tasks.go
+++ b/cmd/kk/pkg/kubernetes/tasks.go
@@ -491,7 +491,7 @@ type FindNode struct {
 func (f *FindNode) Execute(runtime connector.Runtime) error {
 	var resArr []string
 	res, err := runtime.GetRunner().Cmd(
-		"sudo -E /usr/local/bin/kubectl get nodes | grep -v NAME | grep -v 'master\\|control-plane' | awk '{print $1}'",
+		"sudo -E /usr/local/bin/kubectl get nodes | awk '$3 !~ /master|control-plane|ROLES/ {print $1}'",
 		true)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "kubectl get nodes failed")


### PR DESCRIPTION
### What this PR does / why we need it:
fix remove node check may misstake hostnames that contains master string.
If node name is master-1, it will be considered a master node and forbidden remove the node.
