### PR TITLE
Feat: add cni virtual device deletion

### DIFF
--- a/cmd/kk/pkg/bootstrap/os/tasks.go
+++ b/cmd/kk/pkg/bootstrap/os/tasks.go
@@ -172,6 +172,15 @@ var (
 		"ipvsadm -C",
 		"ip link del kube-ipvs0",
 		"ip link del nodelocaldns",
+		"ip link del cni0",
+		"ip link del flannel.1",
+		"ip link del flannel-v6.1",
+		"ip link del flannel-wg",
+		"ip link del flannel-wg-v6",
+		"ip link del cilium_host",
+		"ip link del cilium_vxlan",
+		"ip -br link show | grep 'cali[a-f0-9]*' | awk -F '@' '{print $1}' | xargs -r -t -n 1 ip link del",
+		"ip netns show 2>/dev/null | grep cni- | xargs -r -t -n 1 ip netns del",
 	}
 )
 

--- a/docs/commands/kk-delete-cluster.md
+++ b/docs/commands/kk-delete-cluster.md
@@ -2,7 +2,7 @@
 **kk delete cluster**: Delete a cluster.
 
 # DESCRIPTION
-Delete a cluster. This command will use the `kubeadm reset` to reset all the nodes. Then, reset network policy, stop `etcd`, remove cluster directory and uninstall Kubernetes certs-auto-renew script.
+Delete a cluster. This command will use the `kubeadm reset` to reset all the nodes. Then, reset network policy, stop `etcd`, remove cluster directory, uninstall Kubernetes certs-auto-renew script and remove internal Loadbalancer module. And [network configurations](../network-configurations.md) on each node will be cleaned up.
 
 # OPTIONS
 
@@ -24,7 +24,7 @@ Delete a cluster from a specified configuration file.
 ```
 $ kk delete cluster -f config-example.yaml
 ```
-Delete a cluster included CRI related files and directories from a specified configuraion file.
+Delete a cluster included CRI related files and directories from a specified configuration file.
 ```
 $ kk delete cluster -f config-example.yaml --all
 $ kk delete cluster -f config-example.yaml -A

--- a/docs/commands/kk-delete-node.md
+++ b/docs/commands/kk-delete-node.md
@@ -2,7 +2,7 @@
 **kk delete node**: Delete a node.
 
 # DESCRIPTION
-Delete a node. This command will use the `kubectl drain` to safely evict all pods, and then use `kubectl delete node`  to delete the specified node.
+Delete and cleanup a node. This command will use the `kubectl drain` to safely evict all pods, then use `kubectl delete node` to delete the specified node. And [network configurations](../network-configurations.md) on the node will be cleaned up.
 
 # OPTIONS
 

--- a/docs/network-configurations.md
+++ b/docs/network-configurations.md
@@ -1,0 +1,25 @@
+### Network Configurations
+
+#### IPVS
+
+If your cluster's kubeProxy mode is `ipvs` which is default value in `kk`, kubernetes will add some ipvs records on each node. You can use `ipvsadm` command to get more information.
+
+#### Iptables
+
+If your cluster's kubeProxy mode is `iptables`, kubernetes will add some iptables records on each node. You can use `iptables` command to get more information.
+
+#### Virtual Device
+
+Most of CNI Plugins will create some virtual devices on each node, such as `cni0`. You can use `ip link` command to inspect them in details.
+
+As for `flannel`, virtual devices named with `flannel` prefix will be created.
+As for `calico`, virtual devices named in `cali[a-f0-9]*` regexp format will be created.
+As for `cilium`, virtual devices named with `cilium_` prefix will be created.
+
+If your cluster's kubeProxy mode is `ipvs`, additional virtual device `kube-ipvs0` will be created.
+
+If your cluster enables `nodelocaldns` feature for DNS caching purpose, additional virtual device `nodelocaldns` will be created.
+
+#### Network Namespace
+
+CNI plugins may create some network namespaces named with `cni-` prefix depends on which CNI plugin you choose to use. You can use `ip netns show 2>/dev/null | grep cni-` command to get CNI network namespace list.

--- a/pkg/service/bootstrap/bootstrap.go
+++ b/pkg/service/bootstrap/bootstrap.go
@@ -170,6 +170,15 @@ func (s *Service) ResetNetwork() error {
 		"ipvsadm -C",
 		"ip link del kube-ipvs0",
 		"ip link del nodelocaldns",
+		"ip link del cni0",
+		"ip link del flannel.1",
+		"ip link del flannel-v6.1",
+		"ip link del flannel-wg",
+		"ip link del flannel-wg-v6",
+		"ip link del cilium_host",
+		"ip link del cilium_vxlan",
+		"ip -br link show | grep 'cali[a-f0-9]*' | awk -F '@' '{print $1}' | xargs -r -t -n 1 ip link del",
+		"ip netns show 2>/dev/null | grep cni- | xargs -r -t -n 1 ip netns del",
 	}
 	for _, cmd := range networkResetCmds {
 		_, _ = s.sshClient.SudoCmd(cmd)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
This PR allows kk to try to clean the network config created by flannel, cilium and calico when deleting a cluster.

Currently, `kubeadm reset` won't clean the legacy network config created by CNI. If we reinstall a cluster with the previous cluster config after deleting an existing one, new CNI pods may fail to start because of CNI bridge IP address conflicts. 
[k3s upstream](https://github.com/k3s-io/k3s/blob/master/install.sh#L677) now supports flannel cleanup, we need to keep synced with upstream, and add calico and cilium clean up abilities.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
None
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
