### PR TITLE
feat: add v1.25.5 to k8e binary

### DIFF
--- a/cmd/kk/pkg/k8e/tasks.go
+++ b/cmd/kk/pkg/k8e/tasks.go
@@ -180,8 +180,6 @@ func (g *GenerateK8eService) Execute(runtime connector.Runtime) error {
 	}
 
 	defaultKubeletArs := map[string]string{
-		"cni-conf-dir":    "/etc/cni/net.d",
-		"cni-bin-dir":     "/opt/cni/bin",
 		"kube-reserved":   "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
 		"system-reserved": "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
 		"eviction-hard":   "memory.available<5%,nodefs.available<10%",

--- a/docs/k8e-versions.md
+++ b/docs/k8e-versions.md
@@ -1,0 +1,15 @@
+## What is K8E
+Kubernetes Easy (k8e) is a lightweight, Extensible, Enterprise Kubernetes distribution that allows users to uniformly manage, secure, and get out-of-the-box kubernetes cluster for enterprise environments. more infors can be found in [K8E Site](https://getk8e.com/)
+
+## K8e Versions(amd64)
+
+| Version  | Supported           |
+|----------|---------------------|
+| v1.21.14 | :white_check_mark:  |
+| v1.25.5  | :white_check_mark:  |
+
+## K8e Versions(arm64)
+| Version  | Supported          |
+|----------|--------------------|
+| v1.21.14 | :white_check_mark: |
+| v1.25.5  | :white_check_mark: |

--- a/version/components.json
+++ b/version/components.json
@@ -528,10 +528,12 @@
     },
     "k8e": {
         "amd64": {
-            "v1.21.14": "e0b7dfcf3da936859e19684b2a847cb4f5cadf4d21c3373140886c5fa997a6b8"
+            "v1.21.14": "e0b7dfcf3da936859e19684b2a847cb4f5cadf4d21c3373140886c5fa997a6b8",
+            "v1.25.5": "0913de7c371f0386c0e5e99924acab8fa4b18aa6ff4a376c200f9f39cbffead0"
         },
         "arm64": {
-            "v1.21.14": "0f863969df8178b12655e884d3095d850dbe63675b5a334878b2c7478fc9fac1"
+            "v1.21.14": "0f863969df8178b12655e884d3095d850dbe63675b5a334878b2c7478fc9fac1",
+            "v1.25.5": "d58cf3a0c03b0c0fc01eb5406de65c1c85bff5683c7b6ef9ad99f46616d58525"
         }
     },
     "docker": {


### PR DESCRIPTION
kubernetes v1.25.5 is new stable long term support version.  
k8e distribution now support it.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
let k8e support new kube stable version v1.25.5

Prior to Kubernetes 1.24, CNI plugins could also be managed by kubelet using the command line arguments cni-bin-dir and network-plugin. kubernetes 1.24 removes these command line arguments and CNI management is no longer the job of kubelet.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add new kube version v1.25.5 to k8e distributions.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
