### PR TITLE
chore: rename the task of SyncKubelet

### DIFF
--- a/cmd/kk/pkg/kubernetes/module.go
+++ b/cmd/kk/pkg/kubernetes/module.go
@@ -75,12 +75,12 @@ func (i *InstallKubeBinariesModule) Init() {
 		Retry:    2,
 	}
 
-	syncKubelet := &task.RemoteTask{
-		Name:     "SyncKubelet",
-		Desc:     "Synchronize kubelet",
+	chmodKubelet := &task.RemoteTask{
+		Name:     "ChmodKubelet",
+		Desc:     "Change kubelet mode",
 		Hosts:    i.Runtime.GetHostsByRole(common.K8s),
 		Prepare:  &NodeInCluster{Not: true},
-		Action:   new(SyncKubelet),
+		Action:   new(ChmodKubelet),
 		Parallel: true,
 		Retry:    2,
 	}
@@ -120,7 +120,7 @@ func (i *InstallKubeBinariesModule) Init() {
 
 	i.Tasks = []task.Interface{
 		syncBinary,
-		syncKubelet,
+		chmodKubelet,
 		generateKubeletService,
 		enableKubelet,
 		generateKubeletEnv,

--- a/cmd/kk/pkg/kubernetes/tasks.go
+++ b/cmd/kk/pkg/kubernetes/tasks.go
@@ -154,13 +154,13 @@ func SyncKubeBinaries(runtime connector.Runtime, binariesMap map[string]*files.K
 	return nil
 }
 
-type SyncKubelet struct {
+type ChmodKubelet struct {
 	common.KubeAction
 }
 
-func (s *SyncKubelet) Execute(runtime connector.Runtime) error {
+func (c *ChmodKubelet) Execute(runtime connector.Runtime) error {
 	if _, err := runtime.GetRunner().SudoCmd("chmod +x /usr/local/bin/kubelet", false); err != nil {
-		return errors.Wrap(errors.WithStack(err), "sync kubelet service failed")
+		return errors.Wrap(errors.WithStack(err), "change kubelet mode failed")
 	}
 	return nil
 }
@@ -771,12 +771,12 @@ func (k *KubeadmUpgrade) Execute(runtime connector.Runtime) error {
 
 func SetKubeletTasks(runtime connector.Runtime, kubeAction common.KubeAction) error {
 	host := runtime.RemoteHost()
-	syncKubelet := &task.RemoteTask{
-		Name:     "SyncKubelet",
-		Desc:     "synchronize kubelet",
+	chmodKubelet := &task.RemoteTask{
+		Name:     "ChownKubelet",
+		Desc:     "Change kubelet owner",
 		Hosts:    []connector.Host{host},
 		Prepare:  new(NotEqualDesiredVersion),
-		Action:   new(SyncKubelet),
+		Action:   new(ChmodKubelet),
 		Parallel: false,
 		Retry:    2,
 	}
@@ -792,7 +792,7 @@ func SetKubeletTasks(runtime connector.Runtime, kubeAction common.KubeAction) er
 	}
 
 	tasks := []task.Interface{
-		syncKubelet,
+		chmodKubelet,
 		enableKubelet,
 	}
 

--- a/cmd/kk/pkg/phase/kubernetes/modules.go
+++ b/cmd/kk/pkg/phase/kubernetes/modules.go
@@ -18,12 +18,12 @@ func (i *InstallKubeletModule) Init() {
 	i.Name = "InstallKubeletModule"
 	i.Desc = "Install kubernetes cluster"
 
-	syncKubelet := &task.RemoteTask{
-		Name:     "SyncKubelet",
-		Desc:     "Synchronize kubelet",
+	chmodKubelet := &task.RemoteTask{
+		Name:     "ChmodKubelet",
+		Desc:     "Change kubelet mode",
 		Hosts:    i.Runtime.GetHostsByRole(common.K8s),
 		Prepare:  &kubernetes.NodeInCluster{Not: true},
-		Action:   new(kubernetes.SyncKubelet),
+		Action:   new(kubernetes.ChmodKubelet),
 		Parallel: true,
 		Retry:    2,
 	}
@@ -62,7 +62,7 @@ func (i *InstallKubeletModule) Init() {
 	}
 
 	i.Tasks = []task.Interface{
-		syncKubelet,
+		chmodKubelet,
 		generateKubeletService,
 		enableKubelet,
 		generateKubeletEnv,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
According to the definition of function `Execute`  about `SyncKubelet`, the task just changes the owner of `kubelet` binary. In addition, we can see the task of `SyncKubeBinary` do the work of syncing `kubelet` already.
As a result, maybe the name of  the task `SyncKubelet` changed to `ChownKubelet` is better for developers to understand.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
