### PR TITLE
Fix typo: change 'retires' to 'retries'

### DIFF
--- a/cmd/kk/pkg/core/task/local_task.go
+++ b/cmd/kk/pkg/core/task/local_task.go
@@ -165,7 +165,7 @@ func (l *LocalTask) Run(runtime connector.Runtime, host connector.Host, resCh ch
 
 func (l *LocalTask) WhenWithRetry(runtime connector.Runtime, host connector.Host) (bool, error) {
 	pass := false
-	err := fmt.Errorf("pre-check exec failed after %d retires", l.Retry)
+	err := fmt.Errorf("pre-check exec failed after %d retries", l.Retry)
 	for i := 0; i < l.Retry; i++ {
 		if res, e := l.When(runtime); e != nil {
 			logger.Log.Messagef(host.GetName(), e.Error())
@@ -200,7 +200,7 @@ func (l *LocalTask) When(runtime connector.Runtime) (bool, error) {
 }
 
 func (l *LocalTask) ExecuteWithRetry(runtime connector.Runtime, host connector.Host) error {
-	err := fmt.Errorf("[%s] exec failed after %d retires: ", l.Name, l.Retry)
+	err := fmt.Errorf("[%s] exec failed after %d retries: ", l.Name, l.Retry)
 	for i := 0; i < l.Retry; i++ {
 		e := l.Action.Execute(runtime)
 		if e != nil {

--- a/cmd/kk/pkg/core/task/remote_task.go
+++ b/cmd/kk/pkg/core/task/remote_task.go
@@ -188,7 +188,7 @@ func (t *RemoteTask) When(runtime connector.Runtime) (bool, error) {
 
 func (t *RemoteTask) WhenWithRetry(runtime connector.Runtime) (bool, error) {
 	pass := false
-	err := fmt.Errorf("pre-check exec failed after %d retires", t.Retry)
+	err := fmt.Errorf("pre-check exec failed after %d retries", t.Retry)
 	for i := 0; i < t.Retry; i++ {
 		if res, e := t.When(runtime); e != nil {
 			logger.Log.Messagef(runtime.RemoteHost().GetName(), e.Error())
@@ -211,7 +211,7 @@ func (t *RemoteTask) WhenWithRetry(runtime connector.Runtime) (bool, error) {
 }
 
 func (t *RemoteTask) ExecuteWithRetry(runtime connector.Runtime) error {
-	err := fmt.Errorf("[%s] exec failed after %d retires: ", t.Name, t.Retry)
+	err := fmt.Errorf("[%s] exec failed after %d retries: ", t.Name, t.Retry)
 	for i := 0; i < t.Retry; i++ {
 		e := t.Action.Execute(runtime)
 		if e != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
cleanup
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Corrected a typo in the code: 'retires' to 'retries'
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
