### PR TITLE
chore: fix spelling mistakes of  the tasks in coredns module

### DIFF
--- a/cmd/kk/pkg/kubernetes/tasks.go
+++ b/cmd/kk/pkg/kubernetes/tasks.go
@@ -785,7 +785,7 @@ spec:
 func OverrideCoreDNSService(runtime connector.Runtime, kubeAction common.KubeAction) error {
 	host := runtime.RemoteHost()
 
-	generateCoreDNDSvc := &task.RemoteTask{
+	generateCoreDNSSvc := &task.RemoteTask{
 		Name:  "GenerateCoreDNSSvc",
 		Desc:  "generate coredns service",
 		Hosts: []connector.Host{host},
@@ -873,7 +873,7 @@ func OverrideCoreDNSService(runtime connector.Runtime, kubeAction common.KubeAct
 
 	tasks := []task.Interface{
 		override,
-		generateCoreDNDSvc,
+		generateCoreDNSSvc,
 		override,
 		generateNodeLocalDNS,
 		applyNodeLocalDNS,

--- a/cmd/kk/pkg/plugins/dns/module.go
+++ b/cmd/kk/pkg/plugins/dns/module.go
@@ -36,7 +36,7 @@ func (c *ClusterDNSModule) Init() {
 	c.Name = "ClusterDNSModule"
 	c.Desc = "Deploy cluster dns"
 
-	generateCoreDNDSvc := &task.RemoteTask{
+	generateCoreDNSSvc := &task.RemoteTask{
 		Name:  "GenerateCoreDNSSvc",
 		Desc:  "Generate coredns service",
 		Hosts: c.Runtime.GetHostsByRole(common.Master),
@@ -125,7 +125,7 @@ func (c *ClusterDNSModule) Init() {
 	}
 
 	c.Tasks = []task.Interface{
-		generateCoreDNDSvc,
+		generateCoreDNSSvc,
 		override,
 		generateNodeLocalDNS,
 		applyNodeLocalDNS,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
Fix the spelling mistakes of the tasks:

- `generateCoreDNSSvc` in `ClusterDNSMoule` 

- `generateCoreDNSSvc` in `OverrideCoreDNSService`
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
