### PR TITLE
fix: Add worker label according to host role

### DIFF
--- a/cmd/kk/pkg/k3s/module.go
+++ b/cmd/kk/pkg/k3s/module.go
@@ -195,20 +195,6 @@ func (i *InitClusterModule) Init() {
 		Retry:    5,
 	}
 
-	addWorkerLabel := &task.RemoteTask{
-		Name:  "AddWorkerLabel",
-		Desc:  "Add worker label",
-		Hosts: i.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-			&ClusterIsExist{Not: true},
-			new(common.IsWorker),
-		},
-		Action:   new(AddWorkerLabel),
-		Parallel: true,
-		Retry:    5,
-	}
-
 	i.Tasks = []task.Interface{
 		k3sService,
 		k3sEnv,
@@ -216,7 +202,6 @@ func (i *InitClusterModule) Init() {
 		enableK3s,
 		copyKubeConfig,
 		addMasterTaint,
-		addWorkerLabel,
 	}
 }
 

--- a/cmd/kk/pkg/k3s/tasks.go
+++ b/cmd/kk/pkg/k3s/tasks.go
@@ -374,11 +374,16 @@ type AddWorkerLabel struct {
 }
 
 func (a *AddWorkerLabel) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().SudoCmd(
-		"/usr/local/bin/kubectl label nodes --selector='!node-role.kubernetes.io/worker' node-role.kubernetes.io/worker=",
-		true); err != nil {
-		return errors.Wrap(errors.WithStack(err), "add worker label failed")
+	for _, host := range runtime.GetAllHosts() {
+		if host.IsRole(common.Worker) {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
+				"/usr/local/bin/kubectl label --overwrite node %s node-role.kubernetes.io/worker=",
+				host.GetName()), true); err != nil {
+				return errors.Wrap(errors.WithStack(err), "add worker label failed")
+			}
+		}
 	}
+
 	return nil
 }
 

--- a/cmd/kk/pkg/k8e/module.go
+++ b/cmd/kk/pkg/k8e/module.go
@@ -182,27 +182,12 @@ func (i *InitClusterModule) Init() {
 		Retry:    5,
 	}
 
-	addWorkerLabel := &task.RemoteTask{
-		Name:  "AddWorkerLabel",
-		Desc:  "Add worker label",
-		Hosts: i.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-			&ClusterIsExist{Not: true},
-			new(common.IsWorker),
-		},
-		Action:   new(AddWorkerLabel),
-		Parallel: true,
-		Retry:    5,
-	}
-
 	i.Tasks = []task.Interface{
 		k8eService,
 		k8eEnv,
 		enableK8e,
 		copyKubeConfig,
 		addMasterTaint,
-		addWorkerLabel,
 	}
 }
 

--- a/cmd/kk/pkg/k8e/tasks.go
+++ b/cmd/kk/pkg/k8e/tasks.go
@@ -369,11 +369,16 @@ type AddWorkerLabel struct {
 }
 
 func (a *AddWorkerLabel) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().SudoCmd(
-		"/usr/local/bin/kubectl label nodes --selector='!node-role.kubernetes.io/worker' node-role.kubernetes.io/worker=",
-		true); err != nil {
-		return errors.Wrap(errors.WithStack(err), "add worker label failed")
+	for _, host := range runtime.GetAllHosts() {
+		if host.IsRole(common.Worker) {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
+				"/usr/local/bin/kubectl label --overwrite node %s node-role.kubernetes.io/worker=",
+				host.GetName()), true); err != nil {
+				return errors.Wrap(errors.WithStack(err), "add worker label failed")
+			}
+		}
 	}
+
 	return nil
 }
 

--- a/cmd/kk/pkg/kubernetes/module.go
+++ b/cmd/kk/pkg/kubernetes/module.go
@@ -188,26 +188,11 @@ func (i *InitKubernetesModule) Init() {
 		Retry:    5,
 	}
 
-	addWorkerLabel := &task.RemoteTask{
-		Name:  "AddWorkerLabel",
-		Desc:  "Add worker label",
-		Hosts: i.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-			&ClusterIsExist{Not: true},
-			new(common.IsWorker),
-		},
-		Action:   new(AddWorkerLabel),
-		Parallel: true,
-		Retry:    5,
-	}
-
 	i.Tasks = []task.Interface{
 		generateKubeadmConfig,
 		kubeadmInit,
 		copyKubeConfig,
 		removeMasterTaint,
-		addWorkerLabel,
 	}
 }
 

--- a/cmd/kk/pkg/kubernetes/tasks.go
+++ b/cmd/kk/pkg/kubernetes/tasks.go
@@ -400,11 +400,16 @@ type AddWorkerLabel struct {
 }
 
 func (a *AddWorkerLabel) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().SudoCmd(
-		"/usr/local/bin/kubectl label nodes --selector='!node-role.kubernetes.io/worker' node-role.kubernetes.io/worker=",
-		true); err != nil {
-		return errors.Wrap(errors.WithStack(err), "add worker label failed")
+	for _, host := range runtime.GetAllHosts() {
+		if host.IsRole(common.Worker) {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
+				"/usr/local/bin/kubectl label --overwrite node %s node-role.kubernetes.io/worker=",
+				host.GetName()), true); err != nil {
+				return errors.Wrap(errors.WithStack(err), "add worker label failed")
+			}
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Add worker label according to host role
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
