### PR TITLE
fix: Add multiple etcd nodes failed

### DIFF
--- a/cmd/kk/pkg/etcd/module.go
+++ b/cmd/kk/pkg/etcd/module.go
@@ -311,15 +311,6 @@ func handleExistCluster(c *ConfigureModule) []task.Interface {
 		Parallel: false,
 	}
 
-	restart := &task.RemoteTask{
-		Name:     "RestartETCD",
-		Desc:     "Restart etcd",
-		Hosts:    c.Runtime.GetHostsByRole(common.ETCD),
-		Prepare:  &NodeETCDExist{Not: true},
-		Action:   new(RestartETCD),
-		Parallel: true,
-	}
-
 	newETCDNodeHealthCheck := &task.RemoteTask{
 		Name:     "NewETCDNodeHealthCheck",
 		Desc:     "Health check on new etcd",
@@ -360,7 +351,6 @@ func handleExistCluster(c *ConfigureModule) []task.Interface {
 		existETCDHealthCheck,
 		generateETCDConfig,
 		joinMember,
-		restart,
 		newETCDNodeHealthCheck,
 		checkMember,
 		allRefreshETCDConfig,

--- a/cmd/kk/pkg/etcd/tasks.go
+++ b/cmd/kk/pkg/etcd/tasks.go
@@ -349,6 +349,12 @@ func (j *JoinMember) Execute(runtime connector.Runtime) error {
 	} else {
 		return errors.New("get etcd cluster status by pipeline cache failed")
 	}
+
+	// After adding a new member for etcd, it is necessary to start the new member as the etcd cluster may experience abnormal behavior.
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl restart etcd && systemctl enable etcd", true); err != nil {
+		return errors.Wrap(errors.WithStack(err), "start etcd failed")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
fix: Add multiple etcd nodes failed
### Which issue(s) this PR fixes:
https://github.com/kubesphere/kubekey/issues/1837
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
