### PR TITLE
[#1853] update the way to get containerd cgroup driver config

### DIFF
--- a/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -383,7 +383,7 @@ func GetKubeletCgroupDriver(runtime connector.Runtime, kubeConf *common.KubeConf
 	case common.Crio:
 		cmd = "crio config | grep cgroup_manager"
 	case common.Conatinerd:
-		cmd = "containerd config dump | grep -i systemd |grep -i cgroup"
+		cmd = "containerd config dump | grep -i systemd |grep -i cgroup || echo 'SystemdCgroup = false'"
 	case common.Isula:
 		cmd = "isula info | grep 'Cgroup Driver'"
 	default:

--- a/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -383,7 +383,7 @@ func GetKubeletCgroupDriver(runtime connector.Runtime, kubeConf *common.KubeConf
 	case common.Crio:
 		cmd = "crio config | grep cgroup_manager"
 	case common.Conatinerd:
-		cmd = "containerd config dump | grep SystemdCgroup"
+		cmd = "containerd config dump | grep -i systemd |grep -i cgroup"
 	case common.Isula:
 		cmd = "isula info | grep 'Cgroup Driver'"
 	default:

--- a/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -383,7 +383,7 @@ func GetKubeletCgroupDriver(runtime connector.Runtime, kubeConf *common.KubeConf
 	case common.Crio:
 		cmd = "crio config | grep cgroup_manager"
 	case common.Conatinerd:
-		cmd = "containerd config dump | grep -i systemd |grep -i cgroup || echo 'SystemdCgroup = false'"
+		cmd = "containerd config dump | grep SystemdCgroup || echo 'SystemdCgroup = false'"
 	case common.Isula:
 		cmd = "isula info | grep 'Cgroup Driver'"
 	default:


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
Fix installation error.

> Failed to get container runtime cgroup driver.: Failed to exec command: sudo -E /bin/bash -c "containerd config dump | grep SystemdCgroup"

### Which issue(s) this PR fixes:
Fixes #1853