### PR TITLE
add clean up the VXLAN interface when delete the cluster

### DIFF
--- a/cmd/kk/pkg/bootstrap/os/tasks.go
+++ b/cmd/kk/pkg/bootstrap/os/tasks.go
@@ -179,6 +179,8 @@ var (
 		"ip link del flannel-wg-v6",
 		"ip link del cilium_host",
 		"ip link del cilium_vxlan",
+		"ip link del vxlan.calico",
+		"ip link del vxlan-v6.calico",
 		"ip -br link show | grep 'cali[a-f0-9]*' | awk -F '@' '{print $1}' | xargs -r -t -n 1 ip link del",
 		"ip netns show 2>/dev/null | grep cni- | xargs -r -t -n 1 ip netns del",
 	}


### PR DESCRIPTION

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
If we create cluster with VXLAN mode before，and when we reinstall the cluster with VXLAN mode again，we will meet the situation that we can not ping other nodes's pod. Because the VXLAN does not send the package to other node. This situation will occur at some calico version. 
We clean up the VXLAN interface when delete cluster, then reinstall the cluster with VXLAN mode again. The Calico VXLAN mode network works well.
So we need clean up the VXLAN interface when we delete the cluster. 
