### PR TITLE
fix(kubeadm): certSANs use quotes, avoid to be parsed as int

### DIFF
--- a/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/cmd/kk/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -84,7 +84,7 @@ apiServer:
 {{ toYaml .ApiServerArgs | indent 4}}
   certSANs:
     {{- range .CertSANs }}
-    - {{ . }}
+    - "{{ . }}"
     {{- end }}
 controllerManager:
   extraArgs:


### PR DESCRIPTION
If not, when we name a node as number, kubeadm will init failed:
```log
json: cannot unmarshal number into Go struct field APIServer.apiServer.certSANs of type string
```