### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cmd/kk/pkg/registry/docker_registry_config.go
+++ b/cmd/kk/pkg/registry/docker_registry_config.go
@@ -18,7 +18,7 @@ package registry
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,9 +81,17 @@ func LookupCertsFile(path string) (ca string, cert string, key string, err error
 		return
 	}
 	logger.Log.Debugf("Looking for TLS certificates and private keys in abs path %s", absPath)
-	fs, err := ioutil.ReadDir(absPath)
+	entries, err := os.ReadDir(absPath)
 	if err != nil {
 		return ca, cert, key, err
+	}
+	fs := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return ca, cert, key, err
+		}
+		fs = append(fs, info)
 	}
 
 	for _, f := range fs {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup


### What this PR does / why we need it:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
