### PR TITLE
fix: add secret option to auth-type.

### DIFF
--- a/api/v1beta1/auth_types.go
+++ b/api/v1beta1/auth_types.go
@@ -42,6 +42,12 @@ type Auth struct {
 	// +optional
 	PrivateKeyPath string `yaml:"privateKeyPath,omitempty" json:"privateKeyPath,omitempty"`
 
+	// Secret is the secret of the PrivateKey or Password for SSH authentication.It should in the same namespace as capkk.
+	// When Password is empty, replace it with data.password.
+	// When PrivateKey is empty, replace it with data.privateKey
+	// +optional
+	Secret string `yaml:"secret,omitempty" json:"secret,omitempty"`
+
 	// Timeout is the timeout for establish an SSH connection.
 	// +optional
 	Timeout *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`

--- a/api/v1beta1/kkcluster_webhook.go
+++ b/api/v1beta1/kkcluster_webhook.go
@@ -195,7 +195,7 @@ func validateLoadBalancer(loadBalancer *KKLoadBalancerSpec) []*field.Error {
 func validateClusterNodes(nodes Nodes) []*field.Error {
 	var errs field.ErrorList
 
-	if nodes.Auth.Password == "" && nodes.Auth.PrivateKey == "" && nodes.Auth.PrivateKeyPath == "" {
+	if nodes.Auth.Password == "" && nodes.Auth.PrivateKey == "" && nodes.Auth.PrivateKeyPath == "" && nodes.Auth.Secret == "" {
 		errs = append(errs, field.Required(field.NewPath("spec", "nodes", "auth"), "password and privateKey can't both be empty"))
 	}
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kkclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kkclusters.yaml
@@ -154,6 +154,12 @@ spec:
                         description: PrivateKeyFile is the path to the private key
                           for SSH authentication.
                         type: string
+                      secret:
+                        description: Secret is the secret of the PrivateKey or Password
+                          for SSH authentication.It should in the same namespace as
+                          capkk. When Password is empty, replace it with data.password.
+                          When PrivateKey is empty, replace it with data.privateKey
+                        type: string
                       timeout:
                         description: Timeout is the timeout for establish an SSH connection.
                         format: int64
@@ -192,6 +198,13 @@ spec:
                             privateKeyPath:
                               description: PrivateKeyFile is the path to the private
                                 key for SSH authentication.
+                              type: string
+                            secret:
+                              description: Secret is the secret of the PrivateKey
+                                or Password for SSH authentication.It should in the
+                                same namespace as capkk. When Password is empty, replace
+                                it with data.password. When PrivateKey is empty, replace
+                                it with data.privateKey
                               type: string
                             timeout:
                               description: Timeout is the timeout for establish an

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kkclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kkclustertemplates.yaml
@@ -175,6 +175,13 @@ spec:
                                 description: PrivateKeyFile is the path to the private
                                   key for SSH authentication.
                                 type: string
+                              secret:
+                                description: Secret is the secret of the PrivateKey
+                                  or Password for SSH authentication.It should in
+                                  the same namespace as capkk. When Password is empty,
+                                  replace it with data.password. When PrivateKey is
+                                  empty, replace it with data.privateKey
+                                type: string
                               timeout:
                                 description: Timeout is the timeout for establish
                                   an SSH connection.
@@ -217,6 +224,13 @@ spec:
                                     privateKeyPath:
                                       description: PrivateKeyFile is the path to the
                                         private key for SSH authentication.
+                                      type: string
+                                    secret:
+                                      description: Secret is the secret of the PrivateKey
+                                        or Password for SSH authentication.It should
+                                        in the same namespace as capkk. When Password
+                                        is empty, replace it with data.password. When
+                                        PrivateKey is empty, replace it with data.privateKey
                                       type: string
                                     timeout:
                                       description: Timeout is the timeout for establish

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kkinstances.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kkinstances.yaml
@@ -85,6 +85,12 @@ spec:
                     description: PrivateKeyFile is the path to the private key for
                       SSH authentication.
                     type: string
+                  secret:
+                    description: Secret is the secret of the PrivateKey or Password
+                      for SSH authentication.It should in the same namespace as capkk.
+                      When Password is empty, replace it with data.password. When
+                      PrivateKey is empty, replace it with data.privateKey
+                    type: string
                   timeout:
                     description: Timeout is the timeout for establish an SSH connection.
                     format: int64

--- a/controllers/kkinstance/kkinstance_controller.go
+++ b/controllers/kkinstance/kkinstance_controller.go
@@ -19,15 +19,15 @@ package kkinstance
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
add secret option for auth-type in kkcluster. the secret should container to key: `password` and `privateKey`. It will set default values for `password` and `privateKey` in `kkcluster.spec.nodes.auth`.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
https://github.com/kubesphere/kubekey/issues/1875
