### PR TITLE
docs: correct the etcd related number type

### DIFF
--- a/docs/config-example.md
+++ b/docs/config-example.md
@@ -111,24 +111,24 @@ spec:
     #   keyFile: /pki/etcd/etcd.key
     dataDir: "/var/lib/etcd"
     # Time (in milliseconds) of a heartbeat interval.
-    heartbeatInterval: "250"
+    heartbeatInterval: 250
     # Time (in milliseconds) for an election to timeout. 
-    electionTimeout: "5000"
+    electionTimeout: 5000
     # Number of committed transactions to trigger a snapshot to disk.
-    snapshotCount: "10000"
+    snapshotCount: 10000
     # Auto compaction retention for mvcc key value store in hour. 0 means disable auto compaction.
-    autoCompactionRetention: "8"
+    autoCompactionRetention: 8
     # Set level of detail for etcd exported metrics, specify 'extensive' to include histogram metrics.
     metrics: basic
     ## Etcd has a default of 2G for its space quota. If you put a value in etcd_memory_limit which is less than
     ## etcd_quota_backend_bytes, you may encounter out of memory terminations of the etcd cluster. Please check
     ## etcd documentation for more information.
     # 8G is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
-    quotaBackendBytes: "2147483648" 
+    quotaBackendBytes: 2147483648 
     # Maximum client request size in bytes the server will accept.
     # etcd is designed to handle small key value pairs typical for metadata.
     # Larger requests will work, but may increase the latency of other requests
-    maxRequestBytes: "1572864"
+    maxRequestBytes: 1572864
     # Maximum number of snapshot files to retain (0 is unlimited)
     maxSnapshots: 5
     # Maximum number of wal files to retain (0 is unlimited)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation


### What this PR does / why we need it:
The example config file does not match with the latest code lines.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
None
```

See also https://github.com/kubesphere/kubekey/blob/ba5daf36534f007a8afd92f8f0706e818adf80ca/cmd/kk/apis/kubekey/v1alpha2/etcd_types.go#L36

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
