### PR TITLE
fix: imagefullName support more than two slash-separated

### DIFF
--- a/cmd/kk/pkg/images/tasks.go
+++ b/cmd/kk/pkg/images/tasks.go
@@ -179,7 +179,7 @@ func (s *SaveImages) Execute(runtime connector.Runtime) error {
 			// Ex:
 			// oci:./kubekey/artifact/images:kubesphere:kube-apiserver:v1.21.5-amd64
 			// oci:./kubekey/artifact/images:kubesphere:kube-apiserver:v1.21.5-arm-v7
-			destName := fmt.Sprintf("oci:%s:%s:%s-%s%s", dirName, imageFullName[1], imageFullName[2], arch, variant)
+			destName := fmt.Sprintf("oci:%s:%s:%s-%s%s", dirName, imageFullName[1], suffixImageName(imageFullName[2:]), arch, variant)
 			logger.Log.Infof("Source: %s", srcName)
 			logger.Log.Infof("Destination: %s", destName)
 

--- a/cmd/kk/pkg/images/utils.go
+++ b/cmd/kk/pkg/images/utils.go
@@ -173,11 +173,18 @@ func NewManifestSpec(image string, entries []manifesttypes.ManifestEntry) manife
 
 func validateImageName(imageFullName string) error {
 	image := strings.Split(imageFullName, "/")
-	if len(image) != 3 {
-		return errors.Errorf("image %s is invalid, only the format \"registry/namespace/name:tag\" is supported", imageFullName)
+	if len(image) < 3 {
+		return errors.Errorf("image %s is invalid, image PATH need contain at least two slash-separated", imageFullName)
 	}
-	if len(strings.Split(image[2], ":")) != 2 {
-		return errors.Errorf("image %s is invalid, only the format \"registry/namespace/name:tag\" is supported", imageFullName)
+	if len(strings.Split(image[len(image)-1], ":")) != 2 {
+		return errors.Errorf(`image %s is invalid, image PATH need contain ":"`, imageFullName)
 	}
 	return nil
+}
+
+func suffixImageName(imageFullName []string) string {
+	if len(imageFullName) >= 2 {
+		return strings.Join(imageFullName, "/")
+	}
+	return imageFullName[0]
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
for imagefullName support more than two slash-separated, like 10.121.218.184:30002/cache/goharbor/notary-server-photon:v2.8.2, While the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) supports more than two slash-separated components
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
  None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
