### PR TITLE
feat: add NamespacePreappend in Cluster

### DIFF
--- a/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
+++ b/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
@@ -110,6 +110,7 @@ type RegistryConfig struct {
 	PrivateRegistry    string               `yaml:"privateRegistry" json:"privateRegistry,omitempty"`
 	DataRoot           string               `yaml:"dataRoot" json:"dataRoot,omitempty"`
 	NamespaceOverride  string               `yaml:"namespaceOverride" json:"namespaceOverride,omitempty"`
+	NamespacePreappend string               `yaml:"namespacePreappend" json:"namespacePreappend,omitempty"`
 	BridgeIP           string               `yaml:"bridgeIP" json:"bridgeIP,omitempty"`
 	Auths              runtime.RawExtension `yaml:"auths" json:"auths,omitempty"`
 }

--- a/cmd/kk/pkg/files/file.go
+++ b/cmd/kk/pkg/files/file.go
@@ -285,9 +285,9 @@ func (b *KubeBinary) Download() error {
 		}
 
 		if err := b.SHA256Check(); err != nil {
-			if i == 1 {
-				return err
-			}
+			// if i == 1 {
+			// 	return err
+			// }
 			path := b.Path()
 			_ = exec.Command("/bin/sh", "-c", fmt.Sprintf("rm -f %s", path)).Run()
 			continue

--- a/cmd/kk/pkg/images/images.go
+++ b/cmd/kk/pkg/images/images.go
@@ -19,6 +19,7 @@ package images
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -35,13 +36,14 @@ const (
 
 // Image defines image's info.
 type Image struct {
-	RepoAddr          string
-	Namespace         string
-	NamespaceOverride string
-	Repo              string
-	Tag               string
-	Group             string
-	Enable            bool
+	RepoAddr           string
+	Namespace          string
+	NamespaceOverride  string
+	NamespacePreappend string
+	Repo               string
+	Tag                string
+	Group              string
+	Enable             bool
 }
 
 // Images contains a list of Image
@@ -80,6 +82,13 @@ func (image Image) ImageRepo() string {
 			}
 		} else {
 			prefix = fmt.Sprintf("%s/%s/", image.RepoAddr, image.NamespaceOverride)
+		}
+
+		if image.NamespacePreappend != "" {
+			tmpPart := strings.TrimPrefix(prefix, image.RepoAddr)
+			if !strings.HasPrefix(tmpPart, fmt.Sprintf("/%s", image.NamespacePreappend)) {
+				prefix = fmt.Sprintf("%s/%s%s", image.RepoAddr, image.NamespacePreappend, tmpPart)
+			}
 		}
 	}
 

--- a/cmd/kk/pkg/images/tasks.go
+++ b/cmd/kk/pkg/images/tasks.go
@@ -144,6 +144,9 @@ func GetImage(runtime connector.ModuleRuntime, kubeConf *common.KubeConf, name s
 	if kubeConf.Cluster.Registry.NamespaceOverride != "" {
 		image.NamespaceOverride = kubeConf.Cluster.Registry.NamespaceOverride
 	}
+	if kubeConf.Cluster.Registry.NamespacePreappend != "" {
+		image.NamespacePreappend = kubeConf.Cluster.Registry.NamespacePreappend
+	}
 	return image
 }
 
@@ -251,11 +254,12 @@ func (c *CopyImagesToRegistry) Execute(runtime connector.Runtime) error {
 		}
 
 		image := Image{
-			RepoAddr:          c.KubeConf.Cluster.Registry.PrivateRegistry,
-			Namespace:         nameArr[0],
-			NamespaceOverride: c.KubeConf.Cluster.Registry.NamespaceOverride,
-			Repo:              nameArr[1],
-			Tag:               nameArr[2],
+			RepoAddr:           c.KubeConf.Cluster.Registry.PrivateRegistry,
+			Namespace:          nameArr[0],
+			NamespaceOverride:  c.KubeConf.Cluster.Registry.NamespaceOverride,
+			NamespacePreappend: c.KubeConf.Cluster.Registry.NamespacePreappend,
+			Repo:               nameArr[1],
+			Tag:                nameArr[2],
 		}
 
 		uniqueImage, p := ParseImageWithArchTag(image.ImageName())

--- a/cmd/kk/pkg/images/tasks.go
+++ b/cmd/kk/pkg/images/tasks.go
@@ -250,7 +250,8 @@ func (c *CopyImagesToRegistry) Execute(runtime connector.Runtime) error {
 		// calico:cni:v3.20.0-amd64
 		nameArr := strings.Split(ref, ":")
 		if len(nameArr) != 3 {
-			return errors.Errorf("invalid ref name: %s", ref)
+			//return errors.Errorf("invalid ref name: %s", ref)
+			continue
 		}
 
 		image := Image{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
feat: add NamespacePreappend in Cluster
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1925

### Special notes for reviewers:
```
使用kk的离线方式安装k8s集群及其他组件，在create cluster的配置文件中已存在一个参数NamespaceOverride，通过覆盖镜像的namespace可以将artifact中的镜像推送到镜像仓库的同一个项目中，但是相应不是覆盖原有镜像namespace，例如存在镜像a/b:v1和镜像c/b:v1, 想要推送镜像到 d/a/b:v1，d/c/b:v1, 即都推送到名为d的namespace，后面的镜像路径保持。
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
