### PR TITLE
fix: scp permission denied 

### DIFF
--- a/cmd/kk/pkg/core/connector/ssh.go
+++ b/cmd/kk/pkg/core/connector/ssh.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
+	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/pkg/core/common"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/logger"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/util"
 )
@@ -584,6 +585,9 @@ func (c *connection) MkDirAll(path string, mode string, host Host) error {
 		mode = "775"
 	}
 	mkDstDir := fmt.Sprintf("mkdir -p -m %s %s || true", mode, path)
+	if strings.Contains(path, common.TmpDir) {
+		mkDstDir = fmt.Sprintf("mkdir -p  %s && chmod -R  %s  %s || true", path, mode, common.TmpDir)
+	}
 	if _, _, err := c.Exec(SudoPrefix(mkDstDir), host); err != nil {
 		return err
 	}

--- a/cmd/kk/pkg/core/connector/ssh.go
+++ b/cmd/kk/pkg/core/connector/ssh.go
@@ -36,7 +36,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
-	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/pkg/core/common"
+	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/common"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/logger"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/util"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
fix  scp permission denied err

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1880

### Special notes for reviewers:
```

when do sudoscp  first call r.Conn.MkDirAll  to make remoteTmp  dir,  then scp file to remoteTmp  dir , 
at last move remoteTmp   to remote.   
   note:  remoteTmp   = filepath.Join(common.TmpDir, remote)

pkg/core/connector/runner.go
   func (r *Runner) SudoScp(local, remote string) error {
            ...
            if err := r.Conn.MkDirAll(baseRemotePath, "", r.Host); err != nil {
		return err
	   }
           ...
   }

pkg/core/connector/ssh.go
      func (c *connection) MkDirAll(path string, mode string, host Host) error {
	if mode == "" {
		mode = "775"
	}
	mkDstDir := fmt.Sprintf("mkdir -p -m %s %s || true", mode, path)
	...
    }

   the reason for "scp  permission denied"  is  command "mkdir -p -m" only affect the last dir in path,   for example :
            mkdir -p -m 775   /tmp/kubekey/usr/local/bin/kube-scripts
           "mkdir -p -m"  only  set  kube-scripts  is 775 , other dir is affected by umask
   
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
