### PR TITLE
When joining a node, keep HAProxy consistent, as in the case of adding a node.

### DIFF
--- a/cmd/kk/pkg/phase/kubernetes/join.go
+++ b/cmd/kk/pkg/phase/kubernetes/join.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/module"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/pipeline"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/kubernetes"
+	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/loadbalancer"
 )
 
 func NewCreateJoinNodesPipeline(runtime *common.KubeRuntime) error {
@@ -31,6 +32,7 @@ func NewCreateJoinNodesPipeline(runtime *common.KubeRuntime) error {
 		&precheck.NodePreCheckModule{},
 		&kubernetes.StatusModule{},
 		&kubernetes.JoinNodesModule{},
+		&loadbalancer.HaproxyModule{Skip: !runtime.Cluster.ControlPlaneEndpoint.IsInternalLBEnabled()},
 	}
 
 	p := pipeline.Pipeline{


### PR DESCRIPTION
This commit is aimed at ensuring consistency between the effects of joining a node and adding a node, by enabling haproxy in both cases. Prior to this modification, haproxy was not started when joining a node, leading to functional abnormalities.