### PR TITLE
calculate sha256 file checksum by streaming

### DIFF
--- a/cmd/kk/pkg/files/file.go
+++ b/cmd/kk/pkg/files/file.go
@@ -320,9 +320,9 @@ func sha256sum(path string) (string, error) {
 	}
 	defer file.Close()
 
-	data, err := io.ReadAll(file)
-	if err != nil {
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
 }


### PR DESCRIPTION
### What type of PR is this?
calculate sha256 file checksum by streaming in order to compatible with machine with limited memory size.

/kind feature

### What this PR does / why we need it:
When I initiate harbor registry by kubekey command tool like this:
```shell
./kk init registry
```
It fails time by time with error message "Killed". After debug step by step, I found the root cause in file `cmd/kk/pkg/files/file.go` function `sha256sum`
```go
func (b *KubeBinary) Download() error {
	for i := 5; i > 0; i-- {
		...
		if err := b.SHA256Check(); err != nil {
		    ...
                }
	}
	return nil
}
// SHA256Check is used to hash checks on downloaded binary. (sha256)
func (b *KubeBinary) SHA256Check() error {
	output, err := sha256sum(b.Path())
        ...
	return nil
}

func sha256sum(path string) (string, error) {
	file, err := os.Open(path)
	if err != nil {
		return "", err
	}
	defer file.Close()

	data, err := io.ReadAll(file)
	if err != nil {
		return "", err
	}
	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
}
```
In order to calculate sha256 file checksum in function `sha256sum`,it read all file content into memory.
but I have a server with very low memory(only 2GB), when I run this command, the process be killed by system because of the memory exhausted.
so I changed it into streaming calculate sha256 file checksum, like this:
```go
func sha256sum(path string) (string, error) {
	file, err := os.Open(path)
	if err != nil {
		return "", err
	}
	defer file.Close()

	hasher := sha256.New()
	if _, err := io.Copy(hasher, file); err != nil {
		return "", err
	}
	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
}
```
It works fine on my server.