### PR TITLE
fix: backup script doesn't work when set etcd dataDir to another dir except '/var/lib/etcd'

### DIFF
--- a/cmd/kk/pkg/etcd/tasks.go
+++ b/cmd/kk/pkg/etcd/tasks.go
@@ -406,6 +406,7 @@ func (b *BackupETCD) Execute(runtime connector.Runtime) error {
 		Data: util.Data{
 			"Hostname":            runtime.RemoteHost().GetName(),
 			"Etcdendpoint":        fmt.Sprintf("https://%s:2379", runtime.RemoteHost().GetInternalAddress()),
+			"DataDir":             b.KubeConf.Cluster.Etcd.DataDir,
 			"Backupdir":           b.KubeConf.Cluster.Etcd.BackupDir,
 			"KeepbackupNumber":    b.KubeConf.Cluster.Etcd.KeepBackupNumber + 1,
 			"EtcdBackupScriptDir": b.KubeConf.Cluster.Etcd.BackupScriptDir,

--- a/cmd/kk/pkg/etcd/templates/backup_script.go
+++ b/cmd/kk/pkg/etcd/templates/backup_script.go
@@ -32,7 +32,11 @@ set -o pipefail
 
 ETCDCTL_PATH='/usr/local/bin/etcdctl'
 ENDPOINTS='{{ .Etcdendpoint }}'
+{{- if .DataDir }}
+ETCD_DATA_DIR="{{ .DataDir }}"
+{{- else }}
 ETCD_DATA_DIR="/var/lib/etcd"
+{{- end }}
 BACKUP_DIR="{{ .Backupdir }}/etcd-$(date +%Y-%m-%d-%H-%M-%S)"
 KEEPBACKUPNUMBER='{{ .KeepbackupNumber }}'
 ETCDBACKUPSCIPT='{{ .EtcdBackupScriptDir }}'


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
backup script doesn't work when set etcd dataDir to another dir except '/var/lib/etcd'

