### PR TITLE
Replace "which" with "command -v"

### DIFF
--- a/cmd/kk/pkg/container/prepares.go
+++ b/cmd/kk/pkg/container/prepares.go
@@ -29,7 +29,7 @@ type DockerExist struct {
 }
 
 func (d *DockerExist) PreCheck(runtime connector.Runtime) (bool, error) {
-	output, err := runtime.GetRunner().SudoCmd("if [ -z $(which docker) ] || [ ! -e /var/run/docker.sock ]; "+
+	output, err := runtime.GetRunner().SudoCmd("if [ -z $(command -v docker) ] || [ ! -e /var/run/docker.sock ]; "+
 		"then echo 'not exist'; "+
 		"fi", false)
 	if err != nil {
@@ -48,7 +48,7 @@ type CrictlExist struct {
 
 func (c *CrictlExist) PreCheck(runtime connector.Runtime) (bool, error) {
 	output, err := runtime.GetRunner().SudoCmd(
-		"if [ -z $(which crictl) ]; "+
+		"if [ -z $(command -v crictl) ]; "+
 			"then echo 'not exist'; "+
 			"fi", false)
 	if err != nil {
@@ -68,7 +68,7 @@ type ContainerdExist struct {
 
 func (c *ContainerdExist) PreCheck(runtime connector.Runtime) (bool, error) {
 	output, err := runtime.GetRunner().SudoCmd(
-		"if [ -z $(which containerd) ] || [ ! -e /run/containerd/containerd.sock ]; "+
+		"if [ -z $(command -v containerd) ] || [ ! -e /run/containerd/containerd.sock ]; "+
 			"then echo 'not exist'; "+
 			"fi", false)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
On certain machines with shells like zsh, errors may occur when using "if...which".
We can resolve this issue by replacing "which" with "command -v".

```bash
[qemu-41] ~ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.6 LTS"
[qemu-41] ~ uname -a
Linux qemu-41 5.4.0-144-generic #161-Ubuntu SMP Fri Feb 3 14:49:04 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
```

before:
![Screenshot_20231221_154627](https://github.com/kubesphere/kubekey/assets/13790023/1415c3a3-c4dc-4ec6-8456-055f0f677df6)
```
08:16:14 UTC message: [qemu-43]
downloading image: kubesphere/pause:3.8
08:16:14 UTC message: [qemu-45]
downloading image: kubesphere/pause:3.8
08:16:14 UTC message: [qemu-43]
pull image failed: Failed to exec command: sudo -E /bin/bash -c "env PATH=$PATH crictl pull kubesphere/pause:3.8 --platform amd64" 
env: ‘crictl’: No such file or directory: Process exited with status 127
08:16:14 UTC message: [qemu-42]
pull image failed: Failed to exec command: sudo -E /bin/bash -c "env PATH=$PATH crictl pull kubesphere/pause:3.8 --platform amd64" 
env: ‘crictl’: No such file or directory: Process exited with status 127
env: ‘crictl’: No such file or directory: Process exited with status 127
```

after:
![Screenshot_20231221_154914](https://github.com/kubesphere/kubekey/assets/13790023/28c4ba53-af97-4d13-a994-1edf3a128f9d)



### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
