### PR TITLE
 fix : redeployment failure when internal ip is modified  

### DIFF
--- a/cmd/kk/pkg/bootstrap/os/tasks.go
+++ b/cmd/kk/pkg/bootstrap/os/tasks.go
@@ -258,6 +258,9 @@ func (r *RemoveFiles) Execute(runtime connector.Runtime) error {
 	for _, file := range clusterFiles {
 		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), true)
 	}
+	// remove pki/etcd Path if it exists, otherwise it will cause the etcd reinstallation to fail if ip change
+	pkiPath := fmt.Sprintf("%s/pki/etcd", runtime.GetWorkDir())
+	_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", pkiPath), true)
 	return nil
 }
 


### PR DESCRIPTION


### What type of PR is this?

/kind bug

### What this PR does / why we need it:
When deleting the cluster, delete the generated etcd certificates at the same time, to prevent the host from changing the internal ip, resulting in the redeployment failure.


### Special notes for reviewers:
None

