### PR TITLE
add flag skip-dependency-check when upgrade cluster

### DIFF
--- a/cmd/kk/cmd/upgrade/upgrade.go
+++ b/cmd/kk/cmd/upgrade/upgrade.go
@@ -31,14 +31,15 @@ import (
 )
 
 type UpgradeOptions struct {
-	CommonOptions    *options.CommonOptions
-	ClusterCfgFile   string
-	Kubernetes       string
-	EnableKubeSphere bool
-	KubeSphere       string
-	SkipPullImages   bool
-	DownloadCmd      string
-	Artifact         string
+	CommonOptions       *options.CommonOptions
+	ClusterCfgFile      string
+	Kubernetes          string
+	EnableKubeSphere    bool
+	KubeSphere          string
+	SkipPullImages      bool
+	SkipDependencyCheck bool
+	DownloadCmd         string
+	Artifact            string
 }
 
 func NewUpgradeOptions() *UpgradeOptions {
@@ -80,14 +81,15 @@ func (o *UpgradeOptions) Complete(cmd *cobra.Command, args []string) error {
 
 func (o *UpgradeOptions) Run() error {
 	arg := common.Argument{
-		FilePath:          o.ClusterCfgFile,
-		KubernetesVersion: o.Kubernetes,
-		KsEnable:          o.EnableKubeSphere,
-		KsVersion:         o.KubeSphere,
-		SkipPullImages:    o.SkipPullImages,
-		Debug:             o.CommonOptions.Verbose,
-		SkipConfirmCheck:  o.CommonOptions.SkipConfirmCheck,
-		Artifact:          o.Artifact,
+		FilePath:            o.ClusterCfgFile,
+		KubernetesVersion:   o.Kubernetes,
+		KsEnable:            o.EnableKubeSphere,
+		KsVersion:           o.KubeSphere,
+		SkipPullImages:      o.SkipPullImages,
+		Debug:               o.CommonOptions.Verbose,
+		SkipConfirmCheck:    o.CommonOptions.SkipConfirmCheck,
+		Artifact:            o.Artifact,
+		SkipDependencyCheck: o.SkipDependencyCheck,
 	}
 	return pipelines.UpgradeCluster(arg, o.DownloadCmd)
 }
@@ -100,6 +102,7 @@ func (o *UpgradeOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.DownloadCmd, "download-cmd", "", "curl -L -o %s %s",
 		`The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL`)
 	cmd.Flags().StringVarP(&o.Artifact, "artifact", "a", "", "Path to a KubeKey artifact")
+	cmd.Flags().BoolVarP(&o.SkipDependencyCheck, "skip-dependency-check", "", false, "Skip kubernetes and kubesphere dependency version check")
 }
 
 func completionSetting(cmd *cobra.Command) (err error) {

--- a/cmd/kk/pkg/bootstrap/precheck/module.go
+++ b/cmd/kk/pkg/bootstrap/precheck/module.go
@@ -88,6 +88,7 @@ func (n *NodePreCheckModule) Init() {
 
 type ClusterPreCheckModule struct {
 	common.KubeModule
+	SkipDependencyCheck bool
 }
 
 func (c *ClusterPreCheckModule) Init() {
@@ -159,13 +160,25 @@ func (c *ClusterPreCheckModule) Init() {
 		Parallel: true,
 	}
 
-	c.Tasks = []task.Interface{
-		getKubeConfig,
-		getAllNodesK8sVersion,
-		calculateMinK8sVersion,
-		checkDesiredK8sVersion,
-		ksVersionCheck,
-		dependencyCheck,
-		getKubernetesNodesStatus,
+	if !c.SkipDependencyCheck {
+		c.Tasks = []task.Interface{
+			getKubeConfig,
+			getAllNodesK8sVersion,
+			calculateMinK8sVersion,
+			checkDesiredK8sVersion,
+			ksVersionCheck,
+			dependencyCheck,
+			getKubernetesNodesStatus,
+		}
+	} else {
+		c.Tasks = []task.Interface{
+			getKubeConfig,
+			getAllNodesK8sVersion,
+			calculateMinK8sVersion,
+			checkDesiredK8sVersion,
+			ksVersionCheck,
+			getKubernetesNodesStatus,
+		}
 	}
+
 }

--- a/cmd/kk/pkg/common/kube_runtime.go
+++ b/cmd/kk/pkg/common/kube_runtime.go
@@ -39,6 +39,7 @@ type Argument struct {
 	IgnoreErr           bool
 	SkipPullImages      bool
 	SkipPushImages      bool
+	SkipDependencyCheck bool
 	SecurityEnhancement bool
 	DeployLocalStorage  *bool
 	DownloadCommand     func(path, url string) string

--- a/cmd/kk/pkg/pipelines/upgrade_cluster.go
+++ b/cmd/kk/pkg/pipelines/upgrade_cluster.go
@@ -40,7 +40,7 @@ func NewUpgradeClusterPipeline(runtime *common.KubeRuntime) error {
 	m := []module.Module{
 		&precheck.GreetingsModule{},
 		&precheck.NodePreCheckModule{},
-		&precheck.ClusterPreCheckModule{},
+		&precheck.ClusterPreCheckModule{SkipDependencyCheck: runtime.Arg.SkipDependencyCheck},
 		&confirm.UpgradeConfirmModule{Skip: runtime.Arg.SkipConfirmCheck},
 		&artifact.UnArchiveModule{Skip: noArtifact},
 		&kubernetes.SetUpgradePlanModule{Step: kubernetes.ToV121},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
kind feature


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
add command flag "skip-dependency-check" when upgrade cluster 

### Special notes for reviewers:
```
example: kk upgrade cluster -f config-sample.yaml --skip-dependency-check
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
