### PR TITLE
fix start docker error when init harbor

### DIFF
--- a/cmd/kk/pkg/bootstrap/registry/module.go
+++ b/cmd/kk/pkg/bootstrap/registry/module.go
@@ -170,6 +170,20 @@ func InstallHarbor(i *InstallRegistryModule) []task.Interface {
 		Retry:    2,
 	}
 
+	generateContainerdService := &task.RemoteTask{
+		Name:  "GenerateContainerdService",
+		Desc:  "Generate containerd service",
+		Hosts: i.Runtime.GetHostsByRole(common.K8s),
+		Prepare: &prepare.PrepareCollection{
+			&container.ContainerdExist{Not: true},
+		},
+		Action: &action.Template{
+			Template: docker_template.ContainerdService,
+			Dst:      filepath.Join("/etc/systemd/system", docker_template.ContainerdService.Name()),
+		},
+		Parallel: true,
+	}
+
 	generateDockerService := &task.RemoteTask{
 		Name:  "GenerateDockerService",
 		Desc:  "Generate docker service",
@@ -199,6 +213,17 @@ func InstallHarbor(i *InstallRegistryModule) []task.Interface {
 				"InsecureRegistries": docker_template.InsecureRegistries(i.KubeConf),
 			},
 		},
+		Parallel: true,
+	}
+
+	enableContainerdForDocker := &task.RemoteTask{
+		Name:  "EnableContainerd",
+		Desc:  "Enable containerd",
+		Hosts: i.Runtime.GetHostsByRole(common.K8s),
+		Prepare: &prepare.PrepareCollection{
+			&container.ContainerdExist{Not: true},
+		},
+		Action:   new(container.EnableContainerdForDocker),
 		Parallel: true,
 	}
 
@@ -250,10 +275,10 @@ func InstallHarbor(i *InstallRegistryModule) []task.Interface {
 	}
 
 	generateHarborConfig := &task.RemoteTask{
-		Name:   "GenerateHarborConfig",
-		Desc:   "Generate harbor config",
-		Hosts:  i.Runtime.GetHostsByRole(common.Registry),
-		Action: new(GenerateHarborConfig),
+		Name:     "GenerateHarborConfig",
+		Desc:     "Generate harbor config",
+		Hosts:    i.Runtime.GetHostsByRole(common.Registry),
+		Action:   new(GenerateHarborConfig),
 		Parallel: true,
 		Retry:    1,
 	}
@@ -269,8 +294,10 @@ func InstallHarbor(i *InstallRegistryModule) []task.Interface {
 
 	return []task.Interface{
 		syncBinaries,
+		generateContainerdService,
 		generateDockerService,
 		generateDockerConfig,
+		enableContainerdForDocker,
 		enableDocker,
 		installDockerCompose,
 		syncHarborPackage,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubekey/issues/2156

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
# /opt/kubekey/bin/kk init registry -f config-sample.yaml


 _   __      _          _   __
| | / /     | |        | | / /
| |/ / _   _| |__   ___| |/ /  ___ _   _
|    \| | | | '_ \ / _ \    \ / _ \ | | |
| |\  \ |_| | |_) |  __/ |\  \  __/ |_| |
\_| \_/\__,_|_.__/ \___\_| \_/\___|\__, |
                                    __/ |
                                   |___/

21:09:27 CST [GreetingsModule] Greetings
21:09:29 CST message: [test-3]
Greetings, KubeKey!
21:09:29 CST success: [test-3]
21:09:29 CST [RegistryPackageModule] Download registry package
21:09:29 CST message: [localhost]
downloading amd64 harbor v2.5.3  ...
21:09:37 CST message: [localhost]
downloading amd64 docker 24.0.9  ...
21:09:37 CST message: [localhost]
downloading amd64 compose v2.2.2  ...
21:09:38 CST success: [LocalHost]
21:09:38 CST [ConfigureOSModule] Get OS release
21:09:38 CST success: [test-3]
21:09:38 CST [ConfigureOSModule] Prepare to init OS
21:09:39 CST success: [test-3]
21:09:39 CST [ConfigureOSModule] Generate init os script
21:09:39 CST success: [test-3]
21:09:39 CST [ConfigureOSModule] Exec init os script
21:09:42 CST stdout: [test-3]
net.ipv4.conf.default.rp_filter = 1
net.ipv4.conf.all.rp_filter = 1
net.ipv4.ip_forward = 1
net.bridge.bridge-nf-call-iptables = 1
net.bridge.bridge-nf-call-arptables = 1
net.bridge.bridge-nf-call-ip6tables = 1
net.ipv4.ip_local_reserved_ports = 30000-32767
net.core.netdev_max_backlog = 65535
net.core.rmem_max = 33554432
net.core.wmem_max = 33554432
net.core.somaxconn = 32768
net.ipv4.tcp_max_syn_backlog = 1048576
net.ipv4.neigh.default.gc_thresh1 = 512
net.ipv4.neigh.default.gc_thresh2 = 2048
net.ipv4.neigh.default.gc_thresh3 = 4096
net.ipv4.tcp_retries2 = 15
net.ipv4.tcp_max_tw_buckets = 1048576
net.ipv4.tcp_max_orphans = 65535
net.ipv4.udp_rmem_min = 131072
net.ipv4.udp_wmem_min = 131072
net.ipv4.conf.all.arp_accept = 1
net.ipv4.conf.default.arp_accept = 1
net.ipv4.conf.all.arp_ignore = 1
net.ipv4.conf.default.arp_ignore = 1
vm.max_map_count = 262144
vm.swappiness = 0
vm.overcommit_memory = 0
fs.inotify.max_user_instances = 524288
fs.inotify.max_user_watches = 524288
fs.pipe-max-size = 4194304
fs.aio-max-nr = 262144
kernel.pid_max = 65535
kernel.watchdog_thresh = 5
kernel.hung_task_timeout_secs = 5
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
net.ipv6.conf.all.forwarding = 1
21:09:42 CST success: [test-3]
21:09:42 CST [ConfigureOSModule] configure the ntp server for each node
21:09:42 CST skipped: [test-3]
21:09:42 CST [InitRegistryModule] Fetch registry certs
21:09:42 CST success: [test-3]
21:09:42 CST [InitRegistryModule] Generate registry Certs
[certs] Using existing ca certificate authority
[certs] Using existing dockerhub.kubekey.local certificate and key on disk
21:09:42 CST success: [LocalHost]
21:09:42 CST [InitRegistryModule] Synchronize certs file
21:09:43 CST success: [test-3]
21:09:43 CST [InitRegistryModule] Synchronize certs file to all nodes
21:09:44 CST success: [test-3]
21:09:44 CST [InstallRegistryModule] Sync docker binaries
21:09:50 CST success: [test-3]
21:09:50 CST [InstallRegistryModule] Generate containerd service
21:09:50 CST success: [test-3]
21:09:50 CST [InstallRegistryModule] Generate docker service
21:09:50 CST success: [test-3]
21:09:50 CST [InstallRegistryModule] Generate docker config
21:09:51 CST success: [test-3]
21:09:51 CST [InstallRegistryModule] Enable containerd
21:09:53 CST success: [test-3]
21:09:53 CST [InstallRegistryModule] Enable docker
21:09:55 CST success: [test-3]
21:09:55 CST [InstallRegistryModule] Install docker compose
21:09:56 CST success: [test-3]
21:09:56 CST [InstallRegistryModule] Sync harbor package
21:10:29 CST success: [test-3]
21:10:29 CST [InstallRegistryModule] Generate harbor service
21:10:30 CST success: [test-3]
21:10:30 CST [InstallRegistryModule] Generate harbor config
21:10:30 CST success: [test-3]
21:10:30 CST [InstallRegistryModule] start harbor

Local image registry created successfully. Address: dockerhub.kubekey.local

21:12:17 CST success: [test-3]
21:12:17 CST [ChownWorkerModule] Chown ./kubekey dir
21:12:17 CST success: [LocalHost]
21:12:17 CST Pipeline[InitRegistryPipeline] execute successfully
```
