### PR TITLE
fix bug: upgrade k8s , kubeadm return coredns start version unsupported

### DIFF
--- a/cmd/kk/pkg/kubernetes/module.go
+++ b/cmd/kk/pkg/kubernetes/module.go
@@ -563,6 +563,7 @@ func (p *ProgressiveUpgradeModule) Init() {
 		Desc:  "Generate coredns manifests",
 		Hosts: p.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
+			new(NotEqualPlanVersion),
 			new(common.OnlyFirstMaster),
 		},
 		Action:   new(dns.GenerateCorednsmanifests),
@@ -574,6 +575,7 @@ func (p *ProgressiveUpgradeModule) Init() {
 		Desc:  "Deploy coredns",
 		Hosts: p.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
+			new(NotEqualPlanVersion),
 			new(common.OnlyFirstMaster),
 		},
 		Action:   new(dns.DeployCoreDNS),
@@ -585,6 +587,7 @@ func (p *ProgressiveUpgradeModule) Init() {
 		Desc:  "Generate nodelocaldns",
 		Hosts: p.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
+			new(NotEqualPlanVersion),
 			new(common.OnlyFirstMaster),
 			new(dns.EnableNodeLocalDNS),
 		},
@@ -604,6 +607,7 @@ func (p *ProgressiveUpgradeModule) Init() {
 		Desc:  "Deploy nodelocaldns",
 		Hosts: p.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
+			new(NotEqualPlanVersion),
 			new(common.OnlyFirstMaster),
 			new(dns.EnableNodeLocalDNS)},
 		Action:   new(dns.DeployNodeLocalDNS),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
kk version: build master
cmd: kk upgrade cluster -f config-sample.yaml 
when upgrade k8s v1.21.5 to v1.23.x , i receive error from kubeadm "postupgrade start version xxx is not support"
```
<img width="672" alt="企业微信截图_17109234886695" src="https://github.com/kubesphere/kubekey/assets/45817987/f182cf30-ed1f-453e-b790-0fd27bf90989">


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
