### PR TITLE
Debugged calico.tmpl to support IPv6

### DIFF
--- a/cmd/kk/pkg/plugins/network/templates/calico.tmpl
+++ b/cmd/kk/pkg/plugins/network/templates/calico.tmpl
@@ -4982,9 +4982,19 @@ spec:
             - name: CALICO_IPV4POOL_NAT_OUTGOING
               value: "false"
 {{- end }}
+{{- if .IPv6Support }}
+            # Enable or Disable VXLAN on the default IPv6 IP pool.
+            - name: CALICO_IPV6POOL_VXLAN
+              value: "Always"
+            - name: CALICO_IPV6POOL_NAT_OUTGOING
+              value: "true"
+{{- else }}
             # Enable or Disable VXLAN on the default IPv6 IP pool.
             - name: CALICO_IPV6POOL_VXLAN
               value: "Never"
+            - name: CALICO_IPV6POOL_NAT_OUTGOING
+              value: "false"
+{{- end }}
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:
@@ -5014,6 +5024,8 @@ spec:
 {{- if .IPv6Support }}
             - name: CALICO_IPV6POOL_CIDR
               value: "{{ .KubePodsV6CIDR }}"
+            - name: CALICO_IPV6POOL_BLOCK_SIZE
+              value: "120"
 {{- end }}
 {{- else }}
             - name: NO_DEFAULT_POOLS
@@ -5033,10 +5045,10 @@ spec:
             # Disable IPv6 on Kubernetes.
 {{- if .IPv6Support }}
             - name: FELIX_IPV6SUPPORT
-              value: "false"
+              value: "true"
 {{- else }}
             - name: FELIX_IPV6SUPPORT
-              value: "true"
+              value: "false"
 {{- end }}
             - name: FELIX_HEALTHENABLED
               value: "true"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Added support for setting CALICO_IPV6POOL_BLOCK_SIZE, CALICO_IPV6POOL_VXLAN, CALICO_IPV6POOL_NAT_OUTGOING and FELIX_IPV6SUPPORT.

Hard coded CALICO_IPV6POOL_BLOCK_SIZE as 120. Need to make CALICO_IPV6POOL_BLOCK_SIZE and CALICO_IPV4POOL_BLOCK_SIZE configurable by having something like network.calico.ipv6PoolBlockSize and network.calico.ipv4PoolBlockSize.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
