### PR TITLE
Fixes an issue where the DisableDocker action will remove docker-related files, including /usr/bin/containerd, when deleting clusters with the -A flag, which will cause containerd to fail to start when subsequent DaemonReload action are executed.

### DIFF
--- a/cmd/kk/pkg/container/docker.go
+++ b/cmd/kk/pkg/container/docker.go
@@ -182,7 +182,7 @@ func (d *DisableDocker) Execute(runtime connector.Runtime) error {
 		"/usr/bin/runc",
 		"/usr/bin/ctr",
 		"/usr/bin/docker*",
-		"/usr/bin/containerd*",
+		"/usr/bin/containerd-shim-runc-v2",
 		filepath.Join("/etc/systemd/system", templates.DockerService.Name()),
 		filepath.Join("/etc/docker", templates.DockerConfig.Name()),
 	}


### PR DESCRIPTION
Fixes an issue where the DisableDocker action will remove docker-related files, including /usr/bin/containerd, when deleting clusters with the -A flag, which will cause containerd to fail to start when subsequent DaemonReload action are executed.

### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:
When deleting clusters with the -A flag, the DisableDocker action will remove docker-related files, including /usr/bin/containerd,  which will cause containerd to fail to start when subsequent DaemonReload action are executed.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
