### PR TITLE
Add Flag --skip-remove-artifact to remain kubekey/artifact dir after exporting an artifact

### DIFF
--- a/cmd/kk/cmd/artifact/export.go
+++ b/cmd/kk/cmd/artifact/export.go
@@ -30,10 +30,11 @@ import (
 type ArtifactExportOptions struct {
 	CommonOptions *options.CommonOptions
 
-	ManifestFile string
-	Output       string
-	CriSocket    string
-	DownloadCmd  string
+	ManifestFile       string
+	Output             string
+	CriSocket          string
+	DownloadCmd        string
+	SkipRemoveArtifact bool
 }
 
 func NewArtifactExportOptions() *ArtifactExportOptions {
@@ -76,11 +77,12 @@ func (o *ArtifactExportOptions) Validate(_ []string) error {
 
 func (o *ArtifactExportOptions) Run() error {
 	arg := common.ArtifactArgument{
-		ManifestFile: o.ManifestFile,
-		Output:       o.Output,
-		CriSocket:    o.CriSocket,
-		Debug:        o.CommonOptions.Verbose,
-		IgnoreErr:    o.CommonOptions.IgnoreErr,
+		ManifestFile:       o.ManifestFile,
+		Output:             o.Output,
+		CriSocket:          o.CriSocket,
+		Debug:              o.CommonOptions.Verbose,
+		IgnoreErr:          o.CommonOptions.IgnoreErr,
+		SkipRemoveArtifact: o.SkipRemoveArtifact,
 	}
 
 	return pipelines.ArtifactExport(arg, o.DownloadCmd)
@@ -91,4 +93,6 @@ func (o *ArtifactExportOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "Path to a output path")
 	cmd.Flags().StringVarP(&o.DownloadCmd, "download-cmd", "", "curl -L -o %s %s",
 		`The user defined command to download the necessary binary files. The first param '%s' is output path, the second param '%s', is the URL`)
+	cmd.Flags().BoolVarP(&o.SkipRemoveArtifact, "skip-remove-artifact", "", false, "Skip remove artifact")
+
 }

--- a/cmd/kk/pkg/artifact/tasks.go
+++ b/cmd/kk/pkg/artifact/tasks.go
@@ -109,6 +109,11 @@ func (a *ArchiveDependencies) Execute(runtime connector.Runtime) error {
 		return errors.Wrapf(errors.WithStack(err), "archive %s failed", src)
 	}
 
+	// skip remove artifact if --skip-remove-artifact
+	if a.Manifest.Arg.SkipRemoveArtifact {
+		return nil
+	}
+
 	// remove the src directory
 	if err := os.RemoveAll(src); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "remove %s failed", src)

--- a/cmd/kk/pkg/common/artifact_runtime.go
+++ b/cmd/kk/pkg/common/artifact_runtime.go
@@ -29,12 +29,13 @@ import (
 )
 
 type ArtifactArgument struct {
-	ManifestFile    string
-	Output          string
-	CriSocket       string
-	Debug           bool
-	IgnoreErr       bool
-	DownloadCommand func(path, url string) string
+	ManifestFile       string
+	Output             string
+	CriSocket          string
+	Debug              bool
+	IgnoreErr          bool
+	DownloadCommand    func(path, url string) string
+	SkipRemoveArtifact bool
 }
 
 type ArtifactRuntime struct {


### PR DESCRIPTION
Add Flag --skip-remove-artifact to remain kubekey/artifact dir after exporting an artifact

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Some scenarios may require recreating artifact, such as adding a new image, which would need to re-download all files due to the deletion of the artifact directory. So, add an option to keep the artifact directory to reuse some of the files.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
