### PR TITLE
remove the IPV6 domain mapping from the /etc/hosts file when the host does not have an IPV6 address.

### DIFF
--- a/cmd/kk/pkg/bootstrap/os/templates/init_script.go
+++ b/cmd/kk/pkg/bootstrap/os/templates/init_script.go
@@ -245,11 +245,14 @@ func GenerateHosts(runtime connector.ModuleRuntime, kubeConf *common.KubeConf) [
 				host.GetName(),
 				kubeConf.Cluster.Kubernetes.ClusterName,
 				host.GetName()))
-			hostsList = append(hostsList, fmt.Sprintf("%s  %s.%s %s",
-				host.GetInternalIPv6Address(),
-				host.GetName(),
-				kubeConf.Cluster.Kubernetes.ClusterName,
-				host.GetName()))
+
+			if host.GetInternalIPv6Address() != "" {
+				hostsList = append(hostsList, fmt.Sprintf("%s  %s.%s %s",
+					host.GetInternalIPv6Address(),
+					host.GetName(),
+					kubeConf.Cluster.Kubernetes.ClusterName,
+					host.GetName()))
+			}
 		}
 	}
 


### PR DESCRIPTION
remove the IPV6 domain mapping from the `/etc/hosts` file when the host does not have an IPV6 address.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
When the host does not have IPV6 address, ConfigureOSModule will also write IPV6 domain mapping. It will cause /etc/hosts like following
![image](https://github.com/kubesphere/kubekey/assets/102210430/18a8935e-66ed-437a-b8ac-0ff6cf77877c)
It should not be IPV6 domain mapping when the host does not have IPV6 address in `/etc/hosts`.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
