### PR TITLE
feat: set CustomScriptTask workdir to remoteTaskHome

### DIFF
--- a/cmd/kk/pkg/bootstrap/customscripts/tasks.go
+++ b/cmd/kk/pkg/bootstrap/customscripts/tasks.go
@@ -96,8 +96,9 @@ func (t *CustomScriptTask) Execute(runtime connector.Runtime) error {
 		RunBash = "/bin/bash " + targetPath
 	}
 
+	cd_cmd := fmt.Sprintf("cd %s;", remoteTaskHome)
 	start := time.Now()
-	out, err := runtime.GetRunner().SudoCmd(RunBash, false)
+	out, err := runtime.GetRunner().SudoCmd(cd_cmd+RunBash, false)
 	if err != nil {
 		return errors.Errorf("Exec Bash: %s err:%s", RunBash, err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
when using custom scripts with materials, bash command' workdir is not at remoteTaskHome which saves the material files, so the custom scripts execute failed as it can not find the material files, change workdir to remoteTaskHome before bash command run makes it much better.

like this:
```yaml
spec:
  system:
    preInstall:
      - name: install nfs server
        role: nfs-server
        bash: |
          # workdir at remoteTaskHome
          /bin/bash -x install_nfs_server.sh
        materials:
          - ./scripts/install_nfs_server.sh
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
