### PR TITLE
add check support k8s version

### DIFF
--- a/cmd/kk/pkg/bootstrap/confirm/tasks.go
+++ b/cmd/kk/pkg/bootstrap/confirm/tasks.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"slices"
 	"strings"
 
 	versionK8S "github.com/kubesphere/kubekey/v3/cmd/kk/pkg/version/kubernetes"
@@ -36,6 +35,7 @@ import (
 	"github.com/modood/table"
 	"github.com/pkg/errors"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/utils/strings/slices"
 )
 
 // PreCheckResults defines the items to be checked.
@@ -114,11 +114,12 @@ func (i *InstallationConfirm) Execute(runtime connector.Runtime) error {
 	k8sVersion := i.KubeConf.Cluster.Kubernetes.Version
 	if k8sVersion != kubekeyapiv1alpha2.DefaultKubeVersion {
 		suppportVersions := versionK8S.SupportedK8sVersionList()
-		if !slices.ContainsFunc(suppportVersions, func(s string) bool {
-			return strings.Contains(s, k8sVersion)
-		}) {
-			fmt.Printf("The Kubernetes version :%s isn't support.\n", k8sVersion)
-			fmt.Println("Use kk version --show-supported-k8s, show support k8s versions")
+		if !strings.HasPrefix(k8sVersion, "v") {
+			k8sVersion = "v" + k8sVersion
+		}
+		if !slices.Contains(suppportVersions, k8sVersion) {
+			fmt.Printf("The Kubernetes version: %s isn't supported.\n", k8sVersion)
+			fmt.Println("Use kk version --show-supported-k8s,show supported k8s versions")
 			fmt.Println("")
 			stopFlag = true
 		} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

Use the following command to create a cluster: `kk create cluster -f cluster.yaml`.

If a Kubernetes version specified in cluster.yaml is not found in versions/components.json, the installation process should terminate. Instead of exiting after a failed SHA256 comparison following the download.

### What type of PR is this?
/kind feature


Optionally add one or more of the following kinds if applicable:
/kind flake



### What this PR does / why we need it:
Check the supported k8s versions and terminate early in the precheck.


### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?

```release-note
no
```


