### PR TITLE
feat: change etcd_disk_wal_fysnc_duration_seconds to variable.

### DIFF
--- a/builtin/roles/precheck/env_check/defaults/main.yaml
+++ b/builtin/roles/precheck/env_check/defaults/main.yaml
@@ -1,4 +1,6 @@
 cluster_require:
+  # the etcd sync duration for 99%.(unit us)
+  etcd_disk_wal_fysnc_duration_seconds: 10000
   allow_unsupported_distribution_setup: false
   # support ubuntu, centos.
   supported_os_distributions: ['ubuntu', 'centos']

--- a/builtin/roles/precheck/env_check/tasks/etcd.yaml
+++ b/builtin/roles/precheck/env_check/tasks/etcd.yaml
@@ -39,8 +39,8 @@
           register: fio_result
         - name: Check fio result
           assert:
-            that: fio_result.stdout.jobs|first|get:'sync'|get:'lat_ns'|get:'percentile'|get:'90.000000' <= 10000
-            fail_msg: "etcd_disk_wal_fysnc_duration_seconds: {{ fio_result.stdout.jobs|first|get:'sync'|get:'lat_ns'|get:'percentile'|get:'90.000000' }}us is more than 10000us"
+            that: fio_result.stdout.jobs|first|get:'sync'|get:'lat_ns'|get:'percentile'|get:'90.000000' <= cluster_require.etcd_disk_wal_fysnc_duration_seconds
+            fail_msg: "etcd_disk_wal_fysnc_duration_seconds: {{ fio_result.stdout.jobs|first|get:'sync'|get:'lat_ns'|get:'percentile'|get:'90.000000' }}us is more than {{ cluster_require.etcd_disk_wal_fysnc_duration_seconds }}us"
       always:
         - name: Clean test data dir
           command: rm -rf /tmp/kubekey/etcd/test-data


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
base: https://github.com/kubesphere/kubekey/pull/2285
specify different standards for different environments
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
change etcd_disk_wal_fysnc_duration_seconds to variable
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
