### PR TITLE
feat: save default variable to defaults directory

### DIFF
--- a/builtin/roles/certs/renew-kubernetes/defaults/main.yaml
+++ b/builtin/roles/certs/renew-kubernetes/defaults/main.yaml
@@ -1,0 +1,5 @@
+kubernetes:
+  etcd:
+    deployment_type: external
+cri:
+  container_manager: docker

--- a/builtin/roles/certs/renew-kubernetes/tasks/kube.yaml
+++ b/builtin/roles/certs/renew-kubernetes/tasks/kube.yaml
@@ -9,7 +9,7 @@
   tags: ["certs"]
   run_once: true
   command: |
-    {% if (kubeadm_install_version.stdout|version:'<v1.20.0' %}
+    {% if (kubeadm_install_version.stdout|version:'<v1.20.0') %}
     /usr/local/bin/kubeadm alpha certs renew apiserver
     /usr/local/bin/kubeadm alpha certs renew apiserver-kubelet-client
     /usr/local/bin/kubeadm alpha certs renew front-proxy-client

--- a/builtin/roles/certs/renew-kubernetes/tasks/main.yaml
+++ b/builtin/roles/certs/renew-kubernetes/tasks/main.yaml
@@ -11,12 +11,12 @@
 - name: Reload kubernetes pods
   tags: [ "certs" ]
   command: |
-    {% if (cri.container_manager|default_if_none:"docker" == "docker") %}
+    {% if (cri.container_manager == "docker") %}
     docker ps -af name=k8s_kube-apiserver* -q | xargs --no-run-if-empty docker rm -f
     docker ps -af name=k8s_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f
     docker ps -af name=k8s_ kube-scheduler* -q | xargs --no-run-if-empty docker rm -f
     {% else %}
-    crictl pods --name kube-apiserver* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %
-    crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %
-    crictl pods --name kube-scheduler* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %
+    crictl ps --name kube-apiserver -q | xargs -I% --no-run-if-empty bash -c 'crictl stop % && crictl rm %'
+    crictl ps --name kube-controller-manager -q | xargs -I% --no-run-if-empty bash -c 'crictl stop % && crictl rm %'
+    crictl ps --name kube-scheduler -q | xargs -I% --no-run-if-empty bash -c 'crictl stop % && crictl rm %'
     {% endif %}


### PR DESCRIPTION
fix: save default variable to defaults directory

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
base: https://github.com/kubesphere/kubekey/pull/2288
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
save default variable to defaults directory for kk cert renew
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
