### PR TITLE
fix: unescape --set string.

### DIFF
--- a/cmd/kk/app/options/option.go
+++ b/cmd/kk/app/options/option.go
@@ -119,6 +119,7 @@ func (o *CommonOptions) completeRef(pipeline *kubekeyv1.Pipeline) (*kubekeyv1.Co
 	}
 
 	for _, s := range o.Set {
+		s = unescapeString(s)
 		ss := strings.Split(s, "=")
 		if len(ss) != 2 {
 			return nil, nil, fmt.Errorf("--set value should be k=v")
@@ -210,4 +211,25 @@ func setValue(config *kubekeyv1.Config, key, val string) error {
 	default:
 		return config.SetValue(key, val)
 	}
+}
+
+// unescapeString handles common escape sequences
+func unescapeString(s string) string {
+	replacements := map[string]string{
+		`\\`: `\`,
+		`\"`: `"`,
+		`\'`: `'`,
+		`\n`: "\n",
+		`\r`: "\r",
+		`\t`: "\t",
+		`\b`: "\b",
+		`\f`: "\f",
+	}
+
+	// Iterate over the replacements map and replace escape sequences in the string
+	for old, new := range replacements {
+		s = strings.ReplaceAll(s, old, new)
+	}
+
+	return s
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
when use `--set` to set multi-line string value. The format of the string will change beyond expectations.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
unescape --set string
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
