### PR TITLE
fix: etc/hosts is incorrect when localhost is not belong cluster.

### DIFF
--- a/builtin/roles/addons/cni/templates/calico/v3.27.yaml
+++ b/builtin/roles/addons/cni/templates/calico/v3.27.yaml
@@ -51,7 +51,7 @@ data:
           "log_file_path": "/var/log/calico/cni/cni.log",
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
-          "mtu": "__CNI_MTU__",
+          "mtu": __CNI_MTU__,
           "ipam": {
               "type": "calico-ipam"
           },

--- a/builtin/roles/init/init-os/templates/init-os.sh
+++ b/builtin/roles/init/init-os/templates/init-os.sh
@@ -174,12 +174,40 @@ sed -i '/^$/N;/\n$/N;//D' /etc/hosts
 
 cat >>/etc/hosts<<EOF
 # kubekey hosts BEGIN
-{{- range .inventory_hosts }}
-  {{- if and .internal_ipv4 (ne .internal_ipv4 "") }}
-    {{ printf "%s %s %s.%s" .internal_ipv4 .hostname .hostname ($.kubernetes.cluster_name | default "cluster.local") }}
+# kubernetes hosts
+{{- range .groups.k8s_cluster | default list }}
+  {{- if and (index $.inventory_hosts . "internal_ipv4") (ne (index $.inventory_hosts . "internal_ipv4") "") }}
+    {{ printf "%s %s %s.%s" (index $.inventory_hosts . "internal_ipv4") (index $.inventory_hosts . "hostname") (index $.inventory_hosts . "hostname") ($.kubernetes.cluster_name | default "cluster.local") }}
   {{- end }}
-  {{- if and .internal_ipv6 (ne .internal_ipv6 "") }}
-    {{ printf "%s %s %s.%s" .internal_ipv6 .internal_ipv6 .hostname ($.kubernetes.cluster_name | default "cluster.local") }}
+  {{- if and (index $.inventory_hosts . "internal_ipv6") (ne (index $.inventory_hosts . "internal_ipv6") "") }}
+    {{ printf "%s %s %s.%s" (index $.inventory_hosts . "internal_ipv6") (index $.inventory_hosts . "hostname") (index $.inventory_hosts . "hostname") ($.kubernetes.cluster_name | default "cluster.local") }}
+  {{- end }}
+{{- end }}
+# etcd hosts
+{{- range .groups.etcd | default list }}
+  {{- if and (index $.inventory_hosts . "internal_ipv4") (ne (index $.inventory_hosts . "internal_ipv4") "") }}
+    {{ printf "%s %s" (index $.inventory_hosts . "internal_ipv4") (index $.inventory_hosts . "hostname") }}
+  {{- end }}
+  {{- if and (index $.inventory_hosts . "internal_ipv6") (ne (index $.inventory_hosts . "internal_ipv6") "") }}
+    {{ printf "%s %s" (index $.inventory_hosts . "internal_ipv6") (index $.inventory_hosts . "hostname") }}
+  {{- end }}
+{{- end }}
+# image registry hosts
+{{- range .groups.image_registry | default list }}
+  {{- if and (index $.inventory_hosts . "internal_ipv4") (ne (index $.inventory_hosts . "internal_ipv4") "") }}
+    {{ printf "%s %s" (index $.inventory_hosts . "internal_ipv4") (index $.inventory_hosts . "hostname") }}
+  {{- end }}
+  {{- if and (index $.inventory_hosts . "internal_ipv6") (ne (index $.inventory_hosts . "internal_ipv6") "") }}
+    {{ printf "%s %s" (index $.inventory_hosts . "internal_ipv6") (index $.inventory_hosts . "hostname") }}
+  {{- end }}
+{{- end }}
+# nfs hosts
+{{- range .groups.nfs | default list }}
+  {{- if and (index $.inventory_hosts . "internal_ipv4") (ne (index $.inventory_hosts . "internal_ipv4") "") }}
+    {{ printf "%s %s" (index $.inventory_hosts . "internal_ipv4") (index $.inventory_hosts . "hostname") }}
+  {{- end }}
+  {{- if and (index $.inventory_hosts . "internal_ipv6") (ne (index $.inventory_hosts . "internal_ipv6") "") }}
+    {{ printf "%s %s" (index $.inventory_hosts . "internal_ipv6") (index $.inventory_hosts . "hostname") }}
   {{- end }}
 {{- end }}
 # kubekey hosts END


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
when exec kubekey out of cluster. the /etc/hosts will occurred a incorrect record.like this:
<img width="622" alt="截屏2024-08-07 17 35 06" src="https://github.com/user-attachments/assets/2d151d4a-6078-423c-98fc-eae51421a8a7">
the calico/node will get error ip for localhost like this:
<img width="1338" alt="截屏2024-08-07 17 35 37" src="https://github.com/user-attachments/assets/4c741871-9361-4bdd-bcf1-069b812e35e3">

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
