### PR TITLE
fix: does not push image to registry

### DIFF
--- a/cmd/kk/pkg/images/tasks.go
+++ b/cmd/kk/pkg/images/tasks.go
@@ -156,7 +156,7 @@ func GetImage(runtime connector.ModuleRuntime, kubeConf *common.KubeConf, name s
 type SaveImages struct {
 	common.ArtifactAction
 	ImageStartIndex int
-	ImageTransport string
+	ImageTransport  string
 }
 
 func (s *SaveImages) Execute(runtime connector.Runtime) error {
@@ -314,7 +314,12 @@ func (c *CopyImagesToRegistry) Execute(runtime connector.Runtime) error {
 		}
 
 		srcName := fmt.Sprintf("oci:%s:%s", imagesPath, ref)
-		destName := formatImageName(c.ImageTransport, uniqueImage)
+		destName := formatImageName(c.ImageTransport, image.ImageName())
+
+		if c.ImageTransport == common.DockerDaemon {
+			destName = formatImageName(c.ImageTransport, uniqueImage)
+		}
+
 		logger.Log.Infof("Source: %s", srcName)
 		logger.Log.Infof("Destination: %s", destName)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
fix: does not push image to registry

```
16:21:47 CST success: [LocalHost]

16:21:47 CST [CopyImagesToRegistryModule] Push multi-arch manifest to private registry

16:21:47 CST Push multi-arch manifest list: 192.168.31.189/kubesphereio/thanos:v0.31.0

INFO[0220] Retrieving digests of member images

INFO[0220] trying next host - response was http.StatusNotFound host=192.168.31.189

WARN[0220] Couldn’t access image ‘“192.168.31.189/kubesphereio/thanos:v0.31.0-amd64”’. Skipping due to ‘ignore missing’ configuration.

16:21:47 CST message: [LocalHost]

push image 192.168.31.189/kubesphereio/thanos:v0.31.0 multi-arch manifest failed: all entries were skipped due to missing source image references; no manifest list to push

16:21:47 CST failed: [LocalHost]

error: Pipeline[CreateClusterPipeline] execute failed: Module[CopyImagesToRegistryModule] exec failed:

failed: [LocalHost] [PushManifest] exec failed after 1 retries: push image 192.168.31.189/kubesphereio/thanos:v0.31.0 multi-arch manifest failed: all entries were skipped due to missing source image references; no manifest list to push
```




### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: does not push image to registry
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
