### PR TITLE
kk增加自定义harbor版本

### DIFF
--- a/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
+++ b/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
@@ -108,6 +108,7 @@ type System struct {
 // RegistryConfig defines the configuration information of the image's repository.
 type RegistryConfig struct {
 	Type               string               `yaml:"type" json:"type,omitempty"`
+	Version            string               `yaml:"version" json:"version,omitempty"`
 	RegistryMirrors    []string             `yaml:"registryMirrors" json:"registryMirrors,omitempty"`
 	InsecureRegistries []string             `yaml:"insecureRegistries" json:"insecureRegistries,omitempty"`
 	PrivateRegistry    string               `yaml:"privateRegistry" json:"privateRegistry,omitempty"`

--- a/cmd/kk/pkg/binaries/registry.go
+++ b/cmd/kk/pkg/binaries/registry.go
@@ -98,21 +98,25 @@ func RegistryBinariesDownload(manifest *common.ArtifactManifest, path, arch stri
 	}
 
 	if m.Components.Harbor.Version != "" {
+		harbor := files.NewKubeBinary("harbor", arch, kubekeyapiv1alpha2.DefaultHarborVersion, path, manifest.Arg.DownloadCommand)
+
 		//允许下载version/components.json中规定的版本
 		if _, ok := files.FileSha256["harbor"][arch][m.Components.Harbor.Version]; !ok {
 			supportVersion := ""
 			for key := range files.FileSha256["harbor"][arch] {
 				supportVersion += fmt.Sprintf("%s ", key)
 			}
-			logger.Log.Warningf("Harbor Version only supports %s, the KubeKey artifact will not contain the Harbor Version:%s", supportVersion, m.Components.Harbor.Version)
+			logger.Log.Warningf("Harbor Version only supports %s, the KubeKey artifact will not contain the Harbor Version:%s,use default version:%s", supportVersion, m.Components.Harbor.Version, kubekeyapiv1alpha2.DefaultHarborVersion)
+
 		} else {
 			//harbor := files.NewKubeBinary("harbor", arch, kubekeyapiv1alpha2.DefaultHarborVersion, path, manifest.Arg.DownloadCommand)
-			harbor := files.NewKubeBinary("harbor", arch, m.Components.Harbor.Version, path, manifest.Arg.DownloadCommand)
-			if arch == "amd64" {
-				binaries = append(binaries, harbor)
-			} else {
-				logger.Log.Warningf("Harbor only supports amd64, the KubeKey artifact will not contain the Harbor %s", arch)
-			}
+			harbor = files.NewKubeBinary("harbor", arch, m.Components.Harbor.Version, path, manifest.Arg.DownloadCommand)
+
+		}
+		if arch == "amd64" {
+			binaries = append(binaries, harbor)
+		} else {
+			logger.Log.Warningf("Harbor only supports amd64, the KubeKey artifact will not contain the Harbor %s", arch)
 		}
 
 	}

--- a/version/components.json
+++ b/version/components.json
@@ -1162,6 +1162,7 @@
     "harbor": {
         "amd64": {
             "v2.5.3": "c536eaf5dcb35a1f2a5b1c4278380bde254a288700aa2ba59c1fd464bf2fcbf1",
+            "v2.7.4": "4e192a076a15fb7137c6d4626b2c69175a59d6f1a378366a7c080151e0aea4da",
             "v2.10.1": "aed3fe341e563e11286fb243b2bfe4162d0c5816d548df049df07fabceea038f"
         }
     },


### PR DESCRIPTION
● kk特性：kk不支持自定义harbor版本，manifest中定义的harbor版本无效，每个kk版本使用代码中的默认harbor版本。
● 导致的结果：老版本kk安装2.5.3，在漏洞扫描时出现Harbor 访问控制错误漏洞和弱口令漏洞。新版本kk安装2.10.1版本，该版本不再支持插件形式安装Helm Charts。如果自己项目使用了helm部署，需要使用Harbor中的Helm Charts，而2.10.1将无法使用，只能自己手动修复漏洞或者更改版本。
由于我司业务不同，需要频繁离线部署KubeSphere，每次部署KubeSphere时也需要部署Harbor，每次手动更改harbor，太过麻烦。于是修改KubeKey，使kk安装2.7.4(2.8版本后不再支持helm)版本Harbor。