### PR TITLE
remove centos and docker from dependencies repository

### DIFF
--- a/.github/workflows/gen-repository-iso.yaml
+++ b/.github/workflows/gen-repository-iso.yaml
@@ -14,16 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: centos7-rpms
-            dockerfile: dockerfile.centos7
           - name: almalinux-9.0-rpms
             dockerfile: dockerfile.almalinux90
           - name: debian10-debs
             dockerfile: dockerfile.debian10
           - name: debian11-debs
             dockerfile: dockerfile.debian11
-          - name: ubuntu-16.04-debs
-            dockerfile: dockerfile.ubuntu1604
           - name: ubuntu-18.04-debs
             dockerfile: dockerfile.ubuntu1804
           - name: ubuntu-20.04-debs

--- a/hack/gen-repository-iso/dockerfile.almalinux90
+++ b/hack/gen-repository-iso/dockerfile.almalinux90
@@ -5,7 +5,6 @@ ARG DIR=almalinux-9.0-${TARGETARCH}-rpms
 ARG PKGS=.common[],.rpms[],.almalinux[],.almalinux90[]
 
 RUN dnf install -q -y ${BUILD_TOOLS} \
-    && dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
     && dnf makecache
 
 WORKDIR package

--- a/hack/gen-repository-iso/dockerfile.centos7
+++ b/hack/gen-repository-iso/dockerfile.centos7
@@ -6,7 +6,6 @@ ARG BUILD_TOOLS="yum-utils createrepo mkisofs epel-release"
 ARG DIR=${OS}${OS_VERSION}-${TARGETARCH}-rpms
 
 RUN yum install -q -y ${BUILD_TOOLS} \
-    && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
     && yum makecache
 
 WORKDIR package

--- a/hack/gen-repository-iso/dockerfile.debian10
+++ b/hack/gen-repository-iso/dockerfile.debian10
@@ -16,8 +16,6 @@ RUN ARCH=$(dpkg --print-architecture) \
         curl -fsSL https://download.gluster.org/pub/gluster/glusterfs/7/rsa.pub | apt-key add - ; \
         echo deb https://download.gluster.org/pub/gluster/glusterfs/7/LATEST/Debian/${OS_VERSION}/amd64/apt ${OS_RELEASE} main > /etc/apt/sources.list.d/gluster.list ; \
        fi \
-    && curl -fsSL "https://download.docker.com/linux/debian/gpg" | apt-key add -qq - \
-    && echo "deb [arch=$TARGETARCH] https://download.docker.com/linux/debian ${OS_RELEASE} stable" > /etc/apt/sources.list.d/docker.list \
     && apt update -qq
 
 WORKDIR /package

--- a/hack/gen-repository-iso/dockerfile.debian11
+++ b/hack/gen-repository-iso/dockerfile.debian11
@@ -16,8 +16,6 @@ RUN ARCH=$(dpkg --print-architecture) \
         curl -fsSL https://download.gluster.org/pub/gluster/glusterfs/7/rsa.pub | apt-key add - ; \
         echo deb https://download.gluster.org/pub/gluster/glusterfs/7/LATEST/Debian/${OS_VERSION}/amd64/apt ${OS_RELEASE} main > /etc/apt/sources.list.d/gluster.list ; \
        fi \
-    && curl -fsSL "https://download.docker.com/linux/debian/gpg" | apt-key add -qq - \
-    && echo "deb [arch=$TARGETARCH] https://download.docker.com/linux/debian ${OS_RELEASE} stable" > /etc/apt/sources.list.d/docker.list \
     && apt update -qq \
     && apt upgrade -y -qq
 

--- a/hack/gen-repository-iso/dockerfile.ubuntu1804
+++ b/hack/gen-repository-iso/dockerfile.ubuntu1804
@@ -11,8 +11,6 @@ RUN dpkg --get-selections | grep -v deinstall | cut -f1 | cut -d ':' -f1 > packa
 RUN apt update -qq \
     && apt install -y --no-install-recommends $BUILD_TOOLS \
     && add-apt-repository ppa:gluster/glusterfs-7 -y \
-    && curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | apt-key add -qq - \
-    && echo "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu ${OS_RELEASE} stable" > /etc/apt/sources.list.d/docker.list\
     && apt update -qq
 
 WORKDIR /package

--- a/hack/gen-repository-iso/dockerfile.ubuntu2004
+++ b/hack/gen-repository-iso/dockerfile.ubuntu2004
@@ -11,8 +11,6 @@ RUN dpkg --get-selections | grep -v deinstall | cut -f1 | cut -d ':' -f1 > packa
 RUN apt update -qq \
     && apt install -y --no-install-recommends $BUILD_TOOLS \
     && add-apt-repository ppa:gluster/glusterfs-7 -y \
-    && curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | apt-key add -qq - \
-    && echo "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu ${OS_RELEASE} stable" > /etc/apt/sources.list.d/docker.list\
     && apt update -qq
 
 WORKDIR /package

--- a/hack/gen-repository-iso/dockerfile.ubuntu2204
+++ b/hack/gen-repository-iso/dockerfile.ubuntu2204
@@ -12,8 +12,6 @@ RUN dpkg --get-selections | grep -v deinstall | cut -f1 | cut -d ':' -f1 > packa
 RUN apt update -qq \
     && apt install -y --no-install-recommends $BUILD_TOOLS \
     #&& add-apt-repository ppa:gluster/glusterfs-7 -y \
-    && curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | apt-key add -qq - \
-    && echo "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu ${OS_RELEASE} stable" > /etc/apt/sources.list.d/docker.list\
     && apt update -qq
 
 WORKDIR /package

--- a/hack/gen-repository-iso/packages.yaml
+++ b/hack/gen-repository-iso/packages.yaml
@@ -40,45 +40,26 @@ debs:
   - software-properties-common
   - sudo
 
-centos:
-  - containerd.io
+centos: []
 
 centos7:
   - libselinux-python
-  - docker-ce-20.10.8
-  - docker-ce-cli-20.10.8
 
-debian:
-  - containerd.io
+debian: []
 
-debian10:
-  - docker-ce=5:20.10.8~3-0~debian-buster
-  - docker-ce-cli=5:20.10.8~3-0~debian-buster
+debian10: []
 
-debian11:
-  - docker-ce=5:20.10.8~3-0~debian-bullseye
-  - docker-ce-cli=5:20.10.8~3-0~debian-bullseye
+debian11: []
 
-ubuntu:
-  - containerd.io
+ubuntu: []
 
-ubuntu1804:
-  - docker-ce=5:20.10.8~3-0~ubuntu-bionic
-  - docker-ce-cli=5:20.10.8~3-0~ubuntu-bionic
+ubuntu1804: []
 
-ubuntu2004:
-  - docker-ce=5:20.10.8~3-0~ubuntu-focal
-  - docker-ce-cli=5:20.10.8~3-0~ubuntu-focal
+ubuntu2004: []
 
 # The minimum version of docker-ce on ubuntu 2204 is 20.10.13
-ubuntu2204:
-  - docker-ce=5:20.10.13~3-0~ubuntu-jammy
-  - docker-ce-cli=5:20.10.13~3-0~ubuntu-jammy
+ubuntu2204: []
 
-almalinux:
-  - containerd.io
-  - docker-compose-plugin
+almalinux: []
 
-almalinux90:
-  - docker-ce-20.10.17
-  - docker-ce-cli-20.10.17
+almalinux90: []


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
remove centos and docker from dependencies repository

Centos7 is no longer maintained.
https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7

Kubekey uses binary to install docker, so removing Docker from the dependency package reduces the introduction of CVEs.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
remove centos and docker from dependencies repository
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
