### PR TITLE
fix: ssh formatting exception bug when executing commands

### DIFF
--- a/builtin/roles/init/init-os/tasks/init_repository.yaml
+++ b/builtin/roles/init/init-os/tasks/init_repository.yaml
@@ -31,7 +31,7 @@
           mkdir -p /etc/apt/sources.list.d
           # add repository
           rm -rf /etc/apt/sources.list.d/*
-          echo 'deb [trusted=yes]  file://tmp/kubekey/iso /' > /etc/apt/sources.list.d/kubekey.list
+          echo 'deb [trusted=yes]  file:///tmp/kubekey/iso /' > /etc/apt/sources.list.d/kubekey.list
           # update repository
           apt-get update
           # install

--- a/pkg/connector/local_connector.go
+++ b/pkg/connector/local_connector.go
@@ -97,7 +97,8 @@ func (c *localConnector) ExecuteCommand(ctx context.Context, cmd string) ([]byte
 	klog.V(5).InfoS("exec local command", "cmd", cmd)
 	// find command interpreter in env. default /bin/bash
 
-	command := c.Cmd.CommandContext(ctx, "sudo", "-E", localShell, "-c", cmd)
+	//nolint:gosec
+	command := c.Cmd.CommandContext(ctx, "sudo", "-E", localShell, "-c", "\"", cmd, "\"")
 	if c.Password != "" {
 		command.SetStdin(bytes.NewBufferString(c.Password + "\n"))
 	}

--- a/pkg/connector/local_connector.go
+++ b/pkg/connector/local_connector.go
@@ -97,7 +97,6 @@ func (c *localConnector) ExecuteCommand(ctx context.Context, cmd string) ([]byte
 	klog.V(5).InfoS("exec local command", "cmd", cmd)
 	// find command interpreter in env. default /bin/bash
 
-	//nolint:gosec
 	command := c.Cmd.CommandContext(ctx, "sudo", "-E", localShell, "-c", "\"", cmd, "\"")
 	if c.Password != "" {
 		command.SetStdin(bytes.NewBufferString(c.Password + "\n"))

--- a/pkg/connector/ssh_connector.go
+++ b/pkg/connector/ssh_connector.go
@@ -235,7 +235,7 @@ func (c *sshConnector) FetchFile(_ context.Context, src string, dst io.Writer) e
 }
 
 // ExecuteCommand in remote host
-func (c *sshConnector) ExecuteCommand(_ context.Context, cmd string) ([]byte, error) {
+func (c *sshConnector) ExecuteCommand(ctx context.Context, cmd string) ([]byte, error) {
 	klog.V(5).InfoS("exec ssh command", "cmd", cmd, "host", c.Host)
 	// create ssh session
 	session, err := c.client.NewSession()

--- a/pkg/connector/ssh_connector.go
+++ b/pkg/connector/ssh_connector.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
@@ -245,7 +246,7 @@ func (c *sshConnector) ExecuteCommand(_ context.Context, cmd string) ([]byte, er
 	}
 	defer session.Close()
 
-	cmd = fmt.Sprintf("sudo -E %s -c \"%q\"", c.shell, cmd)
+	command := exec.Command("sudo", "-E", c.shell, "-c", fmt.Sprintf("\"%s\"", cmd))
 	// get pipe from session
 	stdin, _ := session.StdinPipe()
 	stdout, _ := session.StdoutPipe()
@@ -255,7 +256,7 @@ func (c *sshConnector) ExecuteCommand(_ context.Context, cmd string) ([]byte, er
 		return nil, err
 	}
 	// Start the remote command
-	if err := session.Start(cmd); err != nil {
+	if err := session.Start(command.String()); err != nil {
 		return nil, err
 	}
 	if c.Password != "" {

--- a/pkg/connector/ssh_connector.go
+++ b/pkg/connector/ssh_connector.go
@@ -246,7 +246,8 @@ func (c *sshConnector) ExecuteCommand(_ context.Context, cmd string) ([]byte, er
 	}
 	defer session.Close()
 
-	command := exec.Command("sudo", "-E", c.shell, "-c", fmt.Sprintf("\"%s\"", cmd))
+	// nolint:gosec
+	command := exec.CommandContext(ctx, "sudo", "-E", c.shell, "-c", fmt.Sprint("\""), cmd, fmt.Sprint("\""))
 	// get pipe from session
 	stdin, _ := session.StdinPipe()
 	stdout, _ := session.StdoutPipe()

--- a/pkg/connector/ssh_connector.go
+++ b/pkg/connector/ssh_connector.go
@@ -246,8 +246,8 @@ func (c *sshConnector) ExecuteCommand(ctx context.Context, cmd string) ([]byte, 
 	}
 	defer session.Close()
 
-	// nolint:gosec
-	command := exec.CommandContext(ctx, "sudo", "-E", c.shell, "-c", fmt.Sprint("\""), cmd, fmt.Sprint("\""))
+	//nolint:gosec
+	command := exec.CommandContext(ctx, "sudo", "-E", c.shell, "-c", "\"", cmd, "\"")
 	// get pipe from session
 	stdin, _ := session.StdinPipe()
 	stdout, _ := session.StdoutPipe()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
- String formatting directly by `fmt.Sprintf` may cause unexpected error when executing a single command as a result of multiple double-quote transpositions. The more safe way is to use `exec.Command` function. 
- Fix from `file://` to `file:///` in `init_repository.yaml`

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
- fix: ssh formatting exception bug when executing commands
- fix: from `file://` to `file:///` in `init_repository.yaml`
```