### PR TITLE
fix: symbolic bug in GatherFacts function

### DIFF
--- a/pkg/connector/local_connector.go
+++ b/pkg/connector/local_connector.go
@@ -120,17 +120,17 @@ func (c *localConnector) HostInfo(ctx context.Context) (map[string]any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("get kernel version error: %w", err)
 		}
-		osVars[_const.VariableOSKernelVersion] = string(bytes.TrimSuffix(kernel, []byte("\n")))
+		osVars[_const.VariableOSKernelVersion] = string(bytes.TrimSpace(kernel))
 		hn, err := c.ExecuteCommand(ctx, "hostname")
 		if err != nil {
 			return nil, fmt.Errorf("get hostname error: %w", err)
 		}
-		osVars[_const.VariableOSHostName] = string(bytes.TrimSuffix(hn, []byte("\n")))
+		osVars[_const.VariableOSHostName] = string(bytes.TrimSpace(hn))
 		arch, err := c.ExecuteCommand(ctx, "arch")
 		if err != nil {
 			return nil, fmt.Errorf("get arch error: %w", err)
 		}
-		osVars[_const.VariableOSArchitecture] = string(bytes.TrimSuffix(arch, []byte("\n")))
+		osVars[_const.VariableOSArchitecture] = string(bytes.TrimSpace(arch))
 
 		// process information
 		procVars := make(map[string]any)

--- a/pkg/connector/ssh_connector.go
+++ b/pkg/connector/ssh_connector.go
@@ -293,17 +293,17 @@ func (c *sshConnector) HostInfo(ctx context.Context) (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get kernel version error: %w", err)
 	}
-	osVars[_const.VariableOSKernelVersion] = string(bytes.TrimSuffix(kernel, []byte("\n")))
+	osVars[_const.VariableOSKernelVersion] = string(bytes.TrimSpace(kernel))
 	hn, err := c.ExecuteCommand(ctx, "hostname")
 	if err != nil {
 		return nil, fmt.Errorf("get hostname error: %w", err)
 	}
-	osVars[_const.VariableOSHostName] = string(bytes.TrimSuffix(hn, []byte("\n")))
+	osVars[_const.VariableOSHostName] = string(bytes.TrimSpace(hn))
 	arch, err := c.ExecuteCommand(ctx, "arch")
 	if err != nil {
 		return nil, fmt.Errorf("get arch error: %w", err)
 	}
-	osVars[_const.VariableOSArchitecture] = string(bytes.TrimSuffix(arch, []byte("\n")))
+	osVars[_const.VariableOSArchitecture] = string(bytes.TrimSpace(arch))
 
 	// process information
 	procVars := make(map[string]any)

--- a/pkg/connector/ssh_connector.go
+++ b/pkg/connector/ssh_connector.go
@@ -158,8 +158,8 @@ func (c *sshConnector) Init(context.Context) error {
 		return fmt.Errorf("env command error: %w", err)
 	}
 
-	if strings.TrimSuffix(string(output), "\n") != "" {
-		c.shell = strings.TrimSuffix(string(output), "\n")
+	if strings.TrimSpace(string(output)) != "" {
+		c.shell = strings.TrimSpace(string(output))
 	}
 
 	return nil

--- a/pkg/converter/internal/functions.go
+++ b/pkg/converter/internal/functions.go
@@ -35,7 +35,7 @@ func toYAML(v any) string {
 		return ""
 	}
 
-	return strings.TrimSuffix(string(data), "\n")
+	return strings.TrimSpace(string(data))
 }
 
 // ipInCIDR get the IP of a specific location within the cidr range

--- a/pkg/converter/tmpl/template.go
+++ b/pkg/converter/tmpl/template.go
@@ -68,7 +68,7 @@ func ParseString(ctx map[string]any, input string) (string, error) {
 	}
 	klog.V(6).InfoS(" parse template succeed", "result", result.String())
 
-	return strings.TrimPrefix(strings.TrimSuffix(result.String(), "\n"), "\n"), nil
+	return strings.TrimSpace(result.String()), nil
 }
 
 // IsTmplSyntax Check if the string conforms to the template syntax.

--- a/pkg/converter/tmpl/template.go
+++ b/pkg/converter/tmpl/template.go
@@ -68,7 +68,7 @@ func ParseString(ctx map[string]any, input string) (string, error) {
 	}
 	klog.V(6).InfoS(" parse template succeed", "result", result.String())
 
-	return strings.TrimSpace(result.String()), nil
+	return strings.Trim(result.String(), "\r\n"), nil
 }
 
 // IsTmplSyntax Check if the string conforms to the template syntax.

--- a/pkg/modules/command.go
+++ b/pkg/modules/command.go
@@ -48,7 +48,7 @@ func ModuleCommand(ctx context.Context, options ExecOptions) (string, string) {
 		stderr = err.Error()
 	}
 	if data != nil {
-		stdout = strings.TrimSuffix(string(data), "\n")
+		stdout = strings.TrimSpace(string(data))
 	}
 
 	return stdout, stderr


### PR DESCRIPTION
…nction, to avoid unexpected `\r` symbolic with different os system.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Replace `bytes.TrimSuffix` with `bytes.TrimSpace` in `HostInfo` function, to avoid unexpected `\r` symbols with different os systems.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: symbolic bug in GatherFacts function
```
