### PR TITLE
Fixed a typo on command completion on completion.go

### DIFF
--- a/cmd/kk/cmd/completion/completion.go
+++ b/cmd/kk/cmd/completion/completion.go
@@ -50,8 +50,8 @@ Normally you don't need to do more extra work to have this feature if you've ins
 		Example: `# Installing bash completion on Linux
 ## If bash-completion is not installed on Linux, please install the 'bash-completion' package
 ## via your distribution's package manager.
-## Load the ks completion code for bash into the current shell
-source <(ks completion bash)
+## Load the kk completion code for bash into the current shell
+source <(kk completion bash)
 ## Write bash completion code to a file and source if from .bash_profile
 mkdir -p ~/.config/kk/ && kk completion --type bash > ~/.config/kk/completion.bash.inc
 printf "


### PR DESCRIPTION
Fixed a typo for command completion

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Change the help output of the command completion. (the current help output had a typo)
### Which issue(s) this PR fixes:
No reported issues will be fixed!
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
None
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
