### PR TITLE
Modify execute command way, fix bug and optimize execution logic for playbook

### DIFF
--- a/builtin/roles/init/init-artifact/tasks/main.yaml
+++ b/builtin/roles/init/init-artifact/tasks/main.yaml
@@ -33,5 +33,6 @@
 
 - name: Chown work_dir to sudo
   tags: ["always"]
+  ignore_errors: yes
   command: |
     chown -R ${SUDO_UID}:${SUDO_GID} {{ .work_dir }}

--- a/pkg/connector/local_connector.go
+++ b/pkg/connector/local_connector.go
@@ -97,7 +97,7 @@ func (c *localConnector) ExecuteCommand(ctx context.Context, cmd string) ([]byte
 	klog.V(5).InfoS("exec local command", "cmd", cmd)
 	// find command interpreter in env. default /bin/bash
 
-	command := c.Cmd.CommandContext(ctx, "sudo", "-E", localShell, "-c", "\"", cmd, "\"")
+	command := c.Cmd.CommandContext(ctx, "sudo", "-SE", localShell, "-c", cmd)
 	if c.Password != "" {
 		command.SetStdin(bytes.NewBufferString(c.Password + "\n"))
 	}

--- a/pkg/project/helper.go
+++ b/pkg/project/helper.go
@@ -68,7 +68,7 @@ func loadPlaybook(baseFS fs.FS, pbPath string, pb *kkprojectv1.Playbook) error {
 			return fmt.Errorf("load import_playbook failed: %w", err)
 		}
 
-		if err := dealVarsFiles(p, baseFS, pbPath); err != nil {
+		if err := dealVarsFiles(&p, baseFS, pbPath); err != nil {
 			return fmt.Errorf("load vars_files failed: %w", err)
 		}
 		// fill block in roles
@@ -98,7 +98,7 @@ func dealImportPlaybook(p kkprojectv1.Play, baseFS fs.FS, pbPath string, pb *kkp
 }
 
 // dealVarsFiles "var_files" argument in play
-func dealVarsFiles(p kkprojectv1.Play, baseFS fs.FS, pbPath string) error {
+func dealVarsFiles(p *kkprojectv1.Play, baseFS fs.FS, pbPath string) error {
 	for _, file := range p.VarsFiles {
 		// load vars from vars_files
 		if _, err := fs.Stat(baseFS, filepath.Join(filepath.Dir(pbPath), file)); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Fix some bugs: 
- Modify command execute way, which is more stable for most conditions.
- Fixed an issue where the `vars_files` parameter would not take effect due to the way the value was passed in the `dealVarsFiles` function.
- Ignore errors when executing `chrown` command.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
- Modify command execute way, which is more stable for most conditions.
- Fixed an issue where the `vars_files` parameter would not take effect due to the way the value was passed in the `dealVarsFiles` function.
- Ignore errors when executing `chrown` command.
```
