### PR TITLE
Feature fwind

### DIFF
--- a/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
+++ b/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
@@ -115,6 +115,7 @@ type RegistryConfig struct {
 	NamespaceOverride  string               `yaml:"namespaceOverride" json:"namespaceOverride,omitempty"`
 	BridgeIP           string               `yaml:"bridgeIP" json:"bridgeIP,omitempty"`
 	Auths              runtime.RawExtension `yaml:"auths" json:"auths,omitempty"`
+	Port               int                  `yaml:"port" json:"port,omitempty"`
 }
 
 // KubeSphere defines the configuration information of the KubeSphere.
@@ -318,4 +319,11 @@ func (r *RegistryConfig) GetHost() string {
 		return ""
 	}
 	return strings.Split(r.PrivateRegistry, "/")[0]
+}
+
+func (r *RegistryConfig) GetPort() int {
+	if r.Port == 0 {
+		return 80
+	}
+	return r.Port
 }

--- a/cmd/kk/pkg/bootstrap/os/templates/init_script.go
+++ b/cmd/kk/pkg/bootstrap/os/templates/init_script.go
@@ -259,7 +259,7 @@ func GenerateHosts(runtime connector.ModuleRuntime, kubeConf *common.KubeConf) [
 
 	if len(runtime.GetHostsByRole(common.Registry)) > 0 {
 		if kubeConf.Cluster.Registry.PrivateRegistry != "" {
-			hostsList = append(hostsList, fmt.Sprintf("%s  %s", runtime.GetHostsByRole(common.Registry)[0].GetInternalIPv4Address(), kubeConf.Cluster.Registry.GetHost()))
+			hostsList = append(hostsList, fmt.Sprintf("%s:%d  %s", runtime.GetHostsByRole(common.Registry)[0].GetInternalIPv4Address(), kubeConf.Cluster.Registry.GetPort(), kubeConf.Cluster.Registry.GetHost()))
 			if runtime.GetHostsByRole(common.Registry)[0].GetInternalIPv6Address() != "" {
 				hostsList = append(hostsList, fmt.Sprintf("%s  %s", runtime.GetHostsByRole(common.Registry)[0].GetInternalIPv6Address(), kubeConf.Cluster.Registry.GetHost()))
 			}

--- a/cmd/kk/pkg/bootstrap/registry/templates/harbor.yml.tmpl
+++ b/cmd/kk/pkg/bootstrap/registry/templates/harbor.yml.tmpl
@@ -7,7 +7,7 @@ hostname: {{ .Domain }}
 # http related config
 http:
   # port for http, default is 80. If https enabled, this port will redirect to https port
-  port: 80
+  port: {{ .Port }}
 
 # https related config
 https:


### PR DESCRIPTION
- 在 RegistryConfig 结构中添加 Port 字段，用于配置私有仓库端口
- 实现 GetPort 方法，提供默认端口 80 或自定义端口
- 更新 GenerateHosts 函数，将端口信息添加到主机配置中

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
自定义harbor仓库端口
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
