### PR TITLE
add set env to en_US.UTF-8.  make sure work with en language

### DIFF
--- a/cmd/kk/pkg/core/connector/ssh.go
+++ b/cmd/kk/pkg/core/connector/ssh.go
@@ -258,6 +258,10 @@ func (c *connection) session() (*ssh.Session, error) {
 		return nil, err
 	}
 
+	if err := sess.Setenv("LANG", "en_US.UTF-8"); err != nil { // try make sure work with english language environments
+		return nil, err
+	}
+
 	return sess, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
bug

### What this PR does / why we need it:
kk ssh to host will be blocked at [GreetingsModule] ，it will log nothing until timeout .

issue code:
![图片](https://github.com/user-attachments/assets/a4a47709-29a8-463f-bb51-434a93d64b53)

debug output:
![图片](https://github.com/user-attachments/assets/a00c9e76-3ae4-4cd2-a825-db695fcf73b5)

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

may fix: 
https://github.com/kubesphere/kubekey/issues/2046
https://github.com/kubesphere/kubekey/issues/2066

### Special notes for reviewers:
```
Not sure if it's a good solution, haven't done much testing
```

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
