### PR TITLE
fix: error parse when

### DIFF
--- a/api/project/v1/conditional.go
+++ b/api/project/v1/conditional.go
@@ -47,7 +47,7 @@ func (w *When) UnmarshalYAML(node *yaml.Node) error {
 		}
 		for i, v := range w.Data {
 			if !IsTmplSyntax(v) {
-				w.Data[i] = ParseTmplSyntax(node.Value)
+				w.Data[i] = ParseTmplSyntax(v)
 			}
 		}
 	default:

--- a/pkg/converter/tmpl/template.go
+++ b/pkg/converter/tmpl/template.go
@@ -36,7 +36,7 @@ import (
 func ParseFunc[C ~map[string]any, Output any](ctx C, input string, f func([]byte) Output) (Output, error) {
 	// If input doesn't contain template syntax, return directly
 	if !kkprojectv1.IsTmplSyntax(input) {
-		return f([]byte(input)), nil
+		return f(bytes.Trim([]byte(input), "\r\n")), nil
 	}
 	// Parse the template string
 	tl, err := internal.Template.Parse(input)
@@ -52,7 +52,7 @@ func ParseFunc[C ~map[string]any, Output any](ctx C, input string, f func([]byte
 	klog.V(6).InfoS(" parse template succeed", "result", result.String())
 
 	// Apply parse function to result and return
-	return f(result.Bytes()), nil
+	return f(bytes.Trim(result.Bytes(), "\r\n")), nil
 }
 
 // Parse is a helper function that wraps ParseFunc to directly return bytes.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
