### PR TITLE
feat: change default criSocket as same as dockerd

### DIFF
--- a/config/capkk/release/cluster-template.yaml
+++ b/config/capkk/release/cluster-template.yaml
@@ -45,10 +45,10 @@ spec:
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
-        criSocket: ${CRI_SOCKET=unix:///var/run/containerd/containerd.sock}
+        criSocket: ${CRI_SOCKET=unix:///run/containerd/containerd.sock}
     joinConfiguration:
       nodeRegistration:
-        criSocket: ${CRI_SOCKET=unix:///var/run/containerd/containerd.sock}
+        criSocket: ${CRI_SOCKET=unix:///run/containerd/containerd.sock}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: KKMachineTemplate
@@ -104,4 +104,4 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
-          criSocket: ${CRI_SOCKET=unix:///var/run/containerd/containerd.sock}
+          criSocket: ${CRI_SOCKET=unix:///run/containerd/containerd.sock}

--- a/pkg/controllers/infrastructure/inventory_controller.go
+++ b/pkg/controllers/infrastructure/inventory_controller.go
@@ -262,7 +262,8 @@ func (r *InventoryReconciler) reconcileNormal(ctx context.Context, scope *cluste
 func (r *InventoryReconciler) reconcileInventoryPlaybook(ctx context.Context, scope *clusterScope) error {
 	// get playbook from inventory
 	if scope.Inventory.Annotations[kkcorev1.HostCheckPlaybookAnnotation] == "" {
-		return nil
+		// cannot find playbook. should create it
+		return r.createHostCheckPlaybook(ctx, scope)
 	}
 	playbook := &kkcorev1.Playbook{}
 	if err := r.Client.Get(ctx, ctrlclient.ObjectKey{Name: scope.Inventory.Annotations[kkcorev1.HostCheckPlaybookAnnotation], Namespace: scope.Namespace}, playbook); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
1.change default criSocket as same as dockerd
2. recreate hostCheckPlaybook when it's deleted.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
