### PR TITLE
fix: Disabling ufw clears ipvs rules, and drop cache affects stability

### DIFF
--- a/cmd/kk/pkg/bootstrap/os/templates/init_script.go
+++ b/cmd/kk/pkg/bootstrap/os/templates/init_script.go
@@ -50,7 +50,7 @@ swapoff -a
 sed -i /^[^#]*swap*/s/^/\#/g /etc/fstab
 
 # See https://github.com/kubernetes/website/issues/14457
-if [ -f /etc/selinux/config ]; then 
+if [ -f /etc/selinux/config ]; then
   sed -ri 's/SELINUX=enforcing/SELINUX=disabled/' /etc/selinux/config
 fi
 # for ubuntu: sudo apt install selinux-utils
@@ -185,10 +185,20 @@ tmpfile="$$.tmp"
 awk ' !x[$0]++{print > "'$tmpfile'"}' /etc/security/limits.conf
 mv $tmpfile /etc/security/limits.conf
 
-systemctl stop firewalld 1>/dev/null 2>/dev/null
-systemctl disable firewalld 1>/dev/null 2>/dev/null
-systemctl stop ufw 1>/dev/null 2>/dev/null
-systemctl disable ufw 1>/dev/null 2>/dev/null
+# Check if firewalld service exists and is running
+systemctl status firewalld 1>/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+    # Firewall service exists and is running, stop and disable it
+    systemctl stop firewalld 1>/dev/null 2>/dev/null
+    systemctl disable firewalld 1>/dev/null 2>/dev/null
+fi
+# Check if ufw service exists and is running
+systemctl status ufw 1>/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+    # ufw service exists and is running, stop and disable it
+    systemctl stop ufw 1>/dev/null 2>/dev/null
+    systemctl disable ufw 1>/dev/null 2>/dev/null
+fi
 
 modinfo br_netfilter > /dev/null 2>&1
 if [ $? -eq 0 ]; then
@@ -236,7 +246,7 @@ cat >>/etc/hosts<<EOF
 EOF
 
 sync
-echo 3 > /proc/sys/vm/drop_caches
+# echo 3 > /proc/sys/vm/drop_caches
 
 # Make sure the iptables utility doesn't use the nftables backend.
 update-alternatives --set iptables /usr/sbin/iptables-legacy >/dev/null 2>&1 || true

--- a/feature/builtin/roles/init/init-os/templates/init-os.sh
+++ b/feature/builtin/roles/init/init-os/templates/init-os.sh
@@ -130,10 +130,20 @@ tmpfile="$$.tmp"
 awk ' !x[$0]++{print > "'$tmpfile'"}' /etc/security/limits.conf
 mv $tmpfile /etc/security/limits.conf
 
-systemctl stop firewalld 1>/dev/null 2>/dev/null
-systemctl disable firewalld 1>/dev/null 2>/dev/null
-systemctl stop ufw 1>/dev/null 2>/dev/null
-systemctl disable ufw 1>/dev/null 2>/dev/null
+# Check if firewalld service exists and is running
+systemctl status firewalld 1>/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+    # Firewall service exists and is running, stop and disable it
+    systemctl stop firewalld 1>/dev/null 2>/dev/null
+    systemctl disable firewalld 1>/dev/null 2>/dev/null
+fi
+# Check if ufw service exists and is running
+systemctl status ufw 1>/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+    # ufw service exists and is running, stop and disable it
+    systemctl stop ufw 1>/dev/null 2>/dev/null
+    systemctl disable ufw 1>/dev/null 2>/dev/null
+fi
 
 modinfo br_netfilter > /dev/null 2>&1
 if [ $? -eq 0 ]; then
@@ -220,7 +230,7 @@ cat >>/etc/hosts<<EOF
 EOF
 
 sync
-echo 3 > /proc/sys/vm/drop_caches
+# echo 3 > /proc/sys/vm/drop_caches
 
 # Make sure the iptables utility doesn't use the nftables backend.
 update-alternatives --set iptables /usr/sbin/iptables-legacy >/dev/null 2>&1 || true

--- a/pkg/service/bootstrap/templates/initOS.sh
+++ b/pkg/service/bootstrap/templates/initOS.sh
@@ -55,10 +55,20 @@ sed -r -i  "s@#{0,}?kernel.pid_max ?= ?([0-9]{1,})@kernel.pid_max = 65535@g" /et
 
 awk ' !x[$0]++{print > "/etc/sysctl.conf"}' /etc/sysctl.conf
 
-systemctl stop firewalld 1>/dev/null 2>/dev/null
-systemctl disable firewalld 1>/dev/null 2>/dev/null
-systemctl stop ufw 1>/dev/null 2>/dev/null
-systemctl disable ufw 1>/dev/null 2>/dev/null
+# Check if firewalld service exists and is running
+systemctl status firewalld 1>/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+    # Firewall service exists and is running, stop and disable it
+    systemctl stop firewalld 1>/dev/null 2>/dev/null
+    systemctl disable firewalld 1>/dev/null 2>/dev/null
+fi
+# Check if ufw service exists and is running
+systemctl status ufw 1>/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+    # ufw service exists and is running, stop and disable it
+    systemctl stop ufw 1>/dev/null 2>/dev/null
+    systemctl disable ufw 1>/dev/null 2>/dev/null
+fi
 
 modinfo br_netfilter > /dev/null 2>&1
 if [ $? -eq 0 ]; then
@@ -105,7 +115,7 @@ cat >>/etc/hosts<<EOF
 # kubekey hosts END
 EOF
 
-echo 3 > /proc/sys/vm/drop_caches
+# echo 3 > /proc/sys/vm/drop_caches
 
 # Make sure the iptables utility doesn't use the nftables backend.
 update-alternatives --set iptables /usr/sbin/iptables-legacy >/dev/null 2>&1 || true


### PR DESCRIPTION
Adding a node triggers drop _caches, and Pods using shm will restart

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
stop ufw firewalls and drop caches affect stability

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
![image](https://github.com/user-attachments/assets/809a6a08-d8ca-4b98-acd3-d3ea701a145d)

stop ufw clears ipvs rules, affecting the k8s cluster stability。Dropping caches may cause service jitter and unexpected effects。
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Affects the node initialization phase when clusters are created or new nodes are added to existing clusters
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
