### PR TITLE
Fix(connector): gracefully handle LANG environment setup failures-Update ssh.go

### DIFF
--- a/cmd/kk/pkg/core/connector/ssh.go
+++ b/cmd/kk/pkg/core/connector/ssh.go
@@ -259,9 +259,9 @@ func (c *connection) session() (*ssh.Session, error) {
 	}
 
 	if err := sess.Setenv("LANG", "en_US.UTF-8"); err != nil { // try make sure work with english language environments
-		return nil, err
+		logger.Log.Warningf("Localization warning: Failed to enforce LANG=en_US.UTF-8. (Error: %v)", err)
 	}
-
+	
 	return sess, nil
 }
 

--- a/cmd/kk/pkg/core/connector/ssh.go
+++ b/cmd/kk/pkg/core/connector/ssh.go
@@ -259,7 +259,7 @@ func (c *connection) session() (*ssh.Session, error) {
 	}
 
 	if err := sess.Setenv("LANG", "en_US.UTF-8"); err != nil { // try make sure work with english language environments
-		logger.Log.Warningf("Localization warning: Failed to enforce LANG=en_US.UTF-8. (Error: %v)", err)
+		logger.Log.Warningf("Warning: Failed to enforce LANG=en_US.UTF-8. (Error: %v)", err)
 	}
 	
 	return sess, nil

--- a/cmd/kk/pkg/core/connector/ssh.go
+++ b/cmd/kk/pkg/core/connector/ssh.go
@@ -259,7 +259,7 @@ func (c *connection) session() (*ssh.Session, error) {
 	}
 
 	if err := sess.Setenv("LANG", "en_US.UTF-8"); err != nil { // try make sure work with english language environments
-		logger.Log.Warningf("Warning: Failed to enforce LANG=en_US.UTF-8. (Error: %v)", err)
+		logger.Log.Debugf("Failed to enforce LANG=en_US.UTF-8. (Error: %v)", err)
 	}
 	
 	return sess, nil


### PR DESCRIPTION
Fix(connector): gracefully handle LANG environment setup failures

What this PR does / why we need it:
setenv 操作导致在kk 3.1.8/3.1.9 在centos/rockey linux 9.x下ssh fail ，导致无法正常部署； 经过验证不设置语言对在centos/rockey linux 9.x部署没有影响，建议setenv改为尽力而为方式更合适，失败情况下产生Warn即可。

Which issue(s) this PR fixes:
Fixes https://github.com/kubesphere/kubekey/issues/2546
(https://github.com/kubesphere/kubekey/issues/2546)

引入问题的原始pull， 影响3.1.7后面的所有版本
https://github.com/kubesphere/kubekey/pull/2489

```release-note
gracefully handle LANG environment setup
```