### PR TITLE
feat: add command add nodes

### DIFF
--- a/builtin/core/playbooks/add_nodes.yaml
+++ b/builtin/core/playbooks/add_nodes.yaml
@@ -1,0 +1,91 @@
+---
+# load defaults vars
+- hosts:
+    - all
+  vars_files:
+    - vars/create_cluster.yaml
+    - vars/create_cluster_kubernetes.yaml
+
+- import_playbook: hook/pre_install.yaml
+
+# precheck
+- hosts:
+    - localhost
+  roles:
+    - role: precheck/artifact_check
+      when: and .artifact.artifact_file (ne .artifact.artifact_file "")
+- hosts:
+    - k8s_cluster
+    - etcd
+    - image_registry
+    - nfs
+  gather_facts: true
+  tags: ["always"]
+  roles:
+    - precheck/env_check
+
+- hosts:
+    - localhost
+  gather_facts: true
+  roles:
+    - init/init-artifact
+
+# init os
+- hosts:
+    - add_nodes
+  roles:
+    - init/init-os
+
+- hosts:
+    - kube_control_plane
+  tasks:
+    - name: select init node
+      run_once: true
+      set_fact:
+        init_kubernetes_node: |
+          {{- $initNodes := list -}}
+          {{- range .groups.kube_control_plane -}}
+            {{- if index $.inventory_hosts . "kubernetes_install_service" "stdout" | eq "active" -}}
+              {{- $initNodes = append $initNodes . -}}
+            {{- end -}}
+          {{- end -}}
+          {{- if $initNodes | len | eq 1 -}}
+            {{ $initNodes | first }}
+          {{- else if $initNodes | len | lt 1 -}}
+            {{ index $initNodes (randInt 0 ((sub ($initNodes | len) 1) | int)) }}            
+          {{- end -}}
+    - name: init node
+      when: eq .inventory_name .init_kubernetes_node
+      block:
+        - name: Generate certificate key by kubeadm
+          command: |
+            if [ ! -f /etc/kubernetes/kubeadm-config.yaml ]; then
+              kubectl get cm kubeadm-config -n kube-system -o=jsonpath='{.data.ClusterConfiguration}' > /etc/kubernetes/kubeadm-config.yaml
+            fi
+            /usr/local/bin/kubeadm init phase upload-certs --upload-certs --config /etc/kubernetes/kubeadm-config.yaml 2>&1 \
+              | awk '/Using certificate key:/{getline; print}'
+          register: kubeadm_cert_result
+        - name: Set_Fact certificate key to all hosts
+          set_fact:
+            kubeadm_cert: |
+              {{ .kubeadm_cert_result.stdout }}
+        - name: Generate token by kubeadm
+          command: /usr/local/bin/kubeadm token create
+          register: kubeadm_token_result
+        - name: Set_Fact token to all hosts
+          set_fact:
+            kubeadm_token: |
+              {{ .kubeadm_token_result.stdout }}
+
+- hosts:
+    - add_nodes
+  roles:
+    - role: install/cri
+    - role: kubernetes/pre-kubernetes
+    - role: kubernetes/join-kubernetes
+    - role: kubernetes/certs
+      when: 
+        - .groups.kube_control_plane | default list | has .inventory_name
+        - .kubernetes.renew_certs.enabled    
+
+- import_playbook: hook/post_install.yaml

--- a/builtin/core/roles/kubernetes/init-kubernetes/tasks/deploy_cluster_dns.yaml
+++ b/builtin/core/roles/kubernetes/init-kubernetes/tasks/deploy_cluster_dns.yaml
@@ -11,11 +11,11 @@
     kubectl delete svc kube-dns -n kube-system
     kubectl apply -f /etc/kubernetes/coredns.yaml && kubectl rollout restart deployment -n kube-system coredns
 
-- name: Generate nodelocaldns deployment
+- name: Generate nodelocaldns daemonset
   template:
     src: dns/nodelocaldns.yaml
     dest: /etc/kubernetes/nodelocaldns.yaml
 
-- name: Apply coredns deployment
+- name: Apply nodelocaldns daemonset
   command: |
     kubectl apply -f /etc/kubernetes/nodelocaldns.yaml

--- a/cmd/kk/app/builtin.go
+++ b/cmd/kk/app/builtin.go
@@ -11,9 +11,6 @@ import (
 
 // registerInternalCommand registers an internal command to the list of internal commands.
 // It ensures that the command is not already registered before adding it to the list.
-//
-// Parameters:
-//   - command: The command to be registered.
 func registerInternalCommand(command *cobra.Command) {
 	for _, c := range internalCommand {
 		if c.Name() == command.Name() {
@@ -25,6 +22,7 @@ func registerInternalCommand(command *cobra.Command) {
 }
 
 func init() {
+	registerInternalCommand(builtin.NewAddCommand())
 	registerInternalCommand(builtin.NewArtifactCommand())
 	registerInternalCommand(builtin.NewCertsCommand())
 	registerInternalCommand(builtin.NewCreateCommand())

--- a/cmd/kk/app/builtin/add.go
+++ b/cmd/kk/app/builtin/add.go
@@ -1,0 +1,65 @@
+//go:build builtin
+// +build builtin
+
+/*
+Copyright 2025 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builtin
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/kubesphere/kubekey/v4/cmd/kk/app/options/builtin"
+)
+
+// NewAddCommand creates a new cobra command for adding nodes to a Kubernetes cluster.
+// It adds the "nodes" subcommand to enable adding worker nodes.
+func NewAddCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add nodes to kubernetes cluster",
+	}
+	cmd.AddCommand(newAddNodeCommand())
+
+	return cmd
+}
+
+// newAddNodeCommand creates a new cobra command for adding worker nodes to an existing cluster.
+// It uses the AddNodeOptions to handle configuration and execution of the add nodes operation.
+func newAddNodeCommand() *cobra.Command {
+	o := builtin.NewAddNodeOptions()
+
+	cmd := &cobra.Command{
+		Use:   "nodes",
+		Short: "Add nodes to the cluster according to the new nodes information from the specified configuration file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Complete the configuration and create a playbook for adding nodes
+			playbook, err := o.Complete(cmd, append(args, "playbooks/add_nodes.yaml"))
+			if err != nil {
+				return err
+			}
+
+			// Execute the playbook to add the nodes
+			return o.CommonOptions.Run(cmd.Context(), playbook)
+		},
+	}
+	flags := cmd.Flags()
+	for _, f := range o.Flags().FlagSets {
+		flags.AddFlagSet(f)
+	}
+
+	return cmd
+}

--- a/cmd/kk/app/options/builtin/add.go
+++ b/cmd/kk/app/options/builtin/add.go
@@ -1,0 +1,133 @@
+//go:build builtin
+// +build builtin
+
+/*
+Copyright 2025 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builtin
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/cockroachdb/errors"
+	kkcorev1 "github.com/kubesphere/kubekey/api/core/v1"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/kubesphere/kubekey/v4/cmd/kk/app/options"
+	"github.com/kubesphere/kubekey/v4/pkg/variable"
+)
+
+// NewAddNodeOptions creates a new AddNodeOptions with default values
+func NewAddNodeOptions() *AddNodeOptions {
+	// set default value
+	return &AddNodeOptions{
+		CommonOptions:    options.NewCommonOptions(),
+		Kubernetes:       defaultKubeVersion,
+		ContainerManager: defaultContainerManager,
+	}
+}
+
+// AddNodeOptions contains options for adding nodes to a cluster
+type AddNodeOptions struct {
+	options.CommonOptions
+	// kubernetes version which the cluster will install.
+	Kubernetes string
+	// ContainerRuntime for kubernetes. Such as docker, containerd etc.
+	ContainerManager string
+}
+
+// Flags adds flags for configuring AddNodeOptions to the specified FlagSet
+func (o *AddNodeOptions) Flags() cliflag.NamedFlagSets {
+	fss := o.CommonOptions.Flags()
+	kfs := fss.FlagSet("config")
+	kfs.StringVar(&o.Kubernetes, "with-kubernetes", o.Kubernetes, fmt.Sprintf("Specify a supported version of kubernetes. default is %s", o.Kubernetes))
+	kfs.StringVar(&o.ContainerManager, "container-manager", o.ContainerManager, fmt.Sprintf("Container runtime: docker, crio, containerd and isula. default is %s", o.ContainerManager))
+
+	return fss
+}
+
+// Complete validates and completes the AddNodeOptions configuration.
+// It creates and returns a Playbook object based on the options.
+func (o *AddNodeOptions) Complete(cmd *cobra.Command, args []string) (*kkcorev1.Playbook, error) {
+	playbook := &kkcorev1.Playbook{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "add-nodes-",
+			Namespace:    o.Namespace,
+			Annotations: map[string]string{
+				kkcorev1.BuiltinsProjectAnnotation: "",
+			},
+		},
+	}
+
+	// complete playbook. now only support one playbook
+	var nodes []string
+	if len(args) < 1 {
+		return nil, errors.Errorf("%s\nSee '%s -h' for help and examples", cmd.Use, cmd.CommandPath())
+	} else if len(args) == 1 {
+		o.Playbook = args[0]
+	} else {
+		nodes = args[:len(args)-1]
+		o.Playbook = args[len(args)-1]
+	}
+
+	playbook.Spec = kkcorev1.PlaybookSpec{
+		Playbook: o.Playbook,
+		Debug:    o.Debug,
+	}
+	// override kube_version in config
+	if err := completeConfig(o.Kubernetes, o.CommonOptions.ConfigFile, o.CommonOptions.Config); err != nil {
+		return nil, err
+	}
+	if err := completeInventory(o.CommonOptions.InventoryFile, o.CommonOptions.Inventory); err != nil {
+		return nil, err
+	}
+	if err := o.CommonOptions.Complete(playbook); err != nil {
+		return nil, err
+	}
+
+	return playbook, o.complete(nodes)
+}
+
+// complete updates the configuration with container manager and kubernetes version settings
+func (o *AddNodeOptions) complete(nodes []string) error {
+	if o.ContainerManager != "" {
+		// override container_manager in config
+		if err := unstructured.SetNestedField(o.CommonOptions.Config.Value(), o.ContainerManager, "cri", "container_manager"); err != nil {
+			return errors.Wrapf(err, "failed to set %q to config", "cri.container_manager")
+		}
+	}
+
+	if err := unstructured.SetNestedField(o.CommonOptions.Config.Value(), o.Kubernetes, "kube_version"); err != nil {
+		return errors.Wrapf(err, "failed to set %q to config", "kube_version")
+	}
+
+	// override add_nodes_group in inventory
+	if len(nodes) > 0 {
+		addNodesGroups := o.Inventory.Spec.Groups["add_nodes"]
+		for _, n := range nodes {
+			if !slices.Contains(variable.HostsInGroup(*o.Inventory, "add_nodes"), n) {
+				addNodesGroups.Hosts = append(addNodesGroups.Hosts, n)
+			}
+		}
+		o.Inventory.Spec.Groups["add_nodes"] = addNodesGroups
+	}
+
+	return nil
+}

--- a/pkg/variable/helper.go
+++ b/pkg/variable/helper.go
@@ -199,7 +199,7 @@ func HostsInGroup(inv kkcorev1.Inventory, groupName string) []string {
 		return CombineSlice(hosts, v.Hosts)
 	}
 
-	return nil
+	return make([]string, 0)
 }
 
 // StringVar get string value by key


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
add command `add nodes` 
you can use two way to chose add nodes
1. define nodes in `add_nodes` group in inventory.yaml
```yaml
apiVersion: kubekey.kubesphere.io/v1
kind: Inventory
metadata:
  name: default
  namespace: default
spec:
  groups:
    add_nodes:
      hosts:
      - i-ntnxgrer
      vars: null
    etcd:
      hosts:
      - i-bi3mb19w
      vars: null
    k8s_cluster:
      groups:
      - kube_control_plane
      - kube_worker
      vars: null
    kube_control_plane:
      hosts:
      - i-bi3mb19w
      - i-ntnxgrer
      - i-xcg3bb1u
      vars: null
    kube_worker:
      hosts:
      - i-bi3mb19w
      - i-ntnxgrer
      - i-xcg3bb1u
      vars: null
  hosts:
    i-bi3mb19w:
      connector:
        host: 1.1.1.1
      internal_ipv4: 1.1.1.1
    i-ntnxgrer:
      connector:
        host: 1.1.1.2
      internal_ipv4: 1.1.1.2
    i-xcg3bb1u:
      connector:
        host: 1.1.1.3
      internal_ipv4: 1.1.1.3
  vars:
    set_hostname: false
```
and then run `kk add nodes -i inventory.yaml`
2. define nodes by argument
```yaml
kk add nodes i-ntnxgrer
```

the test result:
![截屏2025-05-08 17 38 28](https://github.com/user-attachments/assets/8facd82a-aa57-4be3-92ab-b5d9360fae10)
![截屏2025-05-08 17 38 18](https://github.com/user-attachments/assets/21d23469-1b82-40e0-b9f2-9a33cab75e74)


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/kubekey/issues/1889
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add command add node
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
