### PR TITLE
feat: Support for auto-detecting nodes to add.

### DIFF
--- a/builtin/core/playbooks/add_nodes.yaml
+++ b/builtin/core/playbooks/add_nodes.yaml
@@ -20,7 +20,6 @@
     - image_registry
     - nfs
   gather_facts: true
-  tags: ["always"]
   roles:
     - precheck/env_check
 
@@ -32,7 +31,7 @@
 
 # init os
 - hosts:
-    - add_nodes
+    - k8s_cluster
   roles:
     - init/init-os
 
@@ -78,13 +77,17 @@
               {{ .kubeadm_token_result.stdout }}
 
 - hosts:
-    - add_nodes
+    - k8s_cluster
   roles:
     - role: install/cri
+      when: or (.add_nodes | default list | len | eq 0) (.add_nodes | default list | has .inventory_name)
     - role: kubernetes/pre-kubernetes
+      when: or (.add_nodes | default list | len | eq 0) (.add_nodes | default list | has .inventory_name)    
     - role: kubernetes/join-kubernetes
+      when: or (.add_nodes | default list | len | eq 0) (.add_nodes | default list | has .inventory_name)
     - role: kubernetes/certs
       when: 
+        - or (.add_nodes | default list | len | eq 0) (.add_nodes | default list | has .inventory_name)
         - .groups.kube_control_plane | default list | has .inventory_name
         - .kubernetes.renew_certs.enabled    
 

--- a/builtin/core/playbooks/create_cluster.yaml
+++ b/builtin/core/playbooks/create_cluster.yaml
@@ -20,7 +20,6 @@
     - image_registry
     - nfs
   gather_facts: true
-  tags: ["always"]
   roles:
     - precheck/env_check
 

--- a/builtin/core/roles/precheck/env_check/tasks/etcd.yaml
+++ b/builtin/core/roles/precheck/env_check/tasks/etcd.yaml
@@ -18,6 +18,7 @@
   assert:
     that: (mod (.groups.etcd | len) 2) | eq 1
     fail_msg: "etcd number should be odd number"
+  run_once: true  
   when: .kubernetes.etcd.deployment_type | eq "external"
 
 ## https://cwiki.yunify.com/pages/viewpage.action?pageId=145920824

--- a/builtin/core/roles/precheck/env_check/tasks/network.yaml
+++ b/builtin/core/roles/precheck/env_check/tasks/network.yaml
@@ -1,18 +1,18 @@
 ---
-# - name: Should found network interface
-#   command:  |
-#     {{- if and .internal_ipv4 (.internal_ipv4 | ne "") }}
-#     if [ ! ip -o addr show | grep -q {{ .internal_ipv4 }} ]; then
-#       echo 'No ipv4 network interface found'
-#       exit 1
-#     fi
-#     {{- end }}
-#     {{- if and .internal_ipv6 (.internal_ipv6 | ne "") }}
-#     if [ ! ip -o addr show | grep -q {{ .internal_ipv6 }} ]; then
-#       echo 'No ipv6 network interface found'
-#       exit 1
-#     fi
-#     {{- end }}
+- name: Should found network interface
+  command:  |
+    {{- if and .internal_ipv4 (.internal_ipv4 | ne "") }}
+    if [ ! ip -o addr show | grep -q {{ .internal_ipv4 }} ]; then
+      echo 'No ipv4 network interface found'
+      exit 1
+    fi
+    {{- end }}
+    {{- if and .internal_ipv6 (.internal_ipv6 | ne "") }}
+    if [ ! ip -o addr show | grep -q {{ .internal_ipv6 }} ]; then
+      echo 'No ipv6 network interface found'
+      exit 1
+    fi
+    {{- end }}
 
 # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
 - name: Stop if cidr is not valid

--- a/cmd/kk/app/builtin/add.go
+++ b/cmd/kk/app/builtin/add.go
@@ -45,6 +45,14 @@ func newAddNodeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "nodes",
 		Short: "Add nodes to the cluster according to the new nodes information from the specified configuration file",
+		Long: `There are two executors available for adding nodes:
+
+1. kk add nodes
+   This will add all nodes listed in the inventory that are not yet installed in the cluster.
+
+2. kk add nodes --control-plane node1,node2 --worker node1,node2
+   This will only add the specified nodes to the cluster as control-plane or worker nodes.
+   Ensure their connection details are provided in the inventory's hosts file.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Complete the configuration and create a playbook for adding nodes
 			playbook, err := o.Complete(cmd, append(args, "playbooks/add_nodes.yaml"))

--- a/cmd/kk/app/options/builtin/builtin.go
+++ b/cmd/kk/app/options/builtin/builtin.go
@@ -30,6 +30,11 @@ import (
 	"github.com/kubesphere/kubekey/v4/builtin/core"
 )
 
+const (
+	defaultGroupControlPlane = "kube_control_plane"
+	defaultGroupWorker       = "kube_worker"
+)
+
 func completeInventory(inventoryFile string, inventory *kkcorev1.Inventory) error {
 	if inventoryFile != "" {
 		data, err := os.ReadFile(inventoryFile)

--- a/cmd/kk/app/options/builtin/create.go
+++ b/cmd/kk/app/options/builtin/create.go
@@ -68,7 +68,7 @@ func (o *CreateClusterOptions) Flags() cliflag.NamedFlagSets {
 	fss := o.CommonOptions.Flags()
 	kfs := fss.FlagSet("config")
 	kfs.StringVar(&o.Kubernetes, "with-kubernetes", o.Kubernetes, fmt.Sprintf("Specify a supported version of kubernetes. default is %s", o.Kubernetes))
-	kfs.StringVar(&o.ContainerManager, "container-manager", o.ContainerManager, fmt.Sprintf("Container runtime: docker, crio, containerd and isula. default is %s", o.ContainerManager))
+	kfs.StringVar(&o.ContainerManager, "container-manager", o.ContainerManager, fmt.Sprintf("Container runtime: docker, containerd. default is %s", o.ContainerManager))
 
 	return fss
 }

--- a/cmd/kk/app/options/builtin/delete.go
+++ b/cmd/kk/app/options/builtin/delete.go
@@ -60,7 +60,7 @@ func (o *DeleteClusterOptions) Flags() cliflag.NamedFlagSets {
 	fss := o.CommonOptions.Flags()
 	kfs := fss.FlagSet("config")
 	kfs.StringVar(&o.Kubernetes, "with-kubernetes", o.Kubernetes, fmt.Sprintf("Specify a supported version of kubernetes. default is %s", o.Kubernetes))
-	kfs.StringVar(&o.ContainerManager, "container-manager", o.ContainerManager, fmt.Sprintf("Container runtime: docker, crio, containerd and isula. default is %s", o.ContainerManager))
+	kfs.StringVar(&o.ContainerManager, "container-manager", o.ContainerManager, fmt.Sprintf("Container runtime: docker, containerd. default is %s", o.ContainerManager))
 
 	return fss
 }

--- a/pkg/controllers/infrastructure/inventory_hostselector.go
+++ b/pkg/controllers/infrastructure/inventory_hostselector.go
@@ -27,7 +27,7 @@ var SequenceSelector = func(ctx context.Context, groupName string, remain int, i
 	groups := inventory.Spec.Groups[groupName]
 	if remain > 0 {
 		// Add hosts from ungrouped
-		ungrouped, ok := variable.ConvertGroup(*inventory)[_const.VariableUnGrouped].([]string)
+		ungrouped, ok := variable.ConvertGroup(*inventory)[_const.VariableUnGrouped]
 		if !ok {
 			klog.ErrorS(nil, "Failed to get ungrouped hosts")
 
@@ -59,7 +59,7 @@ var RandomSelector = func(ctx context.Context, groupName string, remain int, inv
 	groups := inventory.Spec.Groups[groupName]
 	if remain > 0 {
 		// Add hosts from ungrouped
-		ungrouped, ok := variable.ConvertGroup(*inventory)[_const.VariableUnGrouped].([]string)
+		ungrouped, ok := variable.ConvertGroup(*inventory)[_const.VariableUnGrouped]
 		if !ok {
 			klog.ErrorS(nil, "Failed to get ungrouped hosts")
 

--- a/pkg/variable/helper.go
+++ b/pkg/variable/helper.go
@@ -155,9 +155,9 @@ func CombineSlice(g1, g2 []string) []string {
 //
 // Returns:
 //
-//	map[string]any: A map where keys are group names and values are lists of hostnames.
-func ConvertGroup(inv kkcorev1.Inventory) map[string]any {
-	groups := make(map[string]any)
+//	map[string][]string: A map where keys are group names and values are lists of hostnames.
+func ConvertGroup(inv kkcorev1.Inventory) map[string][]string {
+	groups := make(map[string][]string)
 	all := make([]string, 0)
 
 	for hn := range inv.Spec.Hosts {
@@ -174,8 +174,8 @@ func ConvertGroup(inv kkcorev1.Inventory) map[string]any {
 	groups[_const.VariableGroupsAll] = all
 
 	for gn := range inv.Spec.Groups {
-		groups[gn] = HostsInGroup(inv, gn)
-		if hosts, ok := groups[gn].([]string); ok {
+		groups[gn] = hostsInGroup(inv, gn)
+		if hosts, ok := groups[gn]; ok {
 			for _, v := range hosts {
 				if slices.Contains(ungrouped, v) {
 					ungrouped = slices.Delete(ungrouped, slices.Index(ungrouped, v), slices.Index(ungrouped, v)+1)
@@ -189,13 +189,13 @@ func ConvertGroup(inv kkcorev1.Inventory) map[string]any {
 	return groups
 }
 
-// HostsInGroup get a host_name slice in a given group
+// hostsInGroup get a host_name slice in a given group
 // if the given group contains other group. convert other group to host_name slice.
-func HostsInGroup(inv kkcorev1.Inventory, groupName string) []string {
+func hostsInGroup(inv kkcorev1.Inventory, groupName string) []string {
 	if v, ok := inv.Spec.Groups[groupName]; ok {
 		var hosts []string
 		for _, cg := range v.Groups {
-			hosts = CombineSlice(HostsInGroup(inv, cg), hosts)
+			hosts = CombineSlice(hostsInGroup(inv, cg), hosts)
 		}
 
 		return CombineSlice(hosts, v.Hosts)

--- a/pkg/variable/helper_test.go
+++ b/pkg/variable/helper_test.go
@@ -126,7 +126,7 @@ func TestHostsInGroup(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tc.except, HostsInGroup(tc.inventory, tc.groupName))
+			assert.ElementsMatch(t, tc.except, hostsInGroup(tc.inventory, tc.groupName))
 		})
 	}
 }

--- a/pkg/variable/variable.go
+++ b/pkg/variable/variable.go
@@ -90,7 +90,7 @@ func New(ctx context.Context, client ctrlclient.Client, playbook kkcorev1.Playbo
 		},
 	}
 
-	if gd, ok := ConvertGroup(*inventory)["all"].([]string); ok {
+	if gd, ok := ConvertGroup(*inventory)["all"]; ok {
 		for _, hostname := range gd {
 			v.value.Hosts[hostname] = host{
 				RemoteVars:  make(map[string]any),

--- a/pkg/variable/variable_get.go
+++ b/pkg/variable/variable_get.go
@@ -41,9 +41,7 @@ var GetHostnames = func(name []string) GetFunc {
 			// add group's host to gs
 			for gn, gv := range ConvertGroup(vv.value.Inventory) {
 				if gn == n {
-					if gvd, ok := gv.([]string); ok {
-						hs = CombineSlice(hs, gvd)
-					}
+					hs = CombineSlice(hs, gv)
 
 					break
 				}
@@ -56,7 +54,7 @@ var GetHostnames = func(name []string) GetFunc {
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to convert %q to int", match[2])
 				}
-				if group, ok := ConvertGroup(vv.value.Inventory)[match[1]].([]string); ok {
+				if group, ok := ConvertGroup(vv.value.Inventory)[match[1]]; ok {
 					if index >= len(group) {
 						return nil, errors.Errorf("index %v out of range for group %s", index, group)
 					}
@@ -67,7 +65,7 @@ var GetHostnames = func(name []string) GetFunc {
 			// add random host in group
 			regexForRandom := regexp.MustCompile(`^(.+?)\s*\|\s*random$`)
 			if match := regexForRandom.FindStringSubmatch(strings.TrimSpace(n)); match != nil {
-				if group, ok := ConvertGroup(vv.value.Inventory)[match[1]].([]string); ok {
+				if group, ok := ConvertGroup(vv.value.Inventory)[match[1]]; ok {
 					hs = append(hs, group[rand.Intn(len(group))])
 				}
 			}

--- a/pkg/variable/variable_get_test.go
+++ b/pkg/variable/variable_get_test.go
@@ -158,7 +158,7 @@ func TestGetAllVariable(t *testing.T) {
 				"artifact": map[string]any{
 					"images": []any{"abc"},
 				},
-				"groups": map[string]any{"all": []string{"localhost"}, "ungrouped": []string{"localhost"}},
+				"groups": map[string][]string{"all": {"localhost"}, "ungrouped": {"localhost"}},
 				"inventory_hosts": map[string]any{
 					"localhost": map[string]any{
 						"internal_ipv4": "127.0.0.1",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Support for auto-detecting nodes to add.
There are two executors available for adding nodes:

1. `kk add nodes`
   This will add all nodes listed in the inventory that are not yet installed in the cluster.

2. `kk add nodes --control-plane node1,node2 --worker node1,node2`
   This will only add the specified nodes to the cluster as control-plane or worker nodes.
   Ensure their connection details are provided in the inventory's hosts file.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/kubekey/pull/2557

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Support for auto-detecting nodes to ad
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
