### PR TITLE
Update DefaultTimeout to 5h

### DIFF
--- a/cmd/kk/pkg/core/task/const.go
+++ b/cmd/kk/pkg/core/task/const.go
@@ -17,7 +17,7 @@
 package task
 
 const (
-	DefaultTimeout = 120
+	DefaultTimeout = 300
 	DefaultCon     = 10
 
 	DefaultTaskName = "DefaultTask"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:

-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:


### Special notes for reviewers:
```
When downloading offline, it often timed out. Now it is set to 2 hours. Although it is already very long, the time is still not enough if you rely on all the downloads, so it will be extended to 5 hours.
```

### Does this PR introduced a user-facing change?

```release-note
DefaultTimeout 2h->5h
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
