### PR TITLE
feat: add resources tags api

### DIFF
--- a/pkg/const/web.go
+++ b/pkg/const/web.go
@@ -12,11 +12,14 @@ const (
 	// This tag is used to identify and categorize KubeKey-specific resources
 	// in the system, making it easier to filter and manage them
 	KubeKeyTag = "kubekey"
-
 	// OpenAPITag is the tag used for OpenAPI documentation
 	// This tag helps organize and identify OpenAPI/Swagger documentation
 	// related to the KubeKey API endpoints
 	OpenAPITag = "api"
+	// ResourceTag is the tag used for resource-related endpoints
+	// This tag helps organize and identify API endpoints that deal with
+	// resource management and operations
+	ResourceTag = "resources"
 
 	// StatusOK represents a successful operation status
 	// Used to indicate that an API operation completed successfully

--- a/pkg/web/schema.go
+++ b/pkg/web/schema.go
@@ -3,19 +3,22 @@ package web
 import (
 	"net/http"
 
+	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
+
+	_const "github.com/kubesphere/kubekey/v4/pkg/const"
 )
 
 // NewSchemaService creates a new WebService that serves schema files from the specified root path.
-// It sets up a route that handles GET requests to /schema/{subpath} and serves files from the rootPath directory.
-// The {subpath:*} parameter allows for matching any path under /schema/.
+// It sets up a route that handles GET requests to /resources/schema/{subpath} and serves files from the rootPath directory.
+// The {subpath:*} parameter allows for matching any path under /resources/schema/.
 func NewSchemaService(rootPath string) *restful.WebService {
 	ws := new(restful.WebService)
-	ws.Path("/schema")
+	ws.Path("resources/schema")
 
 	ws.Route(ws.GET("/{subpath:*}").To(func(req *restful.Request, resp *restful.Response) {
-		http.StripPrefix("/schema/", http.FileServer(http.Dir(rootPath))).ServeHTTP(resp.ResponseWriter, req.Request)
-	}))
+		http.StripPrefix("resources/schema/", http.FileServer(http.Dir(rootPath))).ServeHTTP(resp.ResponseWriter, req.Request)
+	}).Metadata(restfulspec.KeyOpenAPITags, []string{_const.ResourceTag}))
 
 	return ws
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
add resources tags api
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
/kind feature
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
