### PR TITLE
fix: restart cri after clear iptables

### DIFF
--- a/builtin/core/roles/uninstall/cri/tasks/main.yaml
+++ b/builtin/core/roles/uninstall/cri/tasks/main.yaml
@@ -16,4 +16,4 @@
 
 - name: Delete residue files
   command: |
-   rm -f /usr/local/bin/crictl
+    rm -f /usr/local/bin/crictl

--- a/builtin/core/roles/uninstall/kubernetes/tasks/kubernetes.yaml
+++ b/builtin/core/roles/uninstall/kubernetes/tasks/kubernetes.yaml
@@ -15,6 +15,8 @@
   command: |
     rm -rf /usr/local/bin/kubeadm && rm -rf /usr/local/bin/kubelet && rm -rf /usr/local/bin/kubectl
     rm -rf /var/lib/kubelet/
+    # If /var/log/pods/ is not cleaned up, static pods may accumulate unexpected restarts due to lingering log files interfering with their lifecycle.
+    rm -rf /var/log/pods/
     rm -rf /etc/kubernetes/
     rm -rf .kube/config
     rm -rf /var/lib/etcd

--- a/builtin/core/roles/uninstall/kubernetes/tasks/network.yaml
+++ b/builtin/core/roles/uninstall/kubernetes/tasks/network.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Reset iptables
+- name: Clean iptables
   command: |
     iptables -F
     iptables -X
@@ -37,3 +37,14 @@
   command: |
     ip neigh show | grep {{ .kubernetes.control_plane_endpoint.kube_vip.address }} | awk '{print $1 " dev " $3}' | xargs -r -L1 ip neigh delete
     ip -o addr show | grep {{ .kubernetes.control_plane_endpoint.kube_vip.address }} | awk '{system("ip addr del "$4" dev "$2)}'
+
+- name: Rebuild cri iptables
+  ignore_errors: true
+  when: or (.deleteCRI | not) (.groups.image_registry | default list | has .inventory_hostname)
+  command: |
+    {{- if .cri.container_manager | eq "docker" }}
+    systemctl restart containerd
+    systemctl restart docker
+    {{- else if .cri.container_manager | eq "containerd" }}
+    systemctl restart containerd
+    {{- end }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
If you don't uninstall CRI when deleting a node, you should rebuild iptables after clearing them by restarting CRI.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
 restart cri after clear iptables
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
