### PR TITLE
fix: Eliminate duplicate parse logic.

### DIFF
--- a/pkg/executor/task_executor.go
+++ b/pkg/executor/task_executor.go
@@ -102,12 +102,12 @@ func (e *taskExecutor) runTaskLoop(ctx context.Context) error {
 		}
 		e.task.Status.Phase = kkcorev1alpha1.TaskPhaseRunning
 		if err := e.client.Status().Patch(ctx, e.task, ctrlclient.MergeFrom(task)); err != nil {
-			return errors.Wrap(err, "failed to patch task status")
+			return errors.Wrapf(err, "failed to patch task status of %s", ctrlclient.ObjectKeyFromObject(task))
 		}
 		task = e.task.DeepCopy()
 		e.execTask(ctx)
 		if err := e.client.Status().Patch(ctx, e.task, ctrlclient.MergeFrom(task)); err != nil {
-			return errors.Wrap(err, "failed to patch task status")
+			return errors.Wrapf(err, "failed to patch task status of %s", ctrlclient.ObjectKeyFromObject(task))
 		}
 	}
 	return nil

--- a/pkg/modules/assert.go
+++ b/pkg/modules/assert.go
@@ -24,8 +24,6 @@ import (
 	kkprojectv1 "github.com/kubesphere/kubekey/api/project/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/klog/v2"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubesphere/kubekey/v4/pkg/converter/tmpl"
 	"github.com/kubesphere/kubekey/v4/pkg/variable"
@@ -140,29 +138,15 @@ func ModuleAssert(ctx context.Context, options ExecOptions) (string, string) {
 	}
 	// condition is true
 	if ok {
-		r, err := tmpl.Parse(ha, aa.successMsg)
-		if err == nil {
-			return string(r), ""
-		}
-		klog.V(4).ErrorS(err, "parse \"success_msg\" error", "task", ctrlclient.ObjectKeyFromObject(&options.Task))
-
-		return StdoutTrue, ""
+		return aa.successMsg, ""
 	}
 	// condition is false and fail_msg is not empty
 	if aa.failMsg != "" {
-		r, err := tmpl.Parse(ha, aa.failMsg)
-		if err == nil {
-			return StdoutFalse, string(r)
-		}
-		klog.V(4).ErrorS(err, "parse \"fail_msg\" error", "task", ctrlclient.ObjectKeyFromObject(&options.Task))
+		return "", aa.failMsg
 	}
 	// condition is false and msg is not empty
 	if aa.msg != "" {
-		r, err := tmpl.Parse(ha, aa.msg)
-		if err == nil {
-			return StdoutFalse, string(r)
-		}
-		klog.V(4).ErrorS(err, "parse \"msg\" error", "task", ctrlclient.ObjectKeyFromObject(&options.Task))
+		return "", aa.msg
 	}
 
 	return StdoutFalse, "False"

--- a/pkg/modules/assert_test.go
+++ b/pkg/modules/assert_test.go
@@ -86,7 +86,6 @@ func TestAssert(t *testing.T) {
 					},
 				},
 			},
-			exceptStdout: StdoutFalse,
 			exceptStderr: "False",
 		},
 		{
@@ -103,7 +102,6 @@ func TestAssert(t *testing.T) {
 					},
 				},
 			},
-			exceptStdout: StdoutFalse,
 			exceptStderr: "failed v2",
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

### What this PR does / why we need it:
Eliminate duplicate parse logic.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
