### PR TITLE
fix: zsh interprets curly braces {} as globbing patterns

### DIFF
--- a/cmd/kk/pkg/bootstrap/precheck/tasks.go
+++ b/cmd/kk/pkg/bootstrap/precheck/tasks.go
@@ -327,7 +327,7 @@ func (g *GetKubernetesNodesStatus) Execute(runtime connector.Runtime) error {
 	}
 	g.PipelineCache.Set(common.ClusterNodeStatus, nodeStatus)
 
-	cri, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl get node -o jsonpath=\"{.items[*].status.nodeInfo.containerRuntimeVersion}\"", false)
+	cri, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl get node -o jsonpath='{.items[*].status.nodeInfo.containerRuntimeVersion}'", false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

```console
00:12:32 CST command: [test-node01]
sudo -E /bin/bash -c "/usr/local/bin/kubectl get node -o jsonpath="{.items[*].status.nodeInfo.containerRuntimeVersion}""
00:12:32 CST stdout: [test-node01]
zsh:1: no matches found: /usr/local/bin/kubectl get node -o jsonpath={.items[*].status.nodeInfo.containerRuntimeVersion}
00:12:32 CST stderr: [test-node01]
Failed to exec command: sudo -E /bin/bash -c "/usr/local/bin/kubectl get node -o jsonpath="{.items[*].status.nodeInfo.containerRuntimeVersion}"
"
zsh:1: no matches found: /usr/local/bin/kubectl get node -o jsonpath={.items[*].status.nodeInfo.containerRuntimeVersion}: Process exited with s
tatus 1
00:12:32 CST message: [test-node01]
Failed to exec command: sudo -E /bin/bash -c "/usr/local/bin/kubectl get node -o jsonpath="{.items[*].status.nodeInfo.containerRuntimeVersion}"
"
zsh:1: no matches found: /usr/local/bin/kubectl get node -o jsonpath={.items[*].status.nodeInfo.containerRuntimeVersion}: Process exited with s
tatus 1
00:12:32 CST skipped: [test-node02]
00:12:32 CST failed: [test-node01]
error: Pipeline[UpgradeClusterPipeline] execute failed: Module[ClusterPreCheckModule] exec failed:
failed: [test-node01] [GetKubernetesNodesStatus] exec failed after 3 retries: Failed to exec command: sudo -E /bin/bash -c "/usr/local/bin/kube
ctl get node -o jsonpath="{.items[*].status.nodeInfo.containerRuntimeVersion}""
zsh:1: no matches found: /usr/local/bin/kubectl get node -o jsonpath={.items[*].status.nodeInfo.containerRuntimeVersion}: Process exited with s
tatus 1
```
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
