### PR TITLE
fix: add sshPort of listIP result

### DIFF
--- a/pkg/web/api/result.go
+++ b/pkg/web/api/result.go
@@ -97,6 +97,7 @@ type SchemaTablePlaybook struct {
 // It indicates whether the IP is a localhost, if SSH is reachable, and if SSH authorization is present.
 type IPTable struct {
 	IP            string `json:"ip"`            // IP address
+	SSHPort       string `json:"sshPort"`       // SSH port
 	Localhost     bool   `json:"localhost"`     // Whether the IP is a localhost IP
 	SSHReachable  bool   `json:"sshReachable"`  // Whether SSH port is reachable on this IP
 	SSHAuthorized bool   `json:"sshAuthorized"` // Whether SSH is authorized for this IP

--- a/pkg/web/resources.go
+++ b/pkg/web/resources.go
@@ -108,6 +108,7 @@ func (h schemaHandler) listIP(request *restful.Request, response *restful.Respon
 					mu.Lock()
 					ipTable = append(ipTable, api.IPTable{
 						IP:            ip,
+						SSHPort:       string(sshPort),
 						Localhost:     true,
 						SSHReachable:  true,
 						SSHAuthorized: true,
@@ -126,6 +127,7 @@ func (h schemaHandler) listIP(request *restful.Request, response *restful.Respon
 				mu.Lock()
 				ipTable = append(ipTable, api.IPTable{
 					IP:            ip,
+					SSHPort:       string(sshPort),
 					SSHReachable:  reachable,
 					SSHAuthorized: authorized,
 				})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/feature

### What this PR does / why we need it:
add sshPort of listIP result

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
