### PR TITLE
feat: Add support for building Debian 12 Bookworm repository iso

### DIFF
--- a/.github/workflows/gen-repository-iso.yaml
+++ b/.github/workflows/gen-repository-iso.yaml
@@ -20,6 +20,8 @@ jobs:
             dockerfile: dockerfile.debian10
           - name: debian11-debs
             dockerfile: dockerfile.debian11
+          - name: debian12-debs
+            dockerfile: dockerfile.debian12
           - name: ubuntu-18.04-debs
             dockerfile: dockerfile.ubuntu1804
           - name: ubuntu-20.04-debs

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use KubeKey in the following three scenarios.
 ### Linux Distributions
 
 * **Ubuntu**  *16.04, 18.04, 20.04, 22.04*
-* **Debian**  *Bullseye, Buster, Stretch*
+* **Debian**  *Bookworm, Bullseye, Buster, Stretch*
 * **CentOS/RHEL**  *7*
 * **AlmaLinux**  *9.0*
 * **SUSE Linux Enterprise Server** *15*

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -30,7 +30,7 @@ KubeKey是一个开源的轻量级工具，用于部署Kubernetes集群。它提
 ### Linux 发行版
 
 * **Ubuntu**  *16.04, 18.04, 20.04, 22.04*
-* **Debian**  *Bullseye, Buster, Stretch*
+* **Debian**  *Bookworm, Bullseye, Buster, Stretch*
 * **CentOS/RHEL**  *7*
 * **AlmaLinux**  *9.0*
 * **SUSE Linux Enterprise Server** *15*

--- a/hack/gen-repository-iso/dockerfile.debian12
+++ b/hack/gen-repository-iso/dockerfile.debian12
@@ -1,0 +1,39 @@
+FROM debian:12.11 as debian12
+ARG TARGETARCH
+ARG OS_RELEASE=bookworm
+ARG OS_VERSION=12
+ARG DIR=debian-12-${TARGETARCH}-debs
+ARG PKGS=.common[],.debs[],.debian[],.debian12[]
+ARG BUILD_TOOLS="apt-transport-https software-properties-common ca-certificates curl wget gnupg dpkg-dev genisoimage dirmngr"
+ENV DEBIAN_FRONTEND=noninteractive
+
+# dump system package list
+RUN dpkg --get-selections | grep -v deinstall | cut -f1 | cut -d ':' -f1 > packages.list
+RUN ARCH=$(dpkg --print-architecture) \
+    && apt update -qq \
+    && apt install -y --no-install-recommends $BUILD_TOOLS \
+    && if [ "$TARGETARCH" = "amd64" ]; then \
+        curl -fsSL https://download.gluster.org/pub/gluster/glusterfs/10/rsa.pub | apt-key add - ; \
+        echo deb https://download.gluster.org/pub/gluster/glusterfs/10/LATEST/Debian/${OS_VERSION}/amd64/apt ${OS_RELEASE} main > /etc/apt/sources.list.d/gluster.list ; \
+       fi \
+    && apt update -qq \
+    && apt upgrade -y -qq
+
+WORKDIR /package
+COPY packages.yaml .
+
+COPY --from=mikefarah/yq:4.46.1 /usr/bin/yq /usr/bin/yq
+RUN yq eval "${PKGS}" packages.yaml >> packages.list \
+    && sort -u packages.list | xargs apt-get install --yes --reinstall --print-uris | awk -F "'" '{print $2}' | grep -v '^$' | sort -u > packages.urls
+
+RUN cat  packages.urls
+
+RUN mkdir -p ${DIR} \
+    && wget -q -x -P ${DIR} -i packages.urls \
+    && cd ${DIR} \
+    && dpkg-scanpackages ./ /dev/null | gzip -9c > ./Packages.gz
+
+RUN genisoimage -r -o ${DIR}.iso ${DIR}
+
+FROM scratch
+COPY --from=debian12 /package/*.iso /

--- a/hack/gen-repository-iso/packages.yaml
+++ b/hack/gen-repository-iso/packages.yaml
@@ -51,6 +51,8 @@ debian10: []
 
 debian11: []
 
+debian12: []
+
 ubuntu: []
 
 ubuntu1804: []


### PR DESCRIPTION
What type of PR is this?

Add one of the following kinds:
/kind feature

What this PR does / why we need it:
Support [Debian Stable 12 Bookworm](https://wiki.debian.org/DebianReleases) which has already been released for 2 years.
Comparing to debian 11, the glusterfs version updated to v10 to support debian 12, yq version updated to 4.46.1.