### PR TITLE
feat(cilium): allow nonexclusive cilium installation

### DIFF
--- a/feature/builtin/roles/addons/cni/tasks/cilium.yaml
+++ b/feature/builtin/roles/addons/cni/tasks/cilium.yaml
@@ -35,3 +35,6 @@
       --set k8sServiceHost={{ .cni.cilium.k8s_endpoint }} \
       --set k8sServicePort={{ .cni.cilium.k8s_port }}
     {{- end }}
+    {{- if .cni.cilium.exclusive }}
+      --set cni.exclusive={{ .cni.cilium.exclusive }}
+    {{- end }}


### PR DESCRIPTION
By default cilium operator removes all cni configurations from the host interface and sets itself to be the sole avaliable cni. In case you want to install cilium alongside multus, in order for multus to function properly you need to set cilium to be non exclusive.

references:

https://docs.cilium.io/en/latest/network/kubernetes/configuration/#adjusting-cni-configuration

https://www.talos.dev/v1.10/kubernetes-guides/network/multus/#:~:text=name%3A%20cnibin-,Exclusive%20CNI,-By%20default%2C%20Cilium

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
