### PR TITLE
bugfix: fix harbor verson config path

### DIFF
--- a/builtin/core/roles/image-registry/docker-compose/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/docker-compose/tasks/main.yaml
@@ -10,6 +10,6 @@
   when: or (.dockercompose_install_version.error | empty | not) (.dockercompose_install_version.stdout | ne (printf "Docker Compose version %s" .image_registry.dockercompose_version))
   copy:
     src: >-
-      {{ .binary_dir }}/image-registry/docker-compose/{{ .dockercompose_version }}/{{ .binary_type }}/docker-compose
+      {{ .binary_dir }}/image-registry/docker-compose/{{ .cri.dockercompose_version }}/{{ .binary_type }}/docker-compose
     dest: /usr/local/bin/docker-compose
     mode: 0755

--- a/builtin/core/roles/image-registry/harbor/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/harbor/tasks/main.yaml
@@ -2,37 +2,37 @@
 - name: Harbor | Synchronize Harbor offline package to remote host
   copy:
     src: >-
-      {{ .binary_dir }}/image-registry/harbor/{{ .harbor_version }}/{{ .binary_type }}/harbor-offline-installer-{{ .harbor_version }}.tgz
+      {{ .binary_dir }}/image-registry/harbor/{{ .image_registry.harbor_version }}/{{ .binary_type }}/harbor-offline-installer-{{ .image_registry.harbor_version }}.tgz
     dest: >-
-      /opt/harbor/{{ .harbor_version }}/harbor-offline-installer-{{ .harbor_version }}.tgz
+      /opt/harbor/{{ .image_registry.harbor_version }}/harbor-offline-installer-{{ .image_registry.harbor_version }}.tgz
 
 - name: Harbor | Extract Harbor offline package
   command: |
-    cd /opt/harbor/{{ .harbor_version }}/ && tar -zxvf harbor-offline-installer-{{ .harbor_version }}.tgz
+    cd /opt/harbor/{{ .image_registry.harbor_version }}/ && tar -zxvf harbor-offline-installer-{{ .image_registry.harbor_version }}.tgz
 
 - name: Harbor | Synchronize image registry certificate to remote host
   copy:
     src: >-
       {{ .binary_dir }}/pki/image_registry.crt
     dest: >-
-      /opt/harbor/{{ .harbor_version }}/ssl/server.crt
+      /opt/harbor/{{ .image_registry.harbor_version }}/ssl/server.crt
 
 - name: Harbor | Synchronize image registry private key to remote host
   copy:
     src: >-
       {{ .binary_dir }}/pki/image_registry.key
     dest: >-
-      /opt/harbor/{{ .harbor_version }}/ssl/server.key
+      /opt/harbor/{{ .image_registry.harbor_version }}/ssl/server.key
 
 - name: Harbor | Generate Harbor configuration file
   template:
     src: harbor.yml
     dest: >-
-      /opt/harbor/{{ .harbor_version }}/harbor/harbor.yml
+      /opt/harbor/{{ .image_registry.harbor_version }}/harbor/harbor.yml
 
 - name: Harbor | Install Harbor registry
   command: |
-    cd /opt/harbor/{{ .harbor_version }}/harbor && /bin/bash install.sh
+    cd /opt/harbor/{{ .image_registry.harbor_version }}/harbor && /bin/bash install.sh
 
 - name: Harbor | Register Harbor as a systemd service
   template:
@@ -75,8 +75,8 @@
               - type: bind
                 source: /opt/keepalived/{{ .keepalived_version }}/healthcheck.sh
                 target: /etc/keepalived/healthcheck.sh'
-        TARGET_FILE="/opt/harbor/{{ .harbor_version }}/harbor/docker-compose.yml"
-        TMP_FILE="/opt/harbor/{{ .harbor_version }}/harbor/docker-compose.yml.tmp"
+        TARGET_FILE="/opt/harbor/{{ .image_registry.harbor_version }}/harbor/docker-compose.yml"
+        TMP_FILE="/opt/harbor/{{ .image_registry.harbor_version }}/harbor/docker-compose.yml.tmp"
         awk -v service="$KEEPALIVED_SERVICE" '
           /^services:/ {
             print

--- a/builtin/core/roles/image-registry/harbor/templates/harbor.service
+++ b/builtin/core/roles/image-registry/harbor/templates/harbor.service
@@ -5,7 +5,7 @@ Requires=docker.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/docker-compose -p harbor -f /opt/harbor/{{ .harbor_version }}/harbor/docker-compose.yml up
+ExecStart=/usr/local/bin/docker-compose -p harbor -f /opt/harbor/{{ .image_registry.harbor_version }}/harbor/docker-compose.yml up
 ExecStop=/usr/local/bin/docker-compose -p harbor down
 Restart=on-failure
 [Install]

--- a/builtin/core/roles/image-registry/harbor/templates/harbor.yml
+++ b/builtin/core/roles/image-registry/harbor/templates/harbor.yml
@@ -14,8 +14,8 @@ https:
   # https port for harbor, default is 443
   port: 443
   # The path of cert and key files for nginx
-  certificate: /opt/harbor/{{ .harbor_version }}/ssl/server.crt
-  private_key: /opt/harbor/{{ .harbor_version }}/ssl/server.key
+  certificate: /opt/harbor/{{ .image_registry.harbor_version }}/ssl/server.crt
+  private_key: /opt/harbor/{{ .image_registry.harbor_version }}/ssl/server.key
   # enable strong ssl ciphers (default: false)
   # strong_ssl_ciphers: false
 

--- a/builtin/core/roles/image-registry/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/tasks/main.yaml
@@ -1,5 +1,7 @@
 ---
 - name: ImageRegistry | Synchronize images to remote host
+  when:
+    - .image_manifests | default list | empty | not
   copy:
     src: >-
       {{ .binary_dir }}/images/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:

when init registry ,some harbor version config will shown as <no_value>
fix harbor version config 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix harbor verson config path
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
