### PR TITLE
fix: add condition to check download_image in playbooks and tasks

### DIFF
--- a/builtin/core/playbooks/artifact_images.yaml
+++ b/builtin/core/playbooks/artifact_images.yaml
@@ -19,6 +19,7 @@
           manifests: "{{ .image_manifests | toJson }}"
       when:
         - .image_manifests | default list | empty | not
+        - download.download_image
     - name: PushImage | Push images to registry
       tags: ["push","image_registry"]
       block:

--- a/builtin/core/roles/download/tasks/images.yaml
+++ b/builtin/core/roles/download/tasks/images.yaml
@@ -8,3 +8,4 @@
       manifests: "{{ .image_manifests | toJson }}"
   when:
     - .image_manifests | default list | empty | not
+    - download.download_image

--- a/builtin/core/roles/image-registry/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/tasks/main.yaml
@@ -2,6 +2,7 @@
 - name: ImageRegistry | Synchronize images to remote host
   when:
     - .image_manifests | default list | empty | not
+    - download.download_image
   copy:
     src: >-
       {{ .binary_dir }}/images/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Add a switch to control whether to download the image.
In some cases, when the image is already confirmed to be complete, there’s no need to verify its integrity with the remote registry.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/kubekey/issues/2706
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add a switch to control whether to download the image.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
