### PR TITLE
fix kubekey ip_vs modules covered in kube_proxy-ipvs.conf

### DIFF
--- a/builtin/capkk/roles/init/init-os/templates/init-os.sh
+++ b/builtin/capkk/roles/init/init-os/templates/init-os.sh
@@ -198,10 +198,10 @@ EOF
 
 modprobe nf_conntrack_ipv4 1>/dev/null 2>/dev/null
 if [ $? -eq 0 ]; then
-   echo 'nf_conntrack_ipv4' > /etc/modules-load.d/kube_proxy-ipvs.conf
+   echo 'nf_conntrack_ipv4' >> /etc/modules-load.d/kube_proxy-ipvs.conf
 else
    modprobe nf_conntrack
-   echo 'nf_conntrack' > /etc/modules-load.d/kube_proxy-ipvs.conf
+   echo 'nf_conntrack' >> /etc/modules-load.d/kube_proxy-ipvs.conf
 fi
 sysctl -p
 

--- a/builtin/core/roles/native/init/templates/init-os.sh
+++ b/builtin/core/roles/native/init/templates/init-os.sh
@@ -194,10 +194,10 @@ EOF
 
 modprobe nf_conntrack_ipv4 1>/dev/null 2>/dev/null
 if [ $? -eq 0 ]; then
-   echo 'nf_conntrack_ipv4' > /etc/modules-load.d/kube_proxy-ipvs.conf
+   echo 'nf_conntrack_ipv4' >> /etc/modules-load.d/kube_proxy-ipvs.conf
 else
    modprobe nf_conntrack
-   echo 'nf_conntrack' > /etc/modules-load.d/kube_proxy-ipvs.conf
+   echo 'nf_conntrack' >> /etc/modules-load.d/kube_proxy-ipvs.conf
 fi
 sysctl -p
 


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### Which issue(s) this PR fixes:
Fixes #

ip_vs mod in file /etc/modules-load.d/kube_proxy-ipvs.conf covered by the next code

```release-note
none
```
