### PR TITLE
bugfix: fix offline pkg dir error

### DIFF
--- a/hack/downloadKubekey.sh
+++ b/hack/downloadKubekey.sh
@@ -151,10 +151,10 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Preparing offline package directory..."
-mkdir -p offline
+mkdir -p offline/kubekey/kubekey
 
 echo "Extracting artifact.tgz to offline/ ..."
-tar -xzf artifact.tgz -C offline/ --no-same-owner
+tar -xzf artifact.tgz -C offline/kubekey/kubekey --no-same-owner
 
 echo "Extracting web-installer.tgz to offline/ ..."
 tar -xzf web-installer.tgz -C offline/ --no-same-owner


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
when get kk and exec package.sh to build a offline package, the binary dir will in the root of offline package
but binary should be in offline/kubekey/kubekey

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
fix offline pkg dir error
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix offline pkg dir error
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
