### PR TITLE
bugfix: fix when init registry with other host then push none image

### DIFF
--- a/builtin/core/roles/image-registry/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/tasks/main.yaml
@@ -1,13 +1,4 @@
 ---
-- name: ImageRegistry | Synchronize images to remote host
-  run_once: true
-  when:
-    - printf "%s/images/" .binary_dir | fileExist
-  copy:
-    src: >-
-      {{ .binary_dir }}/images/
-    dest: >-
-      {{ .image_registry.images_dir }}
 
 - name: ImageRegistry | Ensure Harbor project exists for each image
   when: .image_registry.type | eq "harbor"
@@ -38,10 +29,11 @@
     done
 
 - name: ImageRegistry | Push images package to image registry
+  run_once: true
   image:
     push:
       images_dir: >-
-        {{ .image_registry.images_dir }}
+        {{ .binary_dir }}/images/
       dest: >-
         {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
       username: >-


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
fix a bug ,when user init registry ,and registry host is not localhost,then there is no image in new registry
init task use image.pull,but it use kk local storage to read image file ,not remote file.
but task will send imge file to remote ,and use remote file path as images_dir

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
fix when init registry with other host then push none image
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix when init registry with other host then push none image
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
