### PR TITLE
feat: add health check after harbor installed

### DIFF
--- a/builtin/core/roles/image-registry/harbor/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/harbor/tasks/main.yaml
@@ -49,6 +49,31 @@
 - name: Harbor | Start and enable Harbor service
   command: systemctl daemon-reload && systemctl start harbor.service && systemctl enable harbor.service
 
+- name : Harbor | Check harbor api health
+  command: |
+    HARBOR_URL="https://{{ .image_registry.auth.registry }}"
+    MAX_WAIT_SECONDS=300
+    CHECK_INTERVAL=2
+    MAX_RETRIES=$((MAX_WAIT_SECONDS / CHECK_INTERVAL))
+    for ((i=1; i<=MAX_RETRIES; i++)); do
+      # Check health endpoint
+      response=$(curl -k -s -w "%{http_code}" -o /tmp/harbor_health_response.json "$HARBOR_URL/api/v2.0/health")
+      http_code=${response: -3}
+      # Check if healthy
+      if [ "$http_code" -eq 200 ] && grep -q "\"status\":\"healthy\"" /tmp/harbor_health_response.json 2>/dev/null; then
+        rm -f /tmp/harbor_health_response.json
+        exit 0
+      fi
+      # Wait before next check if not max retries reached
+      if [ $i -lt $MAX_RETRIES ]; then
+        sleep $CHECK_INTERVAL
+      fi
+    done
+    # Timeout reached
+    rm -f /tmp/harbor_health_response.json
+    echo "ERROR: Harbor service did not became health within 5 minutes!"
+    exit 1
+
 - name: Harbor | Configure HA and synchronize Harbor images
   when:
     - .image_registry.ha_vip | empty | not
@@ -95,10 +120,28 @@
         systemctl restart harbor.service
     - name: Harbor | Wait for Harbor service to become ready
       command: |
-        if ! timeout 300 bash -c 'while ! nc -zv localhost 443; do sleep 2; done'; then
-            echo "ERROR: Harbor did not start within 5 minutes!"
-            exit 1
-        fi
+        HARBOR_URL="https://{{ .image_registry.auth.registry }}"
+        MAX_WAIT_SECONDS=300
+        CHECK_INTERVAL=2
+        MAX_RETRIES=$((MAX_WAIT_SECONDS / CHECK_INTERVAL))
+        for ((i=1; i<=MAX_RETRIES; i++)); do
+          # Check health endpoint
+          response=$(curl -k -s -w "%{http_code}" -o /tmp/harbor_health_response.json "$HARBOR_URL/api/v2.0/health")
+          http_code=${response: -3}
+          # Check if healthy
+          if [ "$http_code" -eq 200 ] && grep -q "\"status\":\"healthy\"" /tmp/harbor_health_response.json 2>/dev/null; then
+            rm -f /tmp/harbor_health_response.json
+            exit 0
+          fi
+          # Wait before next check if not max retries reached
+          if [ $i -lt $MAX_RETRIES ]; then
+            sleep $CHECK_INTERVAL
+          fi
+        done
+        # Timeout reached
+        rm -f /tmp/harbor_health_response.json
+        echo "ERROR: Harbor service did not became health within 5 minutes!"
+        exit 1
     - name: Harbor | Synchronize harbor-replications script to remote host
       template:
         src: harbor-replications.sh


### PR DESCRIPTION
feat: add health check after harbor installed

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

### What this PR does / why we need it:

when init registry, some times kk access harbor api before harbor api became health
add harbor health check after start harbor,make sure that harbor api become health and then exec other task

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
add health check after harbor installed
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add health check after harbor installed
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
