### PR TITLE
Remove legacy iptables configuration from init scripts

### DIFF
--- a/builtin/capkk/roles/init/init-os/templates/init-os.sh
+++ b/builtin/capkk/roles/init/init-os/templates/init-os.sh
@@ -256,13 +256,3 @@ EOF
 
 sync
 # echo 3 > /proc/sys/vm/drop_caches
-
-# Make sure the iptables utility doesn't use the nftables backend.
-{{- if .internal_ipv4 | empty | not }}
-update-alternatives --set iptables /usr/sbin/iptables-legacy >/dev/null 2>&1 || true
-{{- end }}
-{{- if .internal_ipv6 | empty | not }}
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy >/dev/null 2>&1 || true
-{{- end }}
-update-alternatives --set arptables /usr/sbin/arptables-legacy >/dev/null 2>&1 || true
-update-alternatives --set ebtables /usr/sbin/ebtables-legacy >/dev/null 2>&1 || true

--- a/builtin/core/roles/native/init/templates/init-os.sh
+++ b/builtin/core/roles/native/init/templates/init-os.sh
@@ -203,13 +203,3 @@ sysctl -p
 
 sync
 echo 3 > /proc/sys/vm/drop_caches
-
-# Make sure the iptables utility doesn't use the nftables backend.
-{{- if .internal_ipv4 | empty | not }}
-update-alternatives --set iptables /usr/sbin/iptables-legacy >/dev/null 2>&1 || true
-{{- end }}
-{{- if .internal_ipv6 | empty | not }}
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy >/dev/null 2>&1 || true
-{{- end }}
-update-alternatives --set arptables /usr/sbin/arptables-legacy >/dev/null 2>&1 || true
-update-alternatives --set ebtables /usr/sbin/ebtables-legacy >/dev/null 2>&1 || true


### PR DESCRIPTION
With newer version of k8s, anything using iptables could use iptables-wrappers to figure out the backend is legacy or nft. Force the iptable to use legacy is not necessary anymore.

### What type of PR is this?
/kind feature


### What this PR does / why we need it:
with this PR, we can let the kubelet/kube-proxy/cilium to use iptable-nft as the backend instead of iptable-legacy

### Which issue(s) this PR fixes:
Fixes https://github.com/kubesphere/kubekey/issues/2831


### Does this PR introduced a user-facing change?
Users can always configure iptables on the host before installing kubekey to use whatever backend they want to use

```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
