### PR TITLE
refactor: improve responseWriter implementation in proxy transport

### DIFF
--- a/pkg/proxy/transport.go
+++ b/pkg/proxy/transport.go
@@ -153,25 +153,37 @@ func newProxyTransport(runtimedir string, restConfig *rest.Config) (http.RoundTr
 	return lt, nil
 }
 
+// responseWriter implements http.ResponseWriter for capturing HTTP responses locally.
+// It writes response body to an internal buffer but directly sets headers/status on the *http.Response.
 type responseWriter struct {
-	*http.Response
+	resp *http.Response // The response object to write headers and status to.
+	buf  bytes.Buffer   // Buffer to capture the response body.
 }
 
-// Header get header for responseWriter
+// Header returns the header map that will be sent by WriteHeader.
 func (r *responseWriter) Header() http.Header {
-	return r.Response.Header
+	return r.resp.Header
 }
 
-// Write body for responseWriter
+// Write writes the data to the buffer as part of the HTTP response body.
 func (r *responseWriter) Write(bs []byte) (int, error) {
-	r.Response.Body = io.NopCloser(bytes.NewBuffer(bs))
-
-	return 0, nil
+	return r.buf.Write(bs)
 }
 
-// WriteHeader writer header for responseWriter
+// WriteHeader sets the HTTP status code in the response.
 func (r *responseWriter) WriteHeader(statusCode int) {
-	r.Response.StatusCode = statusCode
+	r.resp.StatusCode = statusCode
+}
+
+// finalize prepares the http.Response by setting its Body to the contents of the buffer.
+// If the status code has not been set, it defaults to http.StatusOK (200).
+func (r *responseWriter) finalize() {
+	// Set the HTTP response body to the buffered data.
+	r.resp.Body = io.NopCloser(bytes.NewReader(r.buf.Bytes()))
+	// Default status code to 200 OK if it was not set by the handler.
+	if r.resp.StatusCode == 0 {
+		r.resp.StatusCode = http.StatusOK
+	}
 }
 
 type transport struct {
@@ -201,8 +213,10 @@ func (l *transport) RoundTrip(request *http.Request) (*http.Response, error) {
 	if err != nil {
 		return response, err
 	}
-	// call handler
-	l.handlerChainFunc(handler).ServeHTTP(&responseWriter{response}, request)
+	// Use a buffered responseWriter to collect the complete response
+	rw := &responseWriter{resp: response}
+	l.handlerChainFunc(handler).ServeHTTP(rw, request)
+	rw.finalize()
 
 	return response, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

- Updated responseWriter to capture HTTP responses more effectively by using an internal buffer for the response body.
- Modified Header and Write methods to directly manipulate the response object.
- Ensured that the response body is set correctly after processing the request, defaulting to 200 OK if no status code is set.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
The reason responseWriter.Write() is called in multiple chunks is that the Go HTTP server flushes data in segments when its internal buffer is full. Even if your handler writes the entire response in one call, the server may split it into multiple writes to the underlying ResponseWriter. io.NopCloser itself does not split the data; the chunked writes come from the server’s internal buffering and flush behavior.
<img width="1858" height="101" alt="企业微信截图_fd61d24e-dfbe-4863-9ef5-c8a0696a2ca9" src="https://github.com/user-attachments/assets/1652596e-e7ac-4f8f-967d-6517d9c02462" />


### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
improve responseWriter implementation in proxy transport
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
