### PR TITLE
bugfix: fix a bug that role and role sons when handle error

### DIFF
--- a/pkg/executor/role_executor.go
+++ b/pkg/executor/role_executor.go
@@ -53,7 +53,7 @@ func (e roleExecutor) Exec(ctx context.Context) error {
 		ignoreErrors: e.ignoreErrors,
 		blocks:       e.role.Block,
 		role:         e.role.Role,
-		when:         e.role.When.Data,
+		when:         e.dealWhen(e.role.When),
 		tags:         e.tags,
 	}.Exec(ctx))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:

when playbook has roles block and then inport many role with when ,then block when will not be used
in role executor , parse role to block with role when only ,but we need both block when and role when
update block when input ,combine role when with block when

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
 fix a bug that role and role sons when handle error
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
 fix a bug that role and role sons when handle error
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
