### PR TITLE
fix: update containerd config template

### DIFF
--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -59,20 +59,22 @@ state = "/run/containerd"
 {{- if or (.cri.registry.auths | empty | not) (.groups.image_registry | default list | empty | not) }}
         [plugins."io.containerd.grpc.v1.cri".registry.configs]
 {{- end }}
+{{- if .image_registry.auth.registry | empty | not }}
           [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .image_registry.auth.registry }}".auth]
             username = "{{ .image_registry.auth.username }}"
             password = "{{ .image_registry.auth.password }}"
           [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .image_registry.auth.registry }}".tls]
-{{- if .image_registry.auth.ca_file | empty | not }}
+  {{- if .image_registry.auth.ca_file | empty | not }}
             ca_file = "/etc/containerd/certs.d/{{ .image_registry.auth.registry }}/ca.crt"
-{{- end }}
-{{- if .image_registry.auth.cert_file | empty | not }}
+  {{- end }}
+  {{- if .image_registry.auth.cert_file | empty | not }}
             cert_file = "/etc/containerd/certs.d/{{ .image_registry.auth.registry }}/server.crt"
-{{- end }}
-{{- if .image_registry.auth.key_file | empty | not }}
+  {{- end }}
+  {{- if .image_registry.auth.key_file | empty | not }}
             key_file = "/etc/containerd/certs.d/{{ .image_registry.auth.registry }}/server.key"
-{{- end }}
+  {{- end }}
             insecure_skip_verify = {{ .image_registry.auth.insecure | default true }}
+{{- end }}
 {{- if .cri.registry.auths | empty | not }}
   {{- range .cri.registry.auths }}
           [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .repo }}".auth]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
- Improved handling of optional fields for registry authentication in the containerd config template.
- Ensured proper indentation and formatting for better readability.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
