### PR TITLE
refactor: improve hostname validation logic in OS precheck tasks

### DIFF
--- a/builtin/core/roles/precheck/kubernetes/tasks/main.yaml
+++ b/builtin/core/roles/precheck/kubernetes/tasks/main.yaml
@@ -45,7 +45,6 @@
   when:
     - .image_registry.auth.registry | empty | not
     - .image_registry.type | empty
-  run_once: true
   command: |
     HTTP_CODE=$(curl -skLI -w "%{http_code}" -u "{{ .image_registry.auth.username }}:{{ .image_registry.auth.password }}" "https://{{ .image_registry.auth.registry }}/v2/" -o /dev/null)
     if [[ "$HTTP_CODE" == "200" ]]; then

--- a/builtin/core/roles/precheck/os/tasks/main.yaml
+++ b/builtin/core/roles/precheck/os/tasks/main.yaml
@@ -1,9 +1,18 @@
 ---
-- name: OS | Fail if hostname is invalid
-  assert:
-    that: .hostname | regexMatch "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
-    fail_msg: >-
-      The hostname "{{ .hostname }}" is invalid. Hostnames must use only lowercase alphanumeric characters, '.', or '-', and must start and end with an alphanumeric character.
+- name: OS | Assert valid system hostname format
+  block:
+    - name: OS | Validate inventory hostname is RFC-compliant
+      when: .set_hostname
+      assert:
+        that: .inventory_hostname | regexMatch "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
+        fail_msg: >-
+          The hostname "{{ .inventory_hostname }}" is invalid. Hostnames must use only lowercase alphanumeric characters, '.', or '-', and must start and end with an alphanumeric character.
+    - name: OS | Validate current host system hostname is RFC-compliant
+      when: .set_hostname | not
+      assert:
+        that: .hostname | regexMatch "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
+        fail_msg: >-
+          The hostname "{{ .hostname }}" is invalid. Hostnames must use only lowercase alphanumeric characters, '.', or '-', and must start and end with an alphanumeric character.
 
 - name: OS | Fail if operating system is not supported
   assert:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
- Updated the hostname validation to ensure compliance with RFC standards.
- Split the validation into two distinct checks based on the .set_hostname condition.
- Removed the deprecated run_once directive from the Kubernetes precheck task for image registry authentication.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/project/issues/7059

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
improve hostname validation logic in OS precheck tasks
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
