### PR TITLE
feat: add default docker registry download url

### DIFF
--- a/builtin/core/roles/defaults/vars/10-download.yaml
+++ b/builtin/core/roles/defaults/vars/10-download.yaml
@@ -165,19 +165,11 @@ download:
         {{- else -}}
         https://github.com/docker/compose/releases/download/{{ .cri.dockercompose_version }}/docker-compose-linux-aarch64
         {{- end -}}
-#    docker_registry:
-#      amd64: >-
-#        {{- if .download.zone | eq "cn" -}}
-#        https://kubernetes-release.pek3b.qingstor.com/registry/{{ .image_registry.docker_registry_version }}/docker-registry-{{ .image_registry.docker_registry_version }}-linux-amd64.tgz
-#        {{- else -}}
-#        https://github.com/kubesphere/kubekey/releases/download/{{ .image_registry.docker_registry_version }}/docker-registry-{{ .image_registry.docker_registry_version }}-linux-amd64.tgz
-#        {{- end -}}
-#      arm64: >-
-#        {{- if .download.zone | eq "cn" -}}
-#        https://kubernetes-release.pek3b.qingstor.com/registry/{{ .image_registry.docker_registry_version }}/docker-registry-{{ .image_registry.docker_registry_version }}-linux-arm64.tgz
-#        {{- else -}}
-#        https://github.com/kubesphere/kubekey/releases/download/{{ .image_registry.docker_registry_version }}/docker-registry-{{ .image_registry.docker_registry_version }}-linux-arm64.tgz
-#        {{- end -}}
+    docker_registry:
+      amd64: >-
+        https://kubekey.pek3b.qingstor.com/docker.io/registry/{{ .image_registry.docker_registry_version }}/docker-registry-{{ .image_registry.docker_registry_version }}-linux-amd64.tgz
+      arm64: >-
+        https://kubekey.pek3b.qingstor.com/docker.io/registry/{{ .image_registry.docker_registry_version }}/docker-registry-{{ .image_registry.docker_registry_version }}-linux-arm64.tgz
     harbor:
       amd64: >-
         {{- if .download.zone | eq "cn" -}}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature


### What this PR does / why we need it:
current kk create image registry with docker registry, kk will show an error about cannot download docker registry
add default download url in config

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
add default docker registry download url
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add default docker registry download url
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
