### PR TITLE
feat: update kubeadm-config file

### DIFF
--- a/builtin/core/roles/kubernetes/init-kubernetes/tasks/main.yaml
+++ b/builtin/core/roles/kubernetes/init-kubernetes/tasks/main.yaml
@@ -29,7 +29,7 @@
     - name: InitKubernetes | Kubernetes Already Installed
       when: .kubernetes_install_LoadState.stdout | eq "load"
       command: |
-        if [ ! -f /etc/kubernetes/kubeadm-config.yaml ]; then
+        if ! grep -q 'ClusterConfiguration' /etc/kubernetes/kubeadm-config.yaml 2>/dev/null; then
           kubectl get cm kubeadm-config -n kube-system -o=jsonpath='{.data.ClusterConfiguration}' > /etc/kubernetes/kubeadm-config.yaml
         fi
     - name: InitKubernetes | Fetch kubeconfig to local workspace


### PR DESCRIPTION
feat: update kubeadm-config file

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
when user create a cluster with more then 3 master,then 1 of them will create full kubeadm-config.yaml
but the rest of them will create file without ClusterConfiguration
when add node ,it will show an error
update file check function, when config has no ClusterConfiguration,then recreate file

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
update kubeadm-config file
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
update kubeadm-config file
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
