### PR TITLE
feat: k8s add haproxy image default value

### DIFF
--- a/builtin/core/defaults/config/v1.23.yaml
+++ b/builtin/core/defaults/config/v1.23.yaml
@@ -95,3 +95,4 @@ spec:
     - docker.io/openebs/linux-utils:3.3.0
     - docker.io/openebs/provisioner-localpv:3.3.0
     - quay.io/tigera/operator:v1.28.5
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.24.yaml
+++ b/builtin/core/defaults/config/v1.24.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:3.4.0
     - docker.io/openebs/provisioner-localpv:3.4.0
     - quay.io/tigera/operator:v1.29.3
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.25.yaml
+++ b/builtin/core/defaults/config/v1.25.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:3.4.0
     - docker.io/openebs/provisioner-localpv:3.4.0
     - quay.io/tigera/operator:v1.29.3
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.26.yaml
+++ b/builtin/core/defaults/config/v1.26.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:3.4.0
     - docker.io/openebs/provisioner-localpv:3.4.0
     - quay.io/tigera/operator:v1.30.4
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.27.yaml
+++ b/builtin/core/defaults/config/v1.27.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:3.4.0
     - docker.io/openebs/provisioner-localpv:3.4.0
     - quay.io/tigera/operator:v1.30.4
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.28.yaml
+++ b/builtin/core/defaults/config/v1.28.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:3.4.0
     - docker.io/openebs/provisioner-localpv:3.4.0
     - quay.io/tigera/operator:v1.34.5
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.29.yaml
+++ b/builtin/core/defaults/config/v1.29.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:3.5.0
     - docker.io/openebs/provisioner-localpv:3.5.0
     - quay.io/tigera/operator:v1.34.5
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.30.yaml
+++ b/builtin/core/defaults/config/v1.30.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:4.0.0
     - docker.io/openebs/provisioner-localpv:4.0.0
     - quay.io/tigera/operator:v1.34.5
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.31.yaml
+++ b/builtin/core/defaults/config/v1.31.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:4.1.0
     - docker.io/openebs/provisioner-localpv:4.1.0
     - quay.io/tigera/operator:v1.34.5
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.32.yaml
+++ b/builtin/core/defaults/config/v1.32.yaml
@@ -96,3 +96,4 @@ spec:
     - docker.io/openebs/linux-utils:4.2.0
     - docker.io/openebs/provisioner-localpv:4.2.0
     - quay.io/tigera/operator:v1.34.5
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/defaults/config/v1.33.yaml
+++ b/builtin/core/defaults/config/v1.33.yaml
@@ -97,3 +97,4 @@ spec:
     - docker.io/openebs/linux-utils:4.2.0
     - docker.io/openebs/provisioner-localpv:4.2.0
     - quay.io/tigera/operator:v1.34.5
+    - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.23.yaml
+++ b/builtin/core/roles/defaults/vars/v1.23.yaml
@@ -88,3 +88,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:3.3.0
   - docker.io/openebs/provisioner-localpv:3.3.0
   - quay.io/tigera/operator:v1.28.5
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.24.yaml
+++ b/builtin/core/roles/defaults/vars/v1.24.yaml
@@ -91,3 +91,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:3.4.0
   - docker.io/openebs/provisioner-localpv:3.4.0
   - quay.io/tigera/operator:v1.29.3
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.25.yaml
+++ b/builtin/core/roles/defaults/vars/v1.25.yaml
@@ -91,3 +91,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:3.4.0
   - docker.io/openebs/provisioner-localpv:3.4.0
   - quay.io/tigera/operator:v1.29.3
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.26.yaml
+++ b/builtin/core/roles/defaults/vars/v1.26.yaml
@@ -91,3 +91,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:3.4.0
   - docker.io/openebs/provisioner-localpv:3.4.0
   - quay.io/tigera/operator:v1.30.4
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.27.yaml
+++ b/builtin/core/roles/defaults/vars/v1.27.yaml
@@ -88,3 +88,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:3.4.0
   - docker.io/openebs/provisioner-localpv:3.4.0
   - quay.io/tigera/operator:v1.30.4
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.28.yaml
+++ b/builtin/core/roles/defaults/vars/v1.28.yaml
@@ -89,3 +89,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:3.4.0
   - docker.io/openebs/provisioner-localpv:3.4.0
   - quay.io/tigera/operator:v1.34.5
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.29.yaml
+++ b/builtin/core/roles/defaults/vars/v1.29.yaml
@@ -89,3 +89,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:3.5.0
   - docker.io/openebs/provisioner-localpv:3.5.0
   - quay.io/tigera/operator:v1.34.5
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.30.yaml
+++ b/builtin/core/roles/defaults/vars/v1.30.yaml
@@ -89,3 +89,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:4.0.0
   - docker.io/openebs/provisioner-localpv:4.0.0
   - quay.io/tigera/operator:v1.34.5
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.31.yaml
+++ b/builtin/core/roles/defaults/vars/v1.31.yaml
@@ -89,4 +89,5 @@ image_manifests:
   - docker.io/openebs/linux-utils:4.1.0
   - docker.io/openebs/provisioner-localpv:4.1.0
   - quay.io/tigera/operator:v1.34.5
+  - docker.io/library/haproxy:2.9.6-alpine
 

--- a/builtin/core/roles/defaults/vars/v1.32.yaml
+++ b/builtin/core/roles/defaults/vars/v1.32.yaml
@@ -91,3 +91,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:4.2.0
   - docker.io/openebs/provisioner-localpv:4.2.0
   - quay.io/tigera/operator:v1.34.5
+  - docker.io/library/haproxy:2.9.6-alpine

--- a/builtin/core/roles/defaults/vars/v1.33.yaml
+++ b/builtin/core/roles/defaults/vars/v1.33.yaml
@@ -91,3 +91,4 @@ image_manifests:
   - docker.io/openebs/linux-utils:4.2.0
   - docker.io/openebs/provisioner-localpv:4.2.0
   - quay.io/tigera/operator:v1.34.5
+  - docker.io/library/haproxy:2.9.6-alpine


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

### What this PR does / why we need it:

add haproxy image for all k8s default config

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
add haproxy image for all k8s default config
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add haproxy image for all k8s default config
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
