### PR TITLE
bugfix: Push Image Credential

### DIFF
--- a/builtin/core/playbooks/artifact_images.yaml
+++ b/builtin/core/playbooks/artifact_images.yaml
@@ -59,13 +59,10 @@
         - name: PushImage | Push images package to image registry
           image:
             push:
+              auths: "{{ .cri.registry.auths | toJson }}"
               images_dir: >-
                 {{ .binary_dir }}/images/
               dest: >-
                 {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
-              username: >-
-                {{ .image_registry.auth.username }}
-              password: >-
-                {{ .image_registry.auth.password }}
               skip_tls_verify: true
 

--- a/cmd/kk/app/options/builtin/init.go
+++ b/cmd/kk/app/options/builtin/init.go
@@ -95,7 +95,7 @@ func (o *InitOSOptions) completeConfig() error {
 		if _, _, err := unstructured.NestedString(o.CommonOptions.Config.Value(), _const.BinaryDir); err != nil {
 			// workdir should set by CommonOptions
 			if err := unstructured.SetNestedField(o.CommonOptions.Config.Value(), filepath.Join(wd, "kubekey"), _const.BinaryDir); err != nil {
-				return errors.Wrapf(err, "failed to set %q in config", _const.Workdir)
+				return errors.Wrapf(err, "failed to set %q in config", _const.BinaryDir)
 			}
 		}
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind bug


### What this PR does / why we need it:
1、私有镜像仓库推送镜像，需要认证
2、BinaryDir设置失败，异常报错不应显示是Workdir配置
