### PR TITLE
bugfix: Push Image Credential

### DIFF
--- a/builtin/core/playbooks/artifact_images.yaml
+++ b/builtin/core/playbooks/artifact_images.yaml
@@ -59,13 +59,12 @@
         - name: PushImage | Push images package to image registry
           image:
             push:
+              auths:
+                - repo: "{{ .image_registry.auth.registry }}"
+                  username: "{{ .image_registry.auth.username }}"
+                  password: "{{ .image_registry.auth.password }}"
+                  insecure: true
               images_dir: >-
                 {{ .binary_dir }}/images/
               dest: >-
                 {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
-              username: >-
-                {{ .image_registry.auth.username }}
-              password: >-
-                {{ .image_registry.auth.password }}
-              skip_tls_verify: true
-

--- a/builtin/core/roles/image-registry/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/tasks/main.yaml
@@ -32,12 +32,12 @@
   run_once: true
   image:
     push:
+      auths:
+        - repo: "{{ .image_registry.auth.registry }}"
+          username: "{{ .image_registry.auth.username }}"
+          password: "{{ .image_registry.auth.password }}"
+          insecure: true
       images_dir: >-
         {{ .binary_dir }}/images/
       dest: >-
         {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
-      username: >-
-        {{ .image_registry.auth.username }}
-      password: >-
-        {{ .image_registry.auth.password }}
-      skip_tls_verify: true

--- a/cmd/kk/app/options/builtin/init.go
+++ b/cmd/kk/app/options/builtin/init.go
@@ -93,9 +93,9 @@ func (o *InitOSOptions) completeConfig() error {
 	} else {
 		// set binary dir if not set
 		if _, _, err := unstructured.NestedString(o.CommonOptions.Config.Value(), _const.BinaryDir); err != nil {
-			// workdir should set by CommonOptions
+			// binary should set by CommonOptions
 			if err := unstructured.SetNestedField(o.CommonOptions.Config.Value(), filepath.Join(wd, "kubekey"), _const.BinaryDir); err != nil {
-				return errors.Wrapf(err, "failed to set %q in config", _const.Workdir)
+				return errors.Wrapf(err, "failed to set %q in config", _const.BinaryDir)
 			}
 		}
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind bug


### What this PR does / why we need it:
1、私有镜像仓库推送镜像，需要认证
2、BinaryDir设置失败，异常报错不应显示是Workdir配置

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Push Image Credential
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
