### PR TITLE
bugfix: 主机分组不可过深，并防止死循环的host分组

### DIFF
--- a/pkg/variable/helper.go
+++ b/pkg/variable/helper.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	kkcorev1 "github.com/kubesphere/kubekey/api/core/v1"
-	"github.com/kubesphere/kubekey/v4/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -34,6 +33,7 @@ import (
 
 	_const "github.com/kubesphere/kubekey/v4/pkg/const"
 	"github.com/kubesphere/kubekey/v4/pkg/converter/tmpl"
+	"github.com/kubesphere/kubekey/v4/pkg/utils"
 )
 
 // CombineVariables merge multiple variables into one variable.
@@ -176,7 +176,8 @@ func hostsInGroup(inv kkcorev1.Inventory, groupName string, groupsGraph *utils.K
 		for _, cg := range v.Groups {
 			if groupsGraph != nil {
 				if groupsGraph.AddEdgeAndCheckCycle(groupName, cg) {
-					continue
+					klog.Warningf("group host found cycle by %s -> %s", groupName, cg)
+					return []string{}
 				}
 			}
 			hosts = CombineSlice(hostsInGroup(inv, cg, groupsGraph), hosts)

--- a/pkg/variable/helper_test.go
+++ b/pkg/variable/helper_test.go
@@ -22,6 +22,8 @@ import (
 	kkcorev1 "github.com/kubesphere/kubekey/api/core/v1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kubesphere/kubekey/v4/pkg/utils"
 )
 
 func TestCombineSlice(t *testing.T) {
@@ -126,7 +128,7 @@ func TestHostsInGroup(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tc.except, hostsInGroup(tc.inventory, tc.groupName, nil))
+			assert.ElementsMatch(t, tc.except, hostsInGroup(tc.inventory, tc.groupName, utils.NewKahnGraph()))
 		})
 	}
 }


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
1、防止死循环的递归遍历主机分组
2、分组不宜过深

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
Fix the circular dependency issue in hostsInGroup.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
