### PR TITLE
feat: worker should not hava kubeconfig

### DIFF
--- a/builtin/core/roles/kubernetes/join-kubernetes/tasks/main.yaml
+++ b/builtin/core/roles/kubernetes/join-kubernetes/tasks/main.yaml
@@ -14,12 +14,14 @@
     /usr/local/bin/kubeadm join --config=/etc/kubernetes/kubeadm-config.yaml --ignore-preflight-errors=FileExisting-crictl,ImagePull
 
 - name: Join | Synchronize kubeconfig to remote node for current user
+  when: .groups.kube_control_plane | default list | has .inventory_hostname
   copy:
     src: >-
       {{ .work_dir }}/kubekey/kubeconfig
     dest: ~/.kube/config
 
 - name: Join | Synchronize kubeconfig to remote node for root
+  when: .groups.kube_control_plane | default list | has .inventory_hostname
   copy:
     src: >-
       {{ .work_dir }}/kubekey/kubeconfig
@@ -30,15 +32,18 @@
   block:
     - name: Join | Remove master and control-plane taints from node
       ignore_errors: true
+      delegate_to: "{{ .init_kubernetes_node }}"
       command: |
         /usr/local/bin/kubectl taint nodes {{ .hostname }} node-role.kubernetes.io/master=:NoSchedule-
         /usr/local/bin/kubectl taint nodes {{ .hostname }} node-role.kubernetes.io/control-plane=:NoSchedule-
     - name: Join | Add worker label to node
+      delegate_to: "{{ .init_kubernetes_node }}"
       command: |
         /usr/local/bin/kubectl label --overwrite node {{ .hostname }} node-role.kubernetes.io/worker=
 
 - name: Join | Add custom annotations to node
   when: .annotations | empty | not
+  delegate_to: "{{ .init_kubernetes_node }}"
   command: |
     kubectl annotate {{ .hostname }} {{- range $k,$v := .annotations }}{{ printf "%s=%s" $k $v}} {{- end }}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Worker node should not have cluster api permissions

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
feat: worker should not hava kubeconfig
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
