### PR TITLE
bugfix: fix containerd config bug when registry like host:port/project

### DIFF
--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -60,27 +60,29 @@ state = "/run/containerd"
         [plugins."io.containerd.grpc.v1.cri".registry.configs]
 {{- end }}
 {{- if .image_registry.auth.registry | empty | not }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .image_registry.auth.registry }}".auth]
+  {{- $registry_parts := .image_registry.auth.registry | splitList "/" | first }}
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $registry_parts }}".auth]
             username = "{{ .image_registry.auth.username }}"
             password = "{{ .image_registry.auth.password }}"
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .image_registry.auth.registry }}".tls]
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $registry_parts }}".tls]
   {{- if .image_registry.auth.ca_file | empty | not }}
-            ca_file = "/etc/containerd/certs.d/{{ .image_registry.auth.registry }}/ca.crt"
+            ca_file = "/etc/containerd/certs.d/{{ $registry_parts }}/ca.crt"
   {{- end }}
   {{- if .image_registry.auth.cert_file | empty | not }}
-            cert_file = "/etc/containerd/certs.d/{{ .image_registry.auth.registry }}/server.crt"
+            cert_file = "/etc/containerd/certs.d/{{ $registry_parts }}/server.crt"
   {{- end }}
   {{- if .image_registry.auth.key_file | empty | not }}
-            key_file = "/etc/containerd/certs.d/{{ .image_registry.auth.registry }}/server.key"
+            key_file = "/etc/containerd/certs.d/{{ $registry_parts }}/server.key"
   {{- end }}
             insecure_skip_verify = {{ .image_registry.auth.insecure | default true }}
 {{- end }}
 {{- if .cri.registry.auths | empty | not }}
   {{- range .cri.registry.auths }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .repo }}".auth]
+    {{- $parts := .repo | splitList "/" | first }}
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $parts }}".auth]
             username = "{{ .username }}"
             password = "{{ .password }}"
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .repo }}".tls]
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $parts  }}".tls]
     {{- if .ca_file }}
             ca_file = {{ .ca_file }}
     {{- end }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
fix containerd config bug when registry like host:port/project

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
fix containerd config bug when registry like host:port/project
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix containerd config bug when registry like host:port/project
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
