### PR TITLE
fix: deal registry.k8s.io images

### DIFF
--- a/builtin/core/defaults/config/v1.23.yaml
+++ b/builtin/core/defaults/config/v1.23.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.8.2
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.6"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: docker
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.6"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.23.0
@@ -61,8 +61,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.5
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -76,7 +75,7 @@ spec:
     # cni_plugins_version: v1.1.1
     # ========== Calico CNI ==========
     # Calico version (effective only when type is calico).
-    calico_version: v3.24.5
+    calico_version: v3.25.2
     # ========== Cilium CNI ==========
     # Cilium version (effective only when type is cilium).
     #cilium_version: 1.14.19
@@ -111,26 +110,26 @@ spec:
     dns_cache_image:
       tag: 1.21.1
   image_manifests:
-    # calico
-    - quay.io/tigera/operator:v1.28.5
-    - docker.io/calico/apiserver:v3.24.5
-    - docker.io/calico/cni:v3.24.5
-    - docker.io/calico/ctl:v3.24.5
-    - docker.io/calico/csi:v3.24.5
-    - docker.io/calico/kube-controllers:v3.24.5
-    - docker.io/calico/node-driver-registrar:v3.24.5
-    - docker.io/calico/node:v3.24.5
-    - docker.io/calico/pod2daemon-flexvol:v3.24.5
-    - docker.io/calico/typha:v3.24.5
+    # calico for v3.25.2
+    - quay.io/tigera/operator:v1.29.6
+    - docker.io/calico/apiserver:v3.25.2
+    - docker.io/calico/cni:v3.25.2
+    - docker.io/calico/ctl:v3.25.2
+    - docker.io/calico/csi:v3.25.2
+    - docker.io/calico/kube-controllers:v3.25.2
+    - docker.io/calico/node-driver-registrar:v3.25.2
+    - docker.io/calico/node:v3.25.2
+    - docker.io/calico/pod2daemon-flexvol:v3.25.2
+    - docker.io/calico/typha:v3.25.2
     # dns
-    - docker.io/kubesphere/coredns:v1.8.6
-    - docker.io/kubesphere/k8s-dns-node-cache:1.21.1
+    - registry.k8s.io/coredns/coredns:v1.8.6
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.6
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.6
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.24.yaml
+++ b/builtin/core/defaults/config/v1.24.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.10.3
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.7"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.6"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.24.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.5
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -111,7 +110,7 @@ spec:
       tag: v1.8.6
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.22.20
+      tag: 1.21.1
   image_manifests:
     # calico for v3.26.5
     - quay.io/tigera/operator:v1.30.11
@@ -125,14 +124,14 @@ spec:
     - docker.io/calico/pod2daemon-flexvol:v3.26.5
     - docker.io/calico/typha:v3.26.5
     # dns
-    - docker.io/kubesphere/coredns:v1.8.6
-    - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+    - registry.k8s.io/coredns/coredns:v1.8.6
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.6
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.7
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.25.yaml
+++ b/builtin/core/defaults/config/v1.25.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.10.3
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.8"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.6"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.25.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.5
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -111,7 +110,7 @@ spec:
       tag: v1.9.3
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.22.20
+      tag: 1.22.8
   image_manifests:
     # calico for v3.26.5
     - quay.io/tigera/operator:v1.30.11
@@ -125,14 +124,14 @@ spec:
     - docker.io/calico/pod2daemon-flexvol:v3.26.5
     - docker.io/calico/typha:v3.26.5
     # dns
-    - docker.io/kubesphere/coredns:v1.9.3
-    - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+    - registry.k8s.io/coredns/coredns:v1.9.3
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.22.8
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.6
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.8
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.26.yaml
+++ b/builtin/core/defaults/config/v1.26.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.11.2
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.9"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.7"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.26.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.7
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -111,7 +110,7 @@ spec:
       tag: v1.9.3
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.22.20
+      tag: 1.22.13
   image_manifests:
     # calico for v3.26.5
     - quay.io/tigera/operator:v1.30.11
@@ -125,14 +124,14 @@ spec:
     - docker.io/calico/pod2daemon-flexvol:v3.26.5
     - docker.io/calico/typha:v3.26.5
     # dns
-    - docker.io/kubesphere/coredns:v1.9.3
-    - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+    - registry.k8s.io/coredns/coredns:v1.9.3
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.22.13
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.7
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.9
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.27.yaml
+++ b/builtin/core/defaults/config/v1.27.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.12.1
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.9"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.7"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.27.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -125,14 +124,14 @@ spec:
     - docker.io/calico/pod2daemon-flexvol:v3.28.5
     - docker.io/calico/typha:v3.28.5
     # dns
-    - docker.io/kubesphere/coredns:v1.10.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+    - registry.k8s.io/coredns/coredns:v1.10.1
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.7
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.9
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.28.yaml
+++ b/builtin/core/defaults/config/v1.28.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.12.1
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.9"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.8"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.28.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -111,7 +110,7 @@ spec:
       tag: v1.10.1
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.22.20
+      tag: 1.22.23
   image_manifests:
     # calico for v3.28.5
     - quay.io/tigera/operator:v1.34.13
@@ -125,14 +124,14 @@ spec:
     - docker.io/calico/pod2daemon-flexvol:v3.28.5
     - docker.io/calico/typha:v3.28.5
     # dns
-    - docker.io/kubesphere/coredns:v1.10.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+    - registry.k8s.io/coredns/coredns:v1.10.1
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.22.23
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.8
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.9
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.29.yaml
+++ b/builtin/core/defaults/config/v1.29.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.13.3
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.9"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.8"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.29.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -111,7 +110,7 @@ spec:
       tag: v1.11.1
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.22.20
+      tag: 1.22.23
   image_manifests:
     # calico for v3.29.7
     - quay.io/tigera/operator:v1.36.16
@@ -125,14 +124,14 @@ spec:
     - docker.io/calico/pod2daemon-flexvol:v3.29.7
     - docker.io/calico/typha:v3.29.7
     # dns
-    - docker.io/kubesphere/coredns:v1.11.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+    - registry.k8s.io/coredns/coredns:v1.11.1
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.22.23
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.8
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.9
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.30.yaml
+++ b/builtin/core/defaults/config/v1.30.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.13.3
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.9"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.8"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.30.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -108,10 +107,10 @@ spec:
   dns:
     # CoreDNS image tag.
     dns_image:
-      tag: v1.11.1
+      tag: v1.11.3
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.22.20
+      tag: 1.22.28
   image_manifests:
     # calico for v3.29.7
     - quay.io/tigera/operator:v1.36.16
@@ -125,14 +124,14 @@ spec:
     - docker.io/calico/pod2daemon-flexvol:v3.29.7
     - docker.io/calico/typha:v3.29.7
     # dns
-    - docker.io/kubesphere/coredns:v1.11.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+    - registry.k8s.io/coredns/coredns:v1.11.3
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.22.28
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.8
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.9
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.31.yaml
+++ b/builtin/core/defaults/config/v1.31.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.13.3
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.10"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.8"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.31.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -108,7 +107,7 @@ spec:
   dns:
     # CoreDNS image tag.
     dns_image:
-      tag: v1.11.1
+      tag: v1.11.3
     # NodeLocalDNS image tag.
     dns_cache_image:
       tag: 1.23.1
@@ -119,20 +118,23 @@ spec:
     - docker.io/calico/cni:v3.30.5
     - docker.io/calico/ctl:v3.30.5
     - docker.io/calico/csi:v3.30.5
+    - docker.io/calico/goldmane:v3.30.5
     - docker.io/calico/kube-controllers:v3.30.5
     - docker.io/calico/node-driver-registrar:v3.30.5
     - docker.io/calico/node:v3.30.5
     - docker.io/calico/pod2daemon-flexvol:v3.30.5
     - docker.io/calico/typha:v3.30.5
+    - docker.io/calico/whisker-backend:v3.30.5
+    - docker.io/calico/whisker:v3.30.5
     # dns
-    - docker.io/kubesphere/coredns:v1.11.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.23.1
+    - registry.k8s.io/coredns/coredns:v1.11.3
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.23.1
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.8
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.10
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.32.yaml
+++ b/builtin/core/defaults/config/v1.32.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.14.3
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.10"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.8"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.32.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -108,10 +107,10 @@ spec:
   dns:
     # CoreDNS image tag.
     dns_image:
-      tag: v1.11.1
+      tag: v1.11.3
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.24.0
+      tag: 1.23.1
   image_manifests:
     # calico for v3.31.3
     - quay.io/tigera/operator:v1.40.3
@@ -119,22 +118,23 @@ spec:
     - docker.io/calico/cni:v3.31.3
     - docker.io/calico/ctl:v3.31.3
     - docker.io/calico/csi:v3.31.3
+    - docker.io/calico/goldmane:v3.31.3
     - docker.io/calico/kube-controllers:v3.31.3
     - docker.io/calico/node-driver-registrar:v3.31.3
     - docker.io/calico/node:v3.31.3
     - docker.io/calico/pod2daemon-flexvol:v3.31.3
     - docker.io/calico/typha:v3.31.3
-    - docker.io/calico/goldmane:v3.31.3
     - docker.io/calico/whisker-backend:v3.31.3
+    - docker.io/calico/whisker:v3.31.3
     # dns
-    - docker.io/kubesphere/coredns:v1.11.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.24.0
+    - registry.k8s.io/coredns/coredns:v1.11.3
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.23.1
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.8
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.10
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.33.yaml
+++ b/builtin/core/defaults/config/v1.33.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.18.5
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.10"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.9"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.33.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -111,7 +110,7 @@ spec:
       tag: v1.12.1
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.24.0
+      tag: 1.25.0
   image_manifests:
     # calico for v3.31.3
     - quay.io/tigera/operator:v1.40.3
@@ -119,22 +118,23 @@ spec:
     - docker.io/calico/cni:v3.31.3
     - docker.io/calico/ctl:v3.31.3
     - docker.io/calico/csi:v3.31.3
+    - docker.io/calico/goldmane:v3.31.3
     - docker.io/calico/kube-controllers:v3.31.3
     - docker.io/calico/node-driver-registrar:v3.31.3
     - docker.io/calico/node:v3.31.3
     - docker.io/calico/pod2daemon-flexvol:v3.31.3
     - docker.io/calico/typha:v3.31.3
-    - docker.io/calico/goldmane:v3.31.3
     - docker.io/calico/whisker-backend:v3.31.3
+    - docker.io/calico/whisker:v3.31.3
     # dns
-    - docker.io/kubesphere/coredns:v1.12.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.24.0
+    - registry.k8s.io/coredns/coredns:v1.12.0
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.25.0
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.9
+    - registry.k8s.io/kube-apiserver:{{ .kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kube_version }}
+    - registry.k8s.io/pause:3.10
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/defaults/config/v1.34.yaml
+++ b/builtin/core/defaults/config/v1.34.yaml
@@ -9,6 +9,9 @@ spec:
     kube_version: {{ .kube_version }}
     # Specify the Helm version to be installed.
     helm_version: v3.18.5
+    # Tag for the sandbox (pause) image used by pods.
+    sandbox_image:
+      tag: "3.10.1"
     control_plane_endpoint:
       # Supported HA types: local, kube_vip, haproxy.
       # If set to local, configure local hostname resolution as follows:
@@ -46,9 +49,6 @@ spec:
   cri:
     # Container runtime type. Supported: containerd, docker.
     container_manager: containerd
-    # Tag for the sandbox (pause) image used by pods.
-    sandbox_image:
-      tag: "3.9"
     # ========== CRI Tool ==========
     # crictl binary version.
     crictl_version: v1.34.0
@@ -63,8 +63,7 @@ spec:
     # runc binary version (active only when container_manager is containerd).
     # runc_version: v1.1.12
   cni:
-    # CNI plugin type (equivalent to kube_network_plugin). Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-    # kube_network_plugin: calico
+    # CNI plugin type. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
     type: calico
     # ========== Multus ==========
     # Configuration for Multus plugin for multiple pod network interfaces.
@@ -111,7 +110,7 @@ spec:
       tag: v1.12.1
     # NodeLocalDNS image tag.
     dns_cache_image:
-      tag: 1.24.0
+      tag: 1.26.4
   image_manifests:
     # calico for v3.31.3
     - quay.io/tigera/operator:v1.40.3
@@ -119,22 +118,23 @@ spec:
     - docker.io/calico/cni:v3.31.3
     - docker.io/calico/ctl:v3.31.3
     - docker.io/calico/csi:v3.31.3
+    - docker.io/calico/goldmane:v3.31.3
     - docker.io/calico/kube-controllers:v3.31.3
     - docker.io/calico/node-driver-registrar:v3.31.3
     - docker.io/calico/node:v3.31.3
     - docker.io/calico/pod2daemon-flexvol:v3.31.3
     - docker.io/calico/typha:v3.31.3
-    - docker.io/calico/goldmane:v3.31.3
     - docker.io/calico/whisker-backend:v3.31.3
+    - docker.io/calico/whisker:v3.31.3
     # dns
-    - docker.io/kubesphere/coredns:v1.12.1
-    - docker.io/kubesphere/k8s-dns-node-cache:1.24.0
+    - registry.k8s.io/coredns/coredns:v1.12.1
+    - registry.k8s.io/dns/k8s-dns-node-cache:1.26.4
     # kubernetes
-    - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-    - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-    - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-    - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-    - docker.io/kubesphere/pause:3.9
+    - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+    - registry.k8s.io/pause:3.10.1
     # openebs/local for 4.4.0
     - docker.io/openebs/linux-utils:4.3.0
     - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/playbooks/artifact_images.yaml
+++ b/builtin/core/playbooks/artifact_images.yaml
@@ -79,4 +79,8 @@
               images_dir: >-
                 {{ .binary_dir }}/images/
               dest: >-
+                {{- if eq .module.image.src.reference.registry "registry.k8s.io" -}}
+                {{ .image_registry.auth.registry }}/registry.k8s.io/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
+                {{- else -}}
                 {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
+                {{- end -}}

--- a/builtin/core/playbooks/delete_cluster.yaml
+++ b/builtin/core/playbooks/delete_cluster.yaml
@@ -19,7 +19,7 @@
         - .delete.cri
         - .groups.image_registry | default list | has .inventory_hostname | not
   post_tasks:
-    - name: delete localDNS file
+    - name: DeleteCluster | Clean up local DNS configuration files
       ignore_errors: true
       loop: "{{ .native.localDNS | toJson }}"
       command: |

--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -36,7 +36,9 @@ state = "/run/containerd"
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    sandbox_image = "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+    {{- if .kubernetes.sandbox_image.tag | empty | not }}
+    sandbox_image = "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"
+    {{- end }}
     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
       runtime_type = "io.containerd.runc.v2"
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]

--- a/builtin/core/roles/cri/docker/templates/cri-dockerd.service
+++ b/builtin/core/roles/cri/docker/templates/cri-dockerd.service
@@ -4,7 +4,7 @@ Documentation=https://docs.mirantis.com
 
 [Service]
 Type=notify
-ExecStart=/usr/local/bin/cri-dockerd --pod-infra-container-image "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+ExecStart=/usr/local/bin/cri-dockerd --pod-infra-container-image "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2

--- a/builtin/core/roles/cri/docker/templates/daemon.json
+++ b/builtin/core/roles/cri/docker/templates/daemon.json
@@ -9,10 +9,15 @@
 {{- if .cri.registry.mirrors }}
   "registry-mirrors": {{ .cri.registry.mirrors | toJson }},
 {{- end }}
-{{- $insecure_registries := .cri.registry.insecure_registries | default list -}} 
-{{- if .image_registry.auth.insecure -}}
-  {{- $insecure_registries = append $insecure_registries .image_registry.auth.registry -}}
-{{- end -}}
+{{- $insecure_registries := .cri.registry.insecure_registries | default list }} 
+{{- if and .image_registry.auth.insecure (.image_registry.auth.registry | empty | not) }}
+  {{- $insecure_registries = append $insecure_registries .image_registry.auth.registry }}
+{{- end }}
+{{- range .cri.registry.auths | default list }}
+  {{- if and .insecure (.repo | empty | not) }}
+    {{- $insecure_registries = append $insecure_registries .repo }}
+  {{- end }}
+{{- end }}
   "insecure-registries": {{ $insecure_registries | toJson }},
  {{- if .cri.docker.bridge_ip }}
   "bip": "{{ .cri.docker.bridge_ip }}",

--- a/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
+++ b/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
@@ -71,7 +71,7 @@ image_registry:
   # Registry endpoint for images from ghcr.io
   k8sio_registry: >-
     {{- if .image_registry.auth.registry | empty | not -}}
-    {{ .image_registry.auth.registry }}
+    {{ .image_registry.auth.registry }}/registry.k8s.io
     {{- else -}}
     registry.k8s.io
     {{- end -}}

--- a/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
+++ b/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
@@ -3,8 +3,14 @@ kubernetes:
   cluster_name: kubekey
 
   # Image repository for built-in Kubernetes images
-  image_repository: >- 
-    {{ .image_registry.dockerio_registry }}/kubesphere
+  image_repository: >-
+    {{ .image_registry.k8sio_registry }}
+
+  # Pause/sandbox image configuration
+  sandbox_image: 
+    registry: >-
+      {{ .image_registry.k8sio_registry }}
+    repository: pause
 
   # Kubernetes network configuration
   # kube-apiserver pod parameters

--- a/builtin/core/roles/defaults/defaults/main/04-cni.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cni.yaml
@@ -1,7 +1,6 @@
 cni:
-  # CNI plugin to use (equivalent to kubernetes.kube_network_plugin)
+  # CNI plugin to use
   # Specify the network plugin to install for the cluster. Supported: calico, cilium, flannel, hybridnet, kubeovn, other
-  # kube_network_plugin: calico
   type: calico
   # Maximum number of pods supported per node
   max_pods: 110

--- a/builtin/core/roles/defaults/defaults/main/04-cri.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cri.yaml
@@ -3,11 +3,6 @@ cri:
   container_manager: containerd
   # Cgroup driver for the container runtime. Supported: systemd, cgroupfs
   cgroup_driver: systemd
-  # Pause/sandbox image configuration
-  sandbox_image: 
-    registry: >-
-      {{ .image_registry.dockerio_registry }}
-    repository: kubesphere/pause
     # tag: "3.9"
   # CRI socket endpoint for the selected container runtime
   cri_socket: >-

--- a/builtin/core/roles/defaults/defaults/main/05-dns.yaml
+++ b/builtin/core/roles/defaults/defaults/main/05-dns.yaml
@@ -5,15 +5,15 @@ dns:
   # CoreDNS image settings
   dns_image: 
     registry: >-
-      {{ .image_registry.dockerio_registry }}
+      {{ .image_registry.k8sio_registry }}
     repository: >-
-      kubesphere
+      coredns
     # tag: v1.11.1
   # NodeLocalDNS image settings
   dns_cache_image: 
     registry: >-
-      {{ .image_registry.dockerio_registry }}
-    repository: kubesphere/k8s-dns-node-cache
+      {{ .image_registry.k8sio_registry }}
+    repository: dns/k8s-dns-node-cache
     # tag: 1.24.0
   # The IP address assigned to the cluster DNS service
   dns_service_ip: >-

--- a/builtin/core/roles/defaults/vars/v1.23.yaml
+++ b/builtin/core/roles/defaults/vars/v1.23.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.8.2
+  sandbox_image:
+    tag: "3.6"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -25,8 +27,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: docker
-  sandbox_image:
-    tag: "3.6"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.23.0
@@ -49,7 +49,7 @@ cni:
   # cni_plugins_version: v1.1.1
   # ========== cni: calico ==========
   # calicoctl binary
-  calico_version: v3.24.5
+  calico_version: v3.25.2
   # ========== cni: cilium ==========
   # cilium helm
   cilium_version: 1.14.19
@@ -75,26 +75,26 @@ dns:
   dns_cache_image:
     tag: 1.21.1
 image_manifests:
-  # calico
-  - quay.io/tigera/operator:v1.28.5
-  - docker.io/calico/apiserver:v3.24.5
-  - docker.io/calico/cni:v3.24.5
-  - docker.io/calico/ctl:v3.24.5
-  - docker.io/calico/csi:v3.24.5
-  - docker.io/calico/kube-controllers:v3.24.5
-  - docker.io/calico/node-driver-registrar:v3.24.5
-  - docker.io/calico/node:v3.24.5
-  - docker.io/calico/pod2daemon-flexvol:v3.24.5
-  - docker.io/calico/typha:v3.24.5
+  # calico for v3.25.2
+  - quay.io/tigera/operator:v1.29.6
+  - docker.io/calico/apiserver:v3.25.2
+  - docker.io/calico/cni:v3.25.2
+  - docker.io/calico/ctl:v3.25.2
+  - docker.io/calico/csi:v3.25.2
+  - docker.io/calico/kube-controllers:v3.25.2
+  - docker.io/calico/node-driver-registrar:v3.25.2
+  - docker.io/calico/node:v3.25.2
+  - docker.io/calico/pod2daemon-flexvol:v3.25.2
+  - docker.io/calico/typha:v3.25.2
   # dns
-  - docker.io/kubesphere/coredns:v1.8.6
-  - docker.io/kubesphere/k8s-dns-node-cache:1.21.1
+  - registry.k8s.io/coredns/coredns:v1.8.6
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.6
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.6
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.24.yaml
+++ b/builtin/core/roles/defaults/vars/v1.24.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.10.3
+  sandbox_image:
+    tag: "3.7"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -28,8 +30,6 @@ cri:
   ipv6_support: false
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.6"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.24.0
@@ -72,11 +72,11 @@ storage_class:
   # ========== storageclass: nfs ==========
   # nfs provisioner helm version
   nfs_provisioner_version: 4.0.18
-  dns:
+dns:
   dns_image:
     tag: v1.8.6
   dns_cache_image:
-    tag: 1.22.20
+    tag: 1.21.1
 image_manifests:
   # calico for v3.26.5
   - quay.io/tigera/operator:v1.30.11
@@ -90,14 +90,14 @@ image_manifests:
   - docker.io/calico/pod2daemon-flexvol:v3.26.5
   - docker.io/calico/typha:v3.26.5
   # dns
-  - docker.io/kubesphere/coredns:v1.8.6
-  - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+  - registry.k8s.io/coredns/coredns:v1.8.6
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.6
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.7
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.25.yaml
+++ b/builtin/core/roles/defaults/vars/v1.25.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.10.3
+  sandbox_image:
+    tag: "3.8"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.6"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.25.0
@@ -76,7 +76,7 @@ dns:
   dns_image:
     tag: v1.9.3
   dns_cache_image:
-    tag: 1.22.20
+    tag: 1.22.8
 image_manifests:
   # calico for v3.26.5
   - quay.io/tigera/operator:v1.30.11
@@ -90,14 +90,14 @@ image_manifests:
   - docker.io/calico/pod2daemon-flexvol:v3.26.5
   - docker.io/calico/typha:v3.26.5
   # dns
-  - docker.io/kubesphere/coredns:v1.9.3
-  - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+  - registry.k8s.io/coredns/coredns:v1.9.3
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.22.8
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.6
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.8
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.26.yaml
+++ b/builtin/core/roles/defaults/vars/v1.26.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.11.2
+  sandbox_image:
+    tag: "3.9"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.7"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.26.0
@@ -76,7 +76,7 @@ dns:
   dns_image:
     tag: v1.9.3
   dns_cache_image:
-    tag: 1.22.20
+    tag: 1.22.13
 image_manifests:
   # calico for v3.26.5
   - quay.io/tigera/operator:v1.30.11
@@ -90,14 +90,14 @@ image_manifests:
   - docker.io/calico/pod2daemon-flexvol:v3.26.5
   - docker.io/calico/typha:v3.26.5
   # dns
-  - docker.io/kubesphere/coredns:v1.9.3
-  - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+  - registry.k8s.io/coredns/coredns:v1.9.3
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.22.13
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.7
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.9
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.27.yaml
+++ b/builtin/core/roles/defaults/vars/v1.27.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.12.1
+  sandbox_image:
+    tag: "3.9"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.7"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.27.0
@@ -88,14 +88,14 @@ image_manifests:
   - docker.io/calico/pod2daemon-flexvol:v3.28.5
   - docker.io/calico/typha:v3.28.5
   # dns
-  - docker.io/kubesphere/coredns:v1.10.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+  - registry.k8s.io/coredns/coredns:v1.10.1
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.7
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.9
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.28.yaml
+++ b/builtin/core/roles/defaults/vars/v1.28.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.12.1
+  sandbox_image:
+    tag: "3.9"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.8"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.28.0
@@ -74,7 +74,7 @@ dns:
   dns_image:
     tag: v1.10.1
   dns_cache_image:
-    tag: 1.22.20
+    tag: 1.22.23
 image_manifests:
   # calico for v3.28.5
   - quay.io/tigera/operator:v1.34.13
@@ -88,14 +88,14 @@ image_manifests:
   - docker.io/calico/pod2daemon-flexvol:v3.28.5
   - docker.io/calico/typha:v3.28.5
   # dns
-  - docker.io/kubesphere/coredns:v1.10.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+  - registry.k8s.io/coredns/coredns:v1.10.1
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.22.23
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.8
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.9
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.29.yaml
+++ b/builtin/core/roles/defaults/vars/v1.29.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.13.3
+  sandbox_image:
+    tag: "3.9"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.8"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.29.0
@@ -74,7 +74,7 @@ dns:
   dns_image:
     tag: v1.11.1
   dns_cache_image:
-    tag: 1.23.1
+    tag: 1.22.23
 image_manifests:
   # calico for v3.29.7
   - quay.io/tigera/operator:v1.36.16
@@ -88,14 +88,14 @@ image_manifests:
   - docker.io/calico/pod2daemon-flexvol:v3.29.7
   - docker.io/calico/typha:v3.29.7
   # dns
-  - docker.io/kubesphere/coredns:v1.11.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+  - registry.k8s.io/coredns/coredns:v1.11.1
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.22.23
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.8
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.9
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.30.yaml
+++ b/builtin/core/roles/defaults/vars/v1.30.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.13.3
+  sandbox_image:
+    tag: "3.9"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.8"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.30.0
@@ -72,9 +72,9 @@ storage_class:
   nfs_provisioner_version: 4.0.18
 dns:
   dns_image:
-    tag: v1.11.1
+    tag: v1.11.3
   dns_cache_image:
-    tag: 1.23.1
+    tag: 1.22.28
 image_manifests:
   # calico for v3.29.7
   - quay.io/tigera/operator:v1.36.16
@@ -88,14 +88,14 @@ image_manifests:
   - docker.io/calico/pod2daemon-flexvol:v3.29.7
   - docker.io/calico/typha:v3.29.7
   # dns
-  - docker.io/kubesphere/coredns:v1.11.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.22.20
+  - registry.k8s.io/coredns/coredns:v1.11.3
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.22.28
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.8
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.9
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.31.yaml
+++ b/builtin/core/roles/defaults/vars/v1.31.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.13.3
+  sandbox_image:
+    tag: "3.10"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.8"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.31.0
@@ -72,7 +72,7 @@ storage_class:
   nfs_provisioner_version: 4.0.18
 dns:
   dns_image:
-    tag: v1.11.1
+    tag: v1.11.3
   dns_cache_image:
     tag: 1.23.1
 image_manifests:
@@ -82,20 +82,23 @@ image_manifests:
   - docker.io/calico/cni:v3.30.5
   - docker.io/calico/ctl:v3.30.5
   - docker.io/calico/csi:v3.30.5
+  - docker.io/calico/goldmane:v3.30.5
   - docker.io/calico/kube-controllers:v3.30.5
   - docker.io/calico/node-driver-registrar:v3.30.5
   - docker.io/calico/node:v3.30.5
   - docker.io/calico/pod2daemon-flexvol:v3.30.5
   - docker.io/calico/typha:v3.30.5
+  - docker.io/calico/whisker-backend:v3.30.5
+  - docker.io/calico/whisker:v3.30.5
   # dns
-  - docker.io/kubesphere/coredns:v1.11.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.23.1
+  - registry.k8s.io/coredns/coredns:v1.11.3
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.23.1
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.8
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.10
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.32.yaml
+++ b/builtin/core/roles/defaults/vars/v1.32.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.14.3
+  sandbox_image:
+    tag: "3.10"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.8"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.32.0
@@ -74,9 +74,9 @@ storage_class:
   nfs_provisioner_version: 4.0.18
 dns:
   dns_image:
-    tag: v1.11.1
+    tag: v1.11.3
   dns_cache_image:
-    tag: 1.24.0
+    tag: 1.23.1
 image_manifests:
   # calico for v3.31.3
   - quay.io/tigera/operator:v1.40.3
@@ -84,22 +84,23 @@ image_manifests:
   - docker.io/calico/cni:v3.31.3
   - docker.io/calico/ctl:v3.31.3
   - docker.io/calico/csi:v3.31.3
+  - docker.io/calico/goldmane:v3.31.3
   - docker.io/calico/kube-controllers:v3.31.3
   - docker.io/calico/node-driver-registrar:v3.31.3
   - docker.io/calico/node:v3.31.3
   - docker.io/calico/pod2daemon-flexvol:v3.31.3
   - docker.io/calico/typha:v3.31.3
-  - docker.io/calico/goldmane:v3.31.3
   - docker.io/calico/whisker-backend:v3.31.3
+  - docker.io/calico/whisker:v3.31.3
   # dns
-  - docker.io/kubesphere/coredns:v1.11.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.24.0
+  - registry.k8s.io/coredns/coredns:v1.11.3
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.23.1
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.8
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.10
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.33.yaml
+++ b/builtin/core/roles/defaults/vars/v1.33.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.18.5
+  sandbox_image:
+    tag: "3.10"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.9"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.33.0
@@ -76,7 +76,7 @@ dns:
   dns_image:
     tag: v1.12.1
   dns_cache_image:
-    tag: 1.24.0
+    tag: 1.25.0
 image_manifests:
   # calico for v3.31.3
   - quay.io/tigera/operator:v1.40.3
@@ -84,22 +84,23 @@ image_manifests:
   - docker.io/calico/cni:v3.31.3
   - docker.io/calico/ctl:v3.31.3
   - docker.io/calico/csi:v3.31.3
+  - docker.io/calico/goldmane:v3.31.3
   - docker.io/calico/kube-controllers:v3.31.3
   - docker.io/calico/node-driver-registrar:v3.31.3
   - docker.io/calico/node:v3.31.3
   - docker.io/calico/pod2daemon-flexvol:v3.31.3
   - docker.io/calico/typha:v3.31.3
-  - docker.io/calico/goldmane:v3.31.3
   - docker.io/calico/whisker-backend:v3.31.3
+  - docker.io/calico/whisker:v3.31.3
   # dns
-  - docker.io/kubesphere/coredns:v1.12.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.24.0
+  - registry.k8s.io/coredns/coredns:v1.12.0
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.25.0
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kube_version }}
-  - docker.io/kubesphere/pause:3.9
+  - registry.k8s.io/kube-apiserver:{{ .kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kube_version }}
+  - registry.k8s.io/pause:3.10
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/defaults/vars/v1.34.yaml
+++ b/builtin/core/roles/defaults/vars/v1.34.yaml
@@ -1,6 +1,8 @@
 kubernetes:
   # helm binary
   helm_version: v3.18.5
+  sandbox_image:
+    tag: "3.10.1"
   control_plane_endpoint:
     kube_vip:
       image:
@@ -26,8 +28,6 @@ image_registry:
 cri:
   # support: containerd,docker
   container_manager: containerd
-  sandbox_image:
-    tag: "3.9"
   # ========== cri ==========
   # crictl binary
   crictl_version: v1.34.0
@@ -76,7 +76,7 @@ dns:
   dns_image:
     tag: v1.12.1
   dns_cache_image:
-    tag: 1.24.0
+    tag: 1.26.4
 image_manifests:
   # calico for v3.31.3
   - quay.io/tigera/operator:v1.40.3
@@ -84,22 +84,23 @@ image_manifests:
   - docker.io/calico/cni:v3.31.3
   - docker.io/calico/ctl:v3.31.3
   - docker.io/calico/csi:v3.31.3
+  - docker.io/calico/goldmane:v3.31.3
   - docker.io/calico/kube-controllers:v3.31.3
   - docker.io/calico/node-driver-registrar:v3.31.3
   - docker.io/calico/node:v3.31.3
   - docker.io/calico/pod2daemon-flexvol:v3.31.3
   - docker.io/calico/typha:v3.31.3
-  - docker.io/calico/goldmane:v3.31.3
   - docker.io/calico/whisker-backend:v3.31.3
+  - docker.io/calico/whisker:v3.31.3
   # dns
-  - docker.io/kubesphere/coredns:v1.12.1
-  - docker.io/kubesphere/k8s-dns-node-cache:1.24.0
+  - registry.k8s.io/coredns/coredns:v1.12.1
+  - registry.k8s.io/dns/k8s-dns-node-cache:1.26.4
   # kubernetes
-  - docker.io/kubesphere/kube-apiserver:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-controller-manager:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-proxy:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/kube-scheduler:{{ .kubernetes.kube_version }}
-  - docker.io/kubesphere/pause:3.9
+  - registry.k8s.io/kube-apiserver:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-controller-manager:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-proxy:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/kube-scheduler:{{ .kubernetes.kube_version }}
+  - registry.k8s.io/pause:3.10.1
   # openebs/local for 4.4.0
   - docker.io/openebs/linux-utils:4.3.0
   - docker.io/openebs/provisioner-localpv:4.4.0

--- a/builtin/core/roles/image-registry/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/tasks/main.yaml
@@ -53,4 +53,8 @@
       images_dir: >-
         {{ .binary_dir }}/images/
       dest: >-
+        {{- if eq .module.image.src.reference.registry "registry.k8s.io" -}}
+        {{ .image_registry.auth.registry }}/registry.k8s.io/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
+        {{- else -}}
         {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
+        {{- end -}}

--- a/builtin/core/roles/kubernetes/init-kubernetes/tasks/init_kubernetes.yaml
+++ b/builtin/core/roles/kubernetes/init-kubernetes/tasks/init_kubernetes.yaml
@@ -20,9 +20,11 @@
       command: |
         sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
           /etc/kubernetes/manifests/kube-vip.yaml
-    - name: Init | Run kubeadm init
-      command: |
-        /usr/local/bin/kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml --ignore-preflight-errors=FileExisting-crictl,ImagePull {{ if not .kubernetes.kube_proxy.enabled }}--skip-phases=addon/kube-proxy{{ end }}
+    - name: Init | Run kubeadm init 
+      command: | 
+        # In Kubernetes, the ImagePullCheck for the pause image uses a hardcoded tag.
+        # Adding --ignore-preflight-errors=ImagePull allows customization of the pause image reference.
+        /usr/local/bin/kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml --ignore-preflight-errors=ImagePull {{ if not .kubernetes.kube_proxy.enabled }}--skip-phases=addon/kube-proxy{{ end }}
     - name: Init | Post-initialization for kube-vip
       when: 
         - .kubernetes.kube_version | semverCompare ">=v1.29.0"

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta2
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta2
@@ -160,7 +160,7 @@ nodeRegistration:
   criSocket: {{ .cri.cri_socket }}
   kubeletExtraArgs:
     cgroup-driver: {{ .cri.cgroup_driver }}
-    pod-infra-container-image: "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+    pod-infra-container-image: "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"
 
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
@@ -159,7 +159,7 @@ nodeRegistration:
   criSocket: {{ .cri.cri_socket }}
   kubeletExtraArgs:
     cgroup-driver: {{ .cri.cgroup_driver }}
-    pod-infra-container-image: "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+    pod-infra-container-image: "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"
 
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
@@ -190,7 +190,7 @@ nodeRegistration:
     - name: cgroup-driver
       value: {{ .cri.cgroup_driver }}
     - name: pod-infra-container-image
-      value: "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+      value: "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"
 
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1

--- a/builtin/core/roles/kubernetes/join-kubernetes/templates/kubeadm/kubeadm-join.v1beta2
+++ b/builtin/core/roles/kubernetes/join-kubernetes/templates/kubeadm/kubeadm-join.v1beta2
@@ -23,4 +23,4 @@ nodeRegistration:
   criSocket: {{ .cri.cri_socket }}
   kubeletExtraArgs:
     cgroup-driver: {{ .cri.cgroup_driver }}
-    pod-infra-container-image: "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+    pod-infra-container-image: "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"

--- a/builtin/core/roles/kubernetes/join-kubernetes/templates/kubeadm/kubeadm-join.v1beta3
+++ b/builtin/core/roles/kubernetes/join-kubernetes/templates/kubeadm/kubeadm-join.v1beta3
@@ -23,4 +23,4 @@ nodeRegistration:
   criSocket: {{ .cri.cri_socket }}
   kubeletExtraArgs:
     cgroup-driver: {{ .cri.cgroup_driver }}
-    pod-infra-container-image: "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+    pod-infra-container-image: "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"

--- a/builtin/core/roles/kubernetes/join-kubernetes/templates/kubeadm/kubeadm-join.v1beta4
+++ b/builtin/core/roles/kubernetes/join-kubernetes/templates/kubeadm/kubeadm-join.v1beta4
@@ -25,4 +25,4 @@ nodeRegistration:
     - name: cgroup-driver
       value: {{ .cri.cgroup_driver }}
     - name: pod-infra-container-image
-      value: "{{ .cri.sandbox_image.registry }}/{{ .cri.sandbox_image.repository }}:{{ .cri.sandbox_image.tag }}"
+      value: "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
registry.k8s.io is designed as an organization-level registry, not a multi-tenant platform.
When mirroring images to a private registry (e.g. Harbor), registry.k8s.io is typically mapped to a single organization or project to align with enterprise registry models.


#### coredns version refer kubernetes
| cordns version | kubernetes version | source |
|---|---|---|
| v1.8.6 | v1.23.0\~v1.23.17, v1.24.0\~v1.24.17 | https://github.com/kubernetes/kubernetes/blob/v1.23.0/cluster/addons/dns/coredns/coredns.yaml.base#L142<br>https://github.com/kubernetes/kubernetes/blob/v1.24.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| v1.9.3 | v1.25.0\~v1.25.16, v1.26.0\~v1.26.15 | https://github.com/kubernetes/kubernetes/blob/v1.25.0/cluster/addons/dns/coredns/coredns.yaml.base#L142<br>https://github.com/kubernetes/kubernetes/blob/v1.26.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| v1.10.1 | v1.27.0\~v1.27.16, v1.28.0\~v1.28.15 | https://github.com/kubernetes/kubernetes/blob/v1.27.0/cluster/addons/dns/coredns/coredns.yaml.base#L142<br>https://github.com/kubernetes/kubernetes/blob/v1.28.0/cluster/addons/dns/coredns/coredns.yaml.base#L136 |
| v1.11.1 | v1.29.0\~v1.29.15, v1.30.0\~v1.30.4, v1.31.0 | https://github.com/kubernetes/kubernetes/blob/v1.29.0/cluster/addons/dns/coredns/coredns.yaml.base#L136<br>https://github.com/kubernetes/kubernetes/blob/v1.30.4/cluster/addons/dns/coredns/coredns.yaml.base#L136<br>https://github.com/kubernetes/kubernetes/blob/v1.31.0/cluster/addons/dns/coredns/coredns.yaml.base#L136 |
| v1.11.3 | v1.30.5\~v1.30.14, v1.31.1\~v1.31.14, v1.32.0\~v1.32.11 | https://github.com/kubernetes/kubernetes/blob/v1.30.5/cluster/addons/dns/coredns/coredns.yaml.base#L136<br>https://github.com/kubernetes/kubernetes/blob/v1.30.4/cluster/addons/dns/coredns/coredns.yaml.base#L136<br>https://github.com/kubernetes/kubernetes/blob/v1.31.1/cluster/addons/dns/coredns/coredns.yaml.base#L136<br>https://github.com/kubernetes/kubernetes/blob/v1.32.0/cluster/addons/dns/coredns/coredns.yaml.base#L136 |
| v1.12.0 | v1.33.0\~v1.33.7 | https://github.com/kubernetes/kubernetes/blob/v1.33.0/cluster/addons/dns/coredns/coredns.yaml.base#L136 |
|v1.12.1 | v1.34.0\~v1.34.3 | https://github.com/kubernetes/kubernetes/blob/v1.34.0/cluster/addons/dns/coredns/coredns.yaml.base#L136 |

#### nodelocaldns version refer kubernetes
| nodelocaldns version | kubernetes version | source |
|---|---|---|
| 1.21.1 | v1.23.0\~v1.23.17, v1.24.0\~v1.24.17 | https://github.com/kubernetes/kubernetes/blob/v1.23.0/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml#L141<br>https://github.com/kubernetes/kubernetes/blob/v1.24.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.22.8 | v1.25.0\~v1.25.16 | https://github.com/kubernetes/kubernetes/blob/v1.25.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.22.13 | v1.26.0\~v1.26.15 | https://github.com/kubernetes/kubernetes/blob/v1.26.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.22.20 | v1.27.0\~v1.27.16 | https://github.com/kubernetes/kubernetes/blob/v1.27.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.22.23 | v1.28.0\~v1.28.15, v1.29.0\~v1.29.15 | https://github.com/kubernetes/kubernetes/blob/v1.28.0/cluster/addons/dns/coredns/coredns.yaml.base#L142<br>https://github.com/kubernetes/kubernetes/blob/v1.29.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.22.28 | v1.30.0\~v1.30.14 | https://github.com/kubernetes/kubernetes/blob/v1.30.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.23.1 | v1.31.0\~v1.31.14, v1.32.0\~v1.32.11 | https://github.com/kubernetes/kubernetes/blob/v1.31.0/cluster/addons/dns/coredns/coredns.yaml.base#L142<br>https://github.com/kubernetes/kubernetes/blob/v1.32.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.25.0 | v1.33.0\~v1.33.7 | https://github.com/kubernetes/kubernetes/blob/v1.31.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |
| 1.26.4 | v1.34.0\~v1.34.3 | https://github.com/kubernetes/kubernetes/blob/v1.34.0/cluster/addons/dns/coredns/coredns.yaml.base#L142 |

#### pause version for kubeadm
| pause version | kubernetes version | source |
|---|---|---|
| 3.6 | v1.23.0\~v1.23.17 | https://github.com/kubernetes/kubernetes/blob/v1.23.0/cmd/kubeadm/app/constants/constants.go#L412<br>https://github.com/kubernetes/kubernetes/blob/v1.23.17/cmd/kubeadm/app/constants/constants.go#L415 |
| 3.7 | v1.24.0\~v1.24.17 | https://github.com/kubernetes/kubernetes/blob/v1.24.0/cmd/kubeadm/app/constants/constants.go#L428<br>https://github.com/kubernetes/kubernetes/blob/v1.24.17/cmd/kubeadm/app/constants/constants.go#L431 |
| 3.8 | v1.25.0\~v1.25.16 | https://github.com/kubernetes/kubernetes/blob/v1.25.0/cmd/kubeadm/app/constants/constants.go#L424<br>https://github.com/kubernetes/kubernetes/blob/v1.25.16/cmd/kubeadm/app/constants/constants.go#L426 |
| 3.9 | v1.26.0\~v1.26.15, v1.27.0\~v1.27.16, v1.28.0\~v1.28.15, v1.29.0\~v1.29.15, v1.30.0\~v1.30.14 | https://github.com/kubernetes/kubernetes/blob/v1.26.0/cmd/kubeadm/app/constants/constants.go#L420<br>https://github.com/kubernetes/kubernetes/blob/v1.26.15/cmd/kubeadm/app/constants/constants.go#L422<br>https://github.com/kubernetes/kubernetes/blob/v1.27.0/cmd/kubeadm/app/constants/constants.go#L420<br>https://github.com/kubernetes/kubernetes/blob/v1.27.16/cmd/kubeadm/app/constants/constants.go#L422<br>https://github.com/kubernetes/kubernetes/blob/v1.28.0/cmd/kubeadm/app/constants/constants.go#L419<br>https://github.com/kubernetes/kubernetes/blob/v1.28.15/cmd/kubeadm/app/constants/constants.go#L419<br>https://github.com/kubernetes/kubernetes/blob/v1.29.0/cmd/kubeadm/app/constants/constants.go#L423<br>https://github.com/kubernetes/kubernetes/blob/v1.29.15/cmd/kubeadm/app/constants/constants.go#L423<br>https://github.com/kubernetes/kubernetes/blob/v1.30.0/cmd/kubeadm/app/constants/constants.go#L436<br>https://github.com/kubernetes/kubernetes/blob/v1.30.14/cmd/kubeadm/app/constants/constants.go#L436 |
| 3.10 | v1.31.0\~v1.31.14, v1.32.0\~v1.32.11, v1.33.0\~v1.33.7 | https://github.com/kubernetes/kubernetes/blob/v1.31.0/cmd/kubeadm/app/constants/constants.go#L438<br>https://github.com/kubernetes/kubernetes/blob/v1.31.14/cmd/kubeadm/app/constants/constants.go#L438<br>https://github.com/kubernetes/kubernetes/blob/v1.32.0/cmd/kubeadm/app/constants/constants.go#L445<br>https://github.com/kubernetes/kubernetes/blob/v1.32.11/cmd/kubeadm/app/constants/constants.go#L445<br>https://github.com/kubernetes/kubernetes/blob/v1.33.0/cmd/kubeadm/app/constants/constants.go#L445<br>https://github.com/kubernetes/kubernetes/blob/v1.33.7/cmd/kubeadm/app/constants/constants.go#L445 |
| 3.10.1 | v1.34.0\~v1.34.3 | https://github.com/kubernetes/kubernetes/blob/v1.34.0/cmd/kubeadm/app/constants/constants.go#L445<br>https://github.com/kubernetes/kubernetes/blob/v1.34.3/cmd/kubeadm/app/constants/constants.go#L445 |

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
deal registry.k8s.io images
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
