### PR TITLE
fix: 防止每执行一次添加一条重复 Defaults secure_path

### DIFF
--- a/builtin/core/roles/native/root/tasks/main.yaml
+++ b/builtin/core/roles/native/root/tasks/main.yaml
@@ -25,9 +25,11 @@
                     NEW_PATH="$NEW_PATH:$path"
                 fi
             done
-            echo "new secure_path: $NEW_PATH"
-            sed -i "s/^Defaults.*secure_path/# &/" "$TMP_FILE"
-            echo "Defaults secure_path=\"$NEW_PATH\"" >> "$TMP_FILE"
+            if [ "$NEW_PATH" != "$EXISTING_PATH" ]; then
+                echo "new secure_path: $NEW_PATH"
+                sed -i "s/^Defaults.*secure_path/# &/" "$TMP_FILE"
+                echo "Defaults secure_path=\"$NEW_PATH\"" >> "$TMP_FILE"
+            fi
         else
             echo "warning: can not get current secure_path"
             echo "Defaults secure_path=\"$ADD_PATHS\"" >> "$TMP_FILE"


### PR DESCRIPTION
### What type of PR is this?

/kind bug


### What this PR does / why we need it:
多次运行程序 对于Defaults secure_path开头的行会反复注释添加，不应该这样

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
