### PR TITLE
bugfix: unable to delete etcd backup files

### DIFF
--- a/builtin/core/roles/etcd/templates/backup.sh
+++ b/builtin/core/roles/etcd/templates/backup.sh
@@ -34,4 +34,4 @@ export ETCDCTL_API=3;$ETCDCTL_PATH --endpoints="$ENDPOINTS" snapshot save $BACKU
 
 sleep 3
 
-cd $BACKUP_DIR/../ && ls -1 |awk '{if(NR > '$KEEPBACKUPNUMBER'){print "rm -rf "$9}}'|sh
+cd $BACKUP_DIR/../ && ls -1r |awk '{if(NR > '$KEEPBACKUPNUMBER'){print "rm -rf "$1}}'|sh


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

This PR fixes an issue where etcd backup files could not be deleted on certain systems.

**The Root Cause:**
The existing script relied on parsing the 9th column of `ls -lt` output to identify filenames. However, on some machines (depending on the OS distribution or environment settings), `ls -lt` produces only 8 columns. This mismatch caused the parsing logic to return an empty string, resulting in `rm -rf` receiving no arguments and failing to perform the cleanup.
```bash
# ls -lt
总计 24
drwxr-xr-x 3 root root 4096  1月20日 02:00 etcd-2026-01-20-02-00-00
```

**The Fix:**
Replaced `ls -lt` with `ls -1`. Since `ls -1` outputs exactly one filename per line without extra metadata columns, it provides a robust and environment-independent way to list files for deletion.

### Which issue(s) this PR fixes:

Fixes #2960 

### Special notes for reviewers:

The change is straightforward:

```bash
# Before
ls -lt | awk '{print $9}' ...

# After
ls -1r | awk '{print $1}' ...

```

This avoids the brittle nature of parsing the long-format output of `ls`.

### Does this PR introduced a user-facing change?

```release-note
Fixed a bug where etcd backup cleanup failed on certain environments due to inconsistent 'ls' output formatting.

```