### PR TITLE
[bugfix] Allow password-only SSH auth when default private key is missing

### DIFF
--- a/pkg/connector/ssh_connector_test.go
+++ b/pkg/connector/ssh_connector_test.go
@@ -197,6 +197,19 @@ func TestSSHConnector_InitValidation(t *testing.T) {
 			shouldError: true,
 			errorMsg:    "no authentication method available",
 		},
+		{
+			name: "explicit private key path that doesn't exist (should fail)",
+			connector: &sshConnector{
+				Host:              "test-host",
+				Port:              22,
+				User:              "root",
+				Password:          "test-password",
+				PrivateKey:        "/tmp/custom/nonexistent/key.pem", // Explicit custom path (not default)
+				PrivateKeyContent: "",
+			},
+			shouldError: true,
+			errorMsg:    "private key file not found",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

This PR fixes a bug in the SSH connector where password-only authentication would fail when the default SSH private key file (`~/.ssh/id_rsa`) doesn't exist on the system.

**Problem:**
When users configure **only** password authentication (without specifying `private_key` or `private_key_content`), the SSH connector would fail with error `"private key file not found: ~/.ssh/id_rsa"` if the default key file didn't exist, even though a valid password was provided.

**Root Cause:**
The `Init()` method always attempted to use the default private key path when no explicit key was configured. If the default key file was missing, it would return an error before attempting password authentication.

**Solution:**
Implement graceful fallback for the default SSH private key path:
- **Default key path** (`~/.ssh/id_rsa`): Skip silently if file doesn't exist → allows password-only authentication
- **Explicit key path** (user-specified): Fail fast with clear error → prevents misconfigurations

This ensures:
- Password-only auth works without requiring default key file
- Explicitly configured key paths still fail with clear errors
- Default key is used automatically when it exists (backward compatible)
- Clear separation between "user-specified" vs "default" behavior

### Which issue(s) this PR fixes:

Related to code review feedback in #2973 by @will4j:
> "c.PrivateKey will be default as defaultSSHPrivateKey, which is ~/.ssh/id_rsa, if ~/.ssh/id_rsa file not exists, this may cause task failed with private key file not found, event if password auth are provided."

### Special notes for reviewers:

**Key Changes:**
1. Modified `pkg/connector/ssh_connector.go` `Init()` method (lines 156-186):
   - Added logic to distinguish between default and explicit key paths
   - Skip key authentication silently if using default path and file doesn't exist
   - Maintain strict validation for explicitly configured key paths

2. Updated documentation comment to reflect new behavior

3. Added test case in `pkg/connector/ssh_connector_test.go`:
   - Test for explicit private key path that doesn't exist (should fail)
   - Verifies that user-specified paths maintain strict validation

**Use Cases:**

| Scenario | Before | After |
|----------|--------|-------|
| Password only + default key missing | ❌ Error | ✅ Success (uses password) |
| Password only + default key exists | ✅ Uses key + password | ✅ Uses key + password |
| Explicit key + file missing | ❌ Error | ❌ Error (unchanged) |
| Explicit key + file exists | ✅ Uses key | ✅ Uses key (unchanged) |

**Note on Password + Private Key Usage:**
Both `password` and `private_key` can be configured simultaneously:
- `private_key`: Used for SSH connection authentication
- `password`: Used for SSH authentication (fallback) AND sudo password when executing commands

This is a common and recommended setup when using non-root users for Kubernetes cluster deployment.

### Does this PR introduced a user-facing change?

```release-note
Fix SSH connector to gracefully handle missing default private key file (~/.ssh/id_rsa) when using password-only authentication. Password-only auth now works without requiring the default SSH key file to exist.
```

### Additional documentation, usage docs, etc.:

```docs
- [Design Document]: SSH_AUTH_FIX.md in repository root
```

**Example Configuration (Password-Only):**
```yaml
hosts:
  node1:
    connector:
      type: ssh
      host: 192.168.1.100
      user: root
      password: mypassword
      # No private_key specified - will use password auth if default key doesn't exist
```

**Example Configuration (Key + Sudo Password):**
```yaml
hosts:
  node1:
    connector:
      type: ssh
      host: 192.168.1.100
      user: deploy              # Non-root user
      private_key: ~/.ssh/id_rsa
      password: sudopassword     # Used for sudo commands
```
