### PR TITLE
Refactor etcd role conditions in playbooks and tasks

### DIFF
--- a/builtin/core/playbooks/add_nodes.yaml
+++ b/builtin/core/playbooks/add_nodes.yaml
@@ -35,7 +35,8 @@
     - etcd
   gather_facts: true
   roles:
-    - etcd
+    - role: etcd
+      when: .etcd.deployment_type | eq "external"
 
 - hosts:
     - k8s_cluster

--- a/builtin/core/playbooks/create_cluster.yaml
+++ b/builtin/core/playbooks/create_cluster.yaml
@@ -34,7 +34,8 @@
 - hosts:
     - etcd
   roles:
-    - etcd
+    - role: etcd
+      when: .etcd.deployment_type | eq "external"
 
 # Install the private image registry
 - hosts:

--- a/builtin/core/playbooks/delete_cluster.yaml
+++ b/builtin/core/playbooks/delete_cluster.yaml
@@ -32,7 +32,9 @@
     - etcd
   roles:
     - role: uninstall/etcd
-      when: .delete.etcd
+      when: 
+        - .delete.etcd
+        - .etcd.deployment_type | eq "external"
 
 - hosts:
    - image_registry

--- a/builtin/core/playbooks/delete_nodes.yaml
+++ b/builtin/core/playbooks/delete_nodes.yaml
@@ -73,6 +73,7 @@
     - role: uninstall/etcd
       when: 
         - .delete.etcd
+        - .etcd.deployment_type | eq "external"
         - .delete_nodes | default list | has .inventory_hostname
 
 - hosts:

--- a/builtin/core/roles/etcd/tasks/main.yaml
+++ b/builtin/core/roles/etcd/tasks/main.yaml
@@ -10,7 +10,7 @@
 - name: ETCD | Expand the etcd cluster by adding new nodes if required
   when:
     - .installed_etcd | empty | not
-    - .need_installed_etcd | fromJson | empty | not
+    - .need_installed_etcd | empty | not
   include_tasks: expansion.yaml
 
 - name: ETCD | Install etcd and set up the backup service if not already present

--- a/builtin/core/roles/etcd/tasks/prepare.yaml
+++ b/builtin/core/roles/etcd/tasks/prepare.yaml
@@ -62,7 +62,7 @@
       (.etcd_install_version.error | empty | not)
       (and
         (.installed_etcd | empty | not)
-        (.need_installed_etcd | fromJson | empty | not)
+        (.need_installed_etcd | empty | not)
       )
   block:
     - name: Prepare | Copy CA certificate to etcd node


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

- Updated playbooks to use a consistent role definition format for etcd, adding conditional checks for external deployment types.
- Modified tasks in the etcd role to simplify condition checks for installation requirements.

This enhances clarity and maintainability of the playbook configurations.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
1. when etcd has installed, it will error in 
```yaml
.need_installed_etcd | fromJon | empty | not
```
2. https://github.com/kubesphere/kubekey/issues/2944#event-22665726777

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
