### PR TITLE
bug: Use uppercase for TAG variable in release workflow

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -43,10 +43,10 @@ jobs:
       - name: Upload Extra File
         run: |
           TAG=${{ steps.prepare.outputs.version }}
-          if [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            REGISTRY=docker.io/kubesphere TAG=$tag make generate
+          if [[ $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            REGISTRY=docker.io/kubesphere TAG=$TAG make generate
           else
-            REGISTRY=docker.io/kubespheredev TAG=$tag make generate
+            REGISTRY=docker.io/kubespheredev TAG=$TAG make generate
           fi
           sed -i "s/^LATEST_VERSION=.*/LATEST_VERSION=${TAG}/" hack/downloadKubekey.sh
           


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


### What this PR does / why we need it:
Fix typo in release workflow to inject correct image tags into infrastructure-components.yaml.


Currently, the Upload Extra File Step in the BuildReleaser Workflow uses `$tag` instead of `$TAG` when executing `make generate`. This is likely an error. As a result, regardless of the TAG value (`${{ steps.prepare.outputs.version }}`), the REGISTRY was set to `kubespheredev` and the TAG remained empty when running `make generate`.

This issue caused an ImagePullBackOff error when applying [infrastructure-components.yaml](https://github.com/kubesphere/kubekey/releases/download/v4.0.3/infrastructure-components.yaml).

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2998

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
None

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
