### PR TITLE
feat: new image specification

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -135,7 +135,7 @@ linters:
       alias:
         # oci
         - pkg: github.com/opencontainers/image-spec/specs-go/v1
-          alias: imagev1
+          alias: ocispec
         # kubekey
         - pkg: "github.com/kubesphere/kubekey/v4/pkg/const"
           alias: _const

--- a/builtin/core/playbooks/artifact_images.yaml
+++ b/builtin/core/playbooks/artifact_images.yaml
@@ -16,12 +16,10 @@
     - name: PullImage | Download container images
       tags: ["pull","image_registry"]
       image:
-        pull:
-          auths: "{{ .cri.registry.auths | toJson }}"
-          images_dir: >-
-            {{ .binary_dir }}/images/
-          manifests: "{{ .image_manifests | toJson }}"
-          skip_tls_verify: "{{ .cri.skip_tls_verify | default false }}"
+        src: "oci://{{ .module.image.reference.registry }}/{{ .module.image.reference.repository }}:{{ .module.image.reference.reference }}"
+        dest: "local://{{ .binary_dir }}/images/"
+        auths: "{{ .cri.registry.auths | toJson }}"
+        manifests: "{{ .image_manifests | toJson }}"
       when:
         - .image_manifests | default list | empty | not
         - .download.download_image
@@ -70,17 +68,15 @@
             fi
         - name: PushImage | Push images package to image registry
           image:
-            push:
-              auths:
-                - repo: "{{ .image_registry.auth.registry }}"
-                  username: "{{ .image_registry.auth.username }}"
-                  password: "{{ .image_registry.auth.password }}"
-                  insecure: true
-              images_dir: >-
-                {{ .binary_dir }}/images/
-              dest: >-
-                {{- if eq .module.image.src.reference.registry "registry.k8s.io" -}}
-                {{ .image_registry.auth.registry }}/registry.k8s.io/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
-                {{- else -}}
-                {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
-                {{- end -}}
+            auths:
+              - registry: "{{ .image_registry.auth.registry }}"
+                username: "{{ .image_registry.auth.username }}"
+                password: "{{ .image_registry.auth.password }}"
+                skip_tls_verify: true
+            src: "local://{{ .binary_dir }}/images/"
+            dest: >-
+              {{- if and (eq .module.image.reference.registry "registry.k8s.io") (.module.image.reference.repository | contains "/" | not) -}}
+              oci://{{ .image_registry.auth.registry }}/kubernetes/{{ .module.image.reference.repository }}:{{ .module.image.src.reference.reference }}
+              {{- else -}}
+              oci://{{ .image_registry.auth.registry }}/{{ .module.image.reference.repository }}:{{ .module.image.reference.reference }}
+              {{- end -}}

--- a/builtin/core/roles/copy/tasks/images.yaml
+++ b/builtin/core/roles/copy/tasks/images.yaml
@@ -1,12 +1,7 @@
 - name: Image | Ensure container images is available
   image:
-    copy:
-      from:
-        path: >-
-          {{ .binary_dir }}/images/
-        manifests: "{{ .image_manifests | toJson }}"
-      to:
-        path: >-
-          {{ .artifact_file_dir }}/kubekey/kubekey/images/
+    manifests: "{{ .image_manifests | toJson }}"
+    src: "local://{{ .binary_dir }}/images/"
+    dest: "local://{{ .artifact_file_dir }}/kubekey/kubekey/images/"
   when:
     - .image_manifests | default list | empty | not

--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -76,24 +76,24 @@ state = "/run/containerd"
   {{- if .image_registry.auth.key_file | empty | not }}
             key_file = "/etc/containerd/certs.d/{{ $registry_parts }}/server.key"
   {{- end }}
-            insecure_skip_verify = {{ .image_registry.auth.insecure | default true }}
+            insecure_skip_verify = {{ .image_registry.auth.skip_tls_verify | default true }}
 {{- end }}
 {{- if .cri.registry.auths | empty | not }}
   {{- range .cri.registry.auths }}
-    {{- $parts := .repo | splitList "/" | first }}
+    {{- $parts := .registry | splitList "/" | first }}
           [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $parts }}".auth]
             username = "{{ .username }}"
             password = "{{ .password }}"
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $parts  }}".tls]
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $parts }}".tls]
     {{- if .ca_file }}
             ca_file = {{ .ca_file }}
     {{- end }}
-    {{- if .crt_file }}
-            cert_file = {{ .crt_file }}
+    {{- if .cert_file }}
+            cert_file = {{ .cert_file }}
     {{- end }}
     {{- if .key_file }}
             key_file = {{ .key_file }}
     {{- end }}
-            insecure_skip_verify = {{ .insecure | default true }}
+            insecure_skip_verify = {{ .skip_tls_verify | default true }}
   {{- end }}
 {{- end }}

--- a/builtin/core/roles/cri/docker/templates/daemon.json
+++ b/builtin/core/roles/cri/docker/templates/daemon.json
@@ -10,12 +10,12 @@
   "registry-mirrors": {{ .cri.registry.mirrors | toJson }},
 {{- end }}
 {{- $insecure_registries := .cri.registry.insecure_registries | default list }} 
-{{- if and .image_registry.auth.insecure (.image_registry.auth.registry | empty | not) }}
+{{- if and .image_registry.auth.skip_tls_verify (.image_registry.auth.registry | empty | not) }}
   {{- $insecure_registries = append $insecure_registries .image_registry.auth.registry }}
 {{- end }}
 {{- range .cri.registry.auths | default list }}
-  {{- if and .insecure (.repo | empty | not) }}
-    {{- $insecure_registries = append $insecure_registries .repo }}
+  {{- if and .skip_tls_verify (.registry | empty | not) }}
+    {{- $insecure_registries = append $insecure_registries .registry }}
   {{- end }}
 {{- end }}
   "insecure-registries": {{ $insecure_registries | toJson }},

--- a/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
+++ b/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
@@ -28,7 +28,7 @@ image_registry:
       {{- end -}}
     username: admin
     password: Harbor12345
-    insecure: >-
+    skip_tls_verify: >-
       {{- if .image_registry.type | empty -}}
       true
       {{- end -}}

--- a/builtin/core/roles/defaults/defaults/main/04-cri.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cri.yaml
@@ -17,6 +17,16 @@ cri:
     mirrors: ["https://registry-1.docker.io"]
     insecure_registries: []
     auths: []
+    # such as:
+    # auths:
+    #   - registry: docker.io
+    #     username: MyDockerAccount
+    #     password: my_password
+    #     skip_tls_verify: true
+    #     ca_cert: /etc/docker/certs.d/docker.io/ca.crt
+    #     cert_file: /etc/docker/certs.d/docker.io/cert.crt
+    #     key_file: /etc/docker/certs.d/docker.io/key.crt
+
     
-  # skip tls verify when pulling images
+  # skip tls verify when pulling images to all auths
   skip_tls_verify: false

--- a/builtin/core/roles/download/tasks/images.yaml
+++ b/builtin/core/roles/download/tasks/images.yaml
@@ -1,16 +1,9 @@
 - name: Image | Download container images
   image:
-    pull:
-      platform: >-
-        {{- if .download.image_platform_all }}
-        *
-        {{- else }}
-        {{ .download.arch | toJson }}
-        {{- end -}}
-      auths: "{{ .cri.registry.auths | toJson }}"
-      images_dir: >-
-        {{ .binary_dir }}/images/
-      manifests: "{{ .image_manifests | toJson }}"
+    src: "oci://{{ .module.image.reference.registry }}/{{ .module.image.reference.repository }}:{{ .module.image.reference.reference }}"
+    dest: "local://{{ .binary_dir }}/images/"
+    auths: "{{ .cri.registry.auths | toJson }}"
+    manifests: "{{ .image_manifests | toJson }}"
   when:
     - .image_manifests | default list | empty | not
     - .download.download_image

--- a/builtin/core/roles/image-registry/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/tasks/main.yaml
@@ -44,17 +44,15 @@
 - name: ImageRegistry | Push images package to image registry
   run_once: true
   image:
-    push:
-      auths:
-        - repo: "{{ .image_registry.auth.registry }}"
-          username: "{{ .image_registry.auth.username }}"
-          password: "{{ .image_registry.auth.password }}"
-          insecure: true
-      images_dir: >-
-        {{ .binary_dir }}/images/
-      dest: >-
-        {{- if eq .module.image.src.reference.registry "registry.k8s.io" -}}
-        {{ .image_registry.auth.registry }}/registry.k8s.io/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
-        {{- else -}}
-        {{ .image_registry.auth.registry }}/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}
-        {{- end -}}
+    auths:
+      - registry: "{{ .image_registry.auth.registry }}"
+        username: "{{ .image_registry.auth.username }}"
+        password: "{{ .image_registry.auth.password }}"
+        skip_tls_verify: true
+    src: "local://{{ .binary_dir }}/images/"
+    dest: >-
+      {{- if and (eq .module.image.reference.registry "registry.k8s.io") (.module.image.reference.repository | contains "/" | not) -}}
+      oci://{{ .image_registry.auth.registry }}/kubernetes/{{ .module.image.reference.repository }}:{{ .module.image.src.reference.reference }}
+      {{- else -}}
+      oci://{{ .image_registry.auth.registry }}/{{ .module.image.reference.repository }}:{{ .module.image.reference.reference }}
+      {{- end -}}

--- a/builtin/core/roles/precheck/image-registry/network/tasks/main.yaml
+++ b/builtin/core/roles/precheck/image-registry/network/tasks/main.yaml
@@ -12,7 +12,7 @@
         check:
           cmd: >-
             /etc/kubekey/scripts/check.sh {{ .image_registry.auth.registry }} 
-                {{- if .image_registry.auth.insecure -}}
+                {{- if .image_registry.auth.skip_tls_verify -}}
                 {{ printf " --insecure  " }} 
                 {{- end -}}
                 {{- if .image_registry.auth.ca_file | empty | not -}}

--- a/docs/en/custom/modules/image.md
+++ b/docs/en/custom/modules/image.md
@@ -6,40 +6,36 @@ Pull images to local directory, push images to remote registry, or copy images b
 
 | Parameter | Description | Type | Required | Default |
 |-----------|-------------|------|----------|---------|
-| pull | Pull from remote registry to local directory | map | No | - |
-| pull.images_dir | Local directory for image storage | string | No | - |
-| pull.manifests | List of images to pull | string array | Yes | - |
-| pull.auths | Remote registry authentication | Object array | No | - |
-| pull.auths.repo | Registry address | string | No | - |
-| pull.auths.username | Username | string | No | - |
-| pull.auths.password | Password | string | No | - |
-| pull.auths.insecure | Whether to skip TLS verification | bool | No | - |
-| pull.auths.plain_http | Whether to use HTTP | bool | No | - |
-| pull.platform | Architecture list (e.g., amd64, arm64) | string array | No | - |
-| pull.skip_tls_verify | Default whether to skip TLS verification | bool | No | - |
-| push | Push from local directory to remote registry | map | No | - |
-| push.images_dir | Local directory for image storage | string | No | - |
-| push.auths | Remote registry authentication | Object array | No | - |
-| push.auths.repo / .username / .password / .insecure / .plain_http | Same as above | - | - | - |
-| push.skip_tls_verify | Default whether to skip TLS verification | bool | No | - |
-| push.src_pattern | Regex, filter images to push | string | No | - |
-| push.dest | Target image, supports [template syntax](../101-syntax.md) | string | No | - |
-| copy | Copy between file system / image registry | map | No | - |
-| copy.platform | Architecture list | string array | No | - |
-| copy.from | Source | map | No | - |
-| copy.from.path | Source directory path | string | No | - |
-| copy.from.manifests | Source image list | string array | No | - |
-| copy.to | Target | map | No | - |
-| copy.to.path | Target path | string | No | - |
-| copy.to.pattern | Regex, filter copy targets | string | No | - |
+| manifests | List of images to operate on | string array | Yes | - |
+| platform | Architecture list (e.g., ["linux/amd64", "linux/arm64"]) | string array | No | - |
+| policy | Policy for platform filtering: `strict` (all platforms must exist, otherwise error), `warn` (log warning if missing, but continue) | string | No | strict |
+| pattern | Regex pattern to match images | string | No | - |
+| auths | Registry authentication | Object array | No | - |
+| auths.repo | Registry address | string | No | - |
+| auths.username | Username | string | No | - |
+| auths.password | Password | string | No | - |
+| auths.insecure | Whether to skip TLS verification | bool | No | - |
+| auths.plain_http | Whether to use HTTP | bool | No | - |
+| src | Source image reference (remote registry or local directory, e.g., `docker.io/library/alpine:3.19` or `local:///var/lib/kubekey/images`) | string | No | - |
+| dest | Destination (local directory or remote registry, e.g., `local:///tmp/images/` or `hub.kubekey/library/alpine:3.19`) | string | No | - |
+| skip_tls_verify | Default whether to skip TLS verification | bool | No | - |
 
-**push.dest** available variables:
+**src/dest format:**
+- Remote registry: `registry/repository:tag` (e.g., `docker.io/library/alpine:3.19`)
+- Local directory: `local:///absolute/path` (e.g., `local:///var/lib/kubekey/images`)
+
+**Operation types (determined by src and dest):**
+- **pull**: `src` = remote registry, `dest` = local directory
+- **push**: `src` = local directory, `dest` = remote registry
+- **copy**: `src` = local directory, `dest` = local directory
+
+**Available variables for dest:**
 
 - `{{ .module.image.src.reference.registry }}`: registry
 - `{{ .module.image.src.reference.repository }}`: repository
 - `{{ .module.image.src.reference.reference }}`: reference (e.g., tag)
 
-**Local directory structure example**:
+**Local directory structure example:**
 
 ```text
 images_dir/
@@ -52,18 +48,18 @@ images_dir/
 
 ## Examples
 
-**1. Pull images**
+**1. Pull images from remote registry**
 
 ```yaml
 - name: pull images
   image:
-    pull:
-      images_dir: /tmp/images/
-      platform: [amd64, arm64]
-      manifests:
-        - "docker.io/kubesphere/ks-apiserver:v4.1.3"
-        - "docker.io/kubesphere/ks-controller-manager:v4.1.3"
-        - "docker.io/kubesphere/ks-console:3.19"
+    manifests:
+      - "docker.io/kubesphere/ks-apiserver:v4.1.3"
+      - "docker.io/kubesphere/ks-controller-manager:v4.1.3"
+    platform: [linux/amd64, linux/arm64]
+    policy: strict
+    src: "docker.io"
+    dest: "local:///tmp/images/"
 ```
 
 **2. Push images to remote registry**
@@ -71,26 +67,33 @@ images_dir/
 ```yaml
 - name: push images
   image:
-    push:
-      images_dir: /tmp/images/
-      dest: "hub.kubekey/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}"
+    manifests:
+      - "library/alpine:3.19"
+    src: "local:///tmp/images/"
+    dest: "hub.kubekey/{{ .module.image.src.reference.repository }}:{{ .module.image.src.reference.reference }}"
 ```
 
 For example:
 
-- `docker.io/kubesphere/ks-apiserver:v4.1.3` → `hub.kubekey/kubesphere/ks-apiserver:v4.1.3`
-- `docker.io/kubesphere/ks-console:3.19` → `hub.kubekey/kubesphere/ks-console:3.19`
+- `library/alpine:3.19` → `hub.kubekey/library/alpine:3.19`
 
-**3. Copy images between file systems**
+**3. Copy images between local directories**
 
 ```yaml
-- name: file to file
+- name: copy images
   image:
-    copy:
-      from:
-        path: /tmp/images/
-        manifests:
-          - docker.io/calico/apiserver:v3.28.2
-      to:
-        path: /tmp/others/images/
+    manifests:
+      - "docker.io/calico/apiserver:v3.28.2"
+    src: "local:///tmp/images/"
+    dest: "local:///tmp/others/images/"
+```
+
+**4. Copy images with regex pattern**
+
+```yaml
+- name: copy images with pattern
+  image:
+    pattern: ".*calico.*"
+    src: "local:///tmp/images/"
+    dest: "local:///tmp/others/images/"
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/cockroachdb/errors v1.12.0
 	github.com/containerd/containerd v1.7.30
 	github.com/emicklei/go-restful-openapi/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/hack/verify-goimports.sh
+++ b/hack/verify-goimports.sh
@@ -47,6 +47,6 @@ if [ "${output}" != "" ]; then
     echo "The following files are not import formatted"
     printf '%s\n' "${output[@]}"
     echo "Please run the following command:"
-    echo "make goimports"
+    echo "make generate-goimports"
     exit 1
 fi

--- a/pkg/modules/image/image_deprecated.go
+++ b/pkg/modules/image/image_deprecated.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2024 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"regexp"
+
+	"github.com/cockroachdb/errors"
+	"k8s.io/utils/ptr"
+
+	"github.com/kubesphere/kubekey/v4/pkg/variable"
+)
+
+// Deprecated: Use the new configuration format (src/dest/manifests) instead.
+// oldImagePullArgs contains parameters for pulling images from remote registries to local directories.
+// This struct is maintained for backward compatibility with older configuration formats.
+type oldImagePullArgs struct {
+	imagesDir     string
+	manifests     []string
+	skipTLSVerify *bool
+	platform      []string
+	auths         []imageAuth
+}
+
+// Deprecated: Use the new configuration format (src/dest/manifests) instead.
+// oldImagePushArgs contains parameters for pushing images from local directories to remote registries.
+// This struct is maintained for backward compatibility with older configuration formats.
+type oldImagePushArgs struct {
+	imagesDir     string
+	skipTLSVerify *bool
+	srcPattern    *regexp.Regexp
+	destTmpl      string
+	auths         []imageAuth
+}
+
+// Deprecated: Use the new configuration format (src/dest/manifests) instead.
+// oldImageCopyArgs contains parameters for copying images between local directories.
+// This struct is maintained for backward compatibility with older configuration formats.
+type oldImageCopyArgs struct {
+	Platform []string               `json:"platform"`
+	From     oldImageCopyTargetArgs `json:"from"`
+	To       oldImageCopyTargetArgs `json:"to"`
+}
+
+// Deprecated: Use the new configuration format (src/dest/manifests) instead.
+// oldImageCopyTargetArgs contains the source or destination configuration for image copy operations.
+// This struct is maintained for backward compatibility with older configuration formats.
+type oldImageCopyTargetArgs struct {
+	Path      string `json:"path"`
+	manifests []string
+	Pattern   *regexp.Regexp
+}
+
+// transferPull parses deprecated "pull" configuration arguments and converts them to the new imageArgs format.
+// Old format: pull images from remote registry to local directory
+// New format: src = remote reference (oci://), dest = local directory (local://)
+func transferPull(pullArgs any, vars map[string]any) (*imageArgs, error) {
+	pull, ok := pullArgs.(map[string]any)
+	if !ok {
+		return nil, errors.New("\"pull\" should be map")
+	}
+
+	ipl := &oldImagePullArgs{}
+	ipl.manifests, _ = variable.StringSliceVar(vars, pull, "manifests")
+	ipl.auths = make([]imageAuth, 0)
+	pullAuths := make([]imageAuth, 0)
+	_ = variable.AnyVar(vars, pull, &pullAuths, "auths")
+	ipl.auths = append(ipl.auths, pullAuths...)
+
+	ipl.imagesDir, _ = variable.StringVar(vars, pull, "images_dir")
+	ipl.skipTLSVerify, _ = variable.BoolVar(vars, pull, "skip_tls_verify")
+	if ipl.skipTLSVerify == nil {
+		ipl.skipTLSVerify = ptr.To(false)
+	}
+	ipl.platform, _ = variable.StringSliceVar(vars, pull, "platform")
+
+	// Validate required fields
+	if len(ipl.manifests) == 0 {
+		return nil, errors.New("\"pull.manifests\" is required")
+	}
+
+	// Convert to new format
+	ia := &imageArgs{
+		manifests: ipl.manifests,
+		platform:  ipl.platform,
+		auths:     ipl.auths,
+		src:       "oci://{{ .module.image.reference }}/{{ .module.image.reference.repository }}:{{ .module.image.reference.reference }}",
+		dest:      "local://" + ipl.imagesDir,
+	}
+
+	return ia, nil
+}
+
+// transferPush parses deprecated "push" configuration arguments and converts them to the new imageArgs format.
+// Old format: push images from local directory to remote registry
+// New format: src = local directory (local://), dest = remote reference (oci://)
+func transferPush(pushArgs any, vars map[string]any) (*imageArgs, error) {
+	push, ok := pushArgs.(map[string]any)
+	if !ok {
+		return nil, errors.New("\"push\" should be map")
+	}
+
+	ips := &oldImagePushArgs{}
+	ips.auths = make([]imageAuth, 0)
+	pushAuths := make([]imageAuth, 0)
+	_ = variable.AnyVar(vars, push, &pushAuths, "auths")
+	ips.auths = append(ips.auths, pushAuths...)
+
+	ips.imagesDir, _ = variable.StringVar(vars, push, "images_dir")
+	srcPattern, _ := variable.StringVar(vars, push, "src_pattern")
+	destTmpl, _ := variable.PrintVar(push, "dest")
+	ips.skipTLSVerify, _ = variable.BoolVar(vars, push, "skip_tls_verify")
+	if ips.skipTLSVerify == nil {
+		ips.skipTLSVerify = ptr.To(false)
+	}
+
+	// Validate required fields
+	if srcPattern != "" {
+		pattern, err := regexp.Compile(srcPattern)
+		if err != nil {
+			return nil, errors.Wrap(err, "\"push.src\" should be a valid regular expression. ")
+		}
+		ips.srcPattern = pattern
+	}
+	if destStr, ok := destTmpl.(string); !ok {
+		return nil, errors.New("\"push.dest\" must be a string")
+	} else if destStr == "" {
+		return nil, errors.New("\"push.dest\" should not be empty")
+	} else {
+		ips.destTmpl = destStr
+	}
+
+	// Convert to new format
+	ia := &imageArgs{
+		src:     "local://" + ips.imagesDir,
+		dest:    "oci://" + ips.destTmpl,
+		pattern: ips.srcPattern,
+		auths:   ips.auths,
+	}
+	if ips.skipTLSVerify != nil {
+		for i := range ia.auths {
+			ia.auths[i].SkipTLSVerify = ips.skipTLSVerify
+		}
+	}
+
+	return ia, nil
+}
+
+// transferCopy parses deprecated "copy" configuration arguments and converts them to the new imageArgs format.
+// Old format: copy images from local directory to local directory
+// New format: src = local directory (local://), dest = local directory (local://)
+func transferCopy(copyArgs any, vars map[string]any) (*imageArgs, error) {
+	cp, ok := copyArgs.(map[string]any)
+	if !ok {
+		return nil, errors.New("\"copy\" should be map")
+	}
+
+	cps := &oldImageCopyArgs{}
+
+	cps.Platform, _ = variable.StringSliceVar(vars, cp, "platform")
+
+	cps.From.manifests, _ = variable.StringSliceVar(vars, cp, "from", "manifests")
+
+	cps.From.Path, _ = variable.StringVar(vars, cp, "from", "path")
+
+	toPath, _ := variable.PrintVar(cp, "to", "path")
+	if destStr, ok := toPath.(string); !ok {
+		return nil, errors.New("\"copy.to.path\" must be a string")
+	} else if destStr == "" {
+		return nil, errors.New("\"copy.to.path\" should not be empty")
+	} else {
+		cps.To.Path = destStr
+	}
+	srcPattern, _ := variable.StringVar(vars, cp, "to", "src_pattern")
+	if srcPattern != "" {
+		pattern, err := regexp.Compile(srcPattern)
+		if err != nil {
+			return nil, errors.Wrap(err, "\"to.pattern\" should be a valid regular expression. ")
+		}
+		cps.From.Pattern = pattern
+	}
+
+	// Convert to new format
+	ia := &imageArgs{
+		src:       "local://" + cps.From.Path,
+		dest:      "local://" + cps.To.Path,
+		platform:  cps.Platform,
+		manifests: cps.From.manifests,
+		pattern:   cps.From.Pattern,
+	}
+
+	return ia, nil
+}

--- a/pkg/modules/image/image_test.go
+++ b/pkg/modules/image/image_test.go
@@ -19,6 +19,7 @@ package image
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"testing"
 	"time"
 
@@ -159,4 +160,530 @@ func TestImageModule(t *testing.T) {
 	t.Run("module exists", func(t *testing.T) {
 		require.NotNil(t, ModuleImage)
 	})
+}
+
+// TestNormalizeImageName tests the normalizeImageName function with various image name formats.
+func TestNormalizeImageName(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "official image without registry",
+			input:    "ubuntu",
+			expected: "docker.io/library/ubuntu",
+		},
+		{
+			name:     "official image with version",
+			input:    "nginx:latest",
+			expected: "docker.io/library/nginx:latest",
+		},
+		{
+			name:     "image with project - not recognized as host",
+			input:    "project/xx",
+			expected: "project/xx",
+		},
+		{
+			name:     "image with registry hostname",
+			input:    "registry.example.com/image",
+			expected: "registry.example.com/image",
+		},
+		{
+			name:     "image with registry hostname and port - treated as project",
+			input:    "registry.example.com:5000/image",
+			expected: "docker.io/registry.example.com:5000/image",
+		},
+		{
+			name:     "image with registry and project",
+			input:    "registry.example.com/project/image",
+			expected: "registry.example.com/project/image",
+		},
+		{
+			name:     "image with library prefix (should keep as is)",
+			input:    "docker.io/library/ubuntu",
+			expected: "docker.io/library/ubuntu",
+		},
+		{
+			name:     "ghcr.io image",
+			input:    "ghcr.io/owner/image",
+			expected: "ghcr.io/owner/image",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := normalizeImageName(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestComputeDigest tests the computeDigest function.
+func TestComputeDigest(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "empty bytes",
+			input:    []byte{},
+			expected: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:     "hello world",
+			input:    []byte("hello world"),
+			expected: "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		},
+		{
+			name:     "test content",
+			input:    []byte("test content"),
+			expected: "sha256:9a025e176209010c11cdbb7c6e653e4c36e41eb1a7f2a6a9e9e4c6e8b1a5c3d",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := computeDigest(tc.input)
+			// Verify the format is correct (sha256:...)
+			require.True(t, len(result) > 7 && result[:7] == "sha256:", "digest should start with sha256:")
+			// Verify it's a valid hex string after sha256:
+			require.Len(t, result, 7+64, "SHA256 digest should be 64 hex characters")
+		})
+	}
+}
+
+// TestImageArgsComplete tests the imageArgs.complete() method validation.
+func TestImageArgsComplete(t *testing.T) {
+	testcases := []struct {
+		name        string
+		ia          *imageArgs
+		expectError bool
+		errorMsg    string
+		description string
+	}{
+		{
+			name: "valid args with src and dest",
+			ia: &imageArgs{
+				manifests: []string{"nginx:latest"},
+				src:       "oci://docker.io/library/nginx:latest",
+				dest:      "local:///var/lib/kubekey/images",
+			},
+			expectError: false,
+			description: "Valid src and dest should pass validation",
+		},
+		{
+			name: "valid args with absolute local paths",
+			ia: &imageArgs{
+				src:  "local:///absolute/path",
+				dest: "local:///another/path",
+			},
+			expectError: false,
+			description: "Absolute local paths should pass validation",
+		},
+		{
+			name: "invalid relative local path in src",
+			ia: &imageArgs{
+				src: "local://relative/path",
+			},
+			expectError: true,
+			errorMsg:    "local path must be an absolute path",
+			description: "Relative local path should fail validation",
+		},
+		{
+			name: "invalid relative local path in dest",
+			ia: &imageArgs{
+				dest: "local://relative/path",
+			},
+			expectError: true,
+			errorMsg:    "local path must be an absolute path",
+			description: "Relative local path in dest should fail validation",
+		},
+		{
+			name: "empty manifests with empty src and dest",
+			ia: &imageArgs{
+				manifests: []string{},
+				src:       "",
+				dest:      "",
+			},
+			expectError: true,
+			errorMsg:    "either \"manifests\" or \"src\"/\"dest\" must be specified",
+			description: "Empty manifests with no src/dest should fail validation",
+		},
+		{
+			name: "valid args with only manifests",
+			ia: &imageArgs{
+				manifests: []string{"nginx:latest", "redis:7"},
+			},
+			expectError: false,
+			description: "Only manifests specified should pass validation",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.ia.complete()
+			if tc.expectError {
+				require.Error(t, err, tc.description)
+				if tc.errorMsg != "" {
+					require.Contains(t, err.Error(), tc.errorMsg, "error message should contain expected text")
+				}
+			} else {
+				require.NoError(t, err, tc.description)
+			}
+		})
+	}
+}
+
+// TestTransferPull tests the transferPull function for deprecated format conversion.
+func TestTransferPull(t *testing.T) {
+	testcases := []struct {
+		name        string
+		pullArgs    map[string]any
+		vars        map[string]any
+		expectError bool
+		description string
+	}{
+		{
+			name: "valid pull args",
+			pullArgs: map[string]any{
+				"manifests":  []string{"nginx:latest", "redis:7"},
+				"images_dir": "/var/lib/kubekey/images",
+				"auths": []map[string]any{
+					{"registry": "docker.io", "username": "user", "password": "pass"},
+				},
+			},
+			vars:        map[string]any{},
+			expectError: false,
+			description: "Valid pull args should be converted successfully",
+		},
+		{
+			name: "missing manifests",
+			pullArgs: map[string]any{
+				"images_dir": "/var/lib/kubekey/images",
+			},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Missing manifests should return error",
+		},
+		{
+			name:        "empty pull args",
+			pullArgs:    map[string]any{},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Empty pull args should return error",
+		},
+		{
+			name:        "invalid pull args type",
+			pullArgs:    map[string]any{"invalid": "type"},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Non-map pull args should return error",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := transferPull(tc.pullArgs, tc.vars)
+			if tc.expectError {
+				require.Error(t, err, tc.description)
+			} else {
+				require.NoError(t, err, tc.description)
+				require.NotNil(t, result, "result should not be nil")
+			}
+		})
+	}
+}
+
+// TestTransferPush tests the transferPush function for deprecated format conversion.
+func TestTransferPush(t *testing.T) {
+	testcases := []struct {
+		name        string
+		pushArgs    map[string]any
+		vars        map[string]any
+		expectError bool
+		description string
+	}{
+		{
+			name: "valid push args",
+			pushArgs: map[string]any{
+				"images_dir":  "/var/lib/kubekey/images",
+				"src_pattern": ".*",
+				"dest":        "registry.example.com/{{ .image }}",
+			},
+			vars:        map[string]any{},
+			expectError: false,
+			description: "Valid push args should be converted successfully",
+		},
+		{
+			name: "missing dest",
+			pushArgs: map[string]any{
+				"images_dir": "/var/lib/kubekey/images",
+			},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Missing dest should return error",
+		},
+		{
+			name:        "invalid push args type",
+			pushArgs:    map[string]any{"invalid": "type"},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Non-map push args should return error",
+		},
+		{
+			name: "invalid regex pattern",
+			pushArgs: map[string]any{
+				"images_dir":  "/var/lib/kubekey/images",
+				"src_pattern": "[invalid",
+				"dest":        "registry.example.com/image",
+			},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Invalid regex pattern should return error",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := transferPush(tc.pushArgs, tc.vars)
+			if tc.expectError {
+				require.Error(t, err, tc.description)
+			} else {
+				require.NoError(t, err, tc.description)
+				require.NotNil(t, result, "result should not be nil")
+			}
+		})
+	}
+}
+
+// TestTransferCopy tests the transferCopy function for deprecated format conversion.
+func TestTransferCopy(t *testing.T) {
+	testcases := []struct {
+		name        string
+		copyArgs    map[string]any
+		vars        map[string]any
+		expectError bool
+		description string
+	}{
+		{
+			name: "valid copy args",
+			copyArgs: map[string]any{
+				"from": map[string]any{
+					"path":      "/source/path",
+					"manifests": []string{"image1", "image2"},
+				},
+				"to": map[string]any{
+					"path": "/dest/path",
+				},
+			},
+			vars:        map[string]any{},
+			expectError: false,
+			description: "Valid copy args should be converted successfully",
+		},
+		{
+			name: "missing from path - returns empty path",
+			copyArgs: map[string]any{
+				"to": map[string]any{
+					"path": "/dest/path",
+				},
+			},
+			vars:        map[string]any{},
+			expectError: false,
+			description: "Missing from path returns empty path (not an error in current implementation)",
+		},
+		{
+			name: "missing to path",
+			copyArgs: map[string]any{
+				"from": map[string]any{
+					"path": "/source/path",
+				},
+			},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Missing to path should return error",
+		},
+		{
+			name:        "invalid copy args type",
+			copyArgs:    map[string]any{"invalid": "type"},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Non-map copy args should return error",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := transferCopy(tc.copyArgs, tc.vars)
+			if tc.expectError {
+				require.Error(t, err, tc.description)
+			} else {
+				require.NoError(t, err, tc.description)
+				require.NotNil(t, result, "result should not be nil")
+			}
+		})
+	}
+}
+
+// TestImageArgsNewFormat tests the newImageArgs function with new format configuration.
+func TestImageArgsNewFormat(t *testing.T) {
+	testcases := []struct {
+		name        string
+		args        map[string]any
+		vars        map[string]any
+		expectError bool
+		description string
+	}{
+		{
+			name: "new format with src and dest",
+			args: map[string]any{
+				"manifests": []string{"nginx:latest"},
+				"src":       "oci://docker.io/library/nginx:latest",
+				"dest":      "local:///var/lib/kubekey/images",
+				"platform":  []string{"linux/amd64"},
+			},
+			vars:        map[string]any{},
+			expectError: false,
+			description: "New format with src/dest should parse successfully",
+		},
+		{
+			name: "new format with pattern",
+			args: map[string]any{
+				"src":     "local:///source",
+				"dest":    "local:///dest",
+				"pattern": ".*nginx.*",
+			},
+			vars:        map[string]any{},
+			expectError: false,
+			description: "New format with pattern should parse successfully",
+		},
+		{
+			name: "invalid pattern regex",
+			args: map[string]any{
+				"src":     "local:///source",
+				"dest":    "local:///dest",
+				"pattern": "[invalid",
+			},
+			vars:        map[string]any{},
+			expectError: true,
+			description: "Invalid pattern regex should return error",
+		},
+		{
+			name: "new format with auths",
+			args: map[string]any{
+				"manifests": []string{"nginx:latest"},
+				"src":       "oci://registry.example.com/image",
+				"dest":      "local:///images",
+				"auths": []map[string]any{
+					{"registry": "registry.example.com", "username": "admin", "password": "secret"},
+				},
+			},
+			vars:        map[string]any{},
+			expectError: false,
+			description: "New format with auths should parse successfully",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := createRawArgs(tc.args)
+			result, err := newImageArgs(context.Background(), raw, tc.vars)
+			if tc.expectError {
+				require.Error(t, err, tc.description)
+			} else {
+				require.NoError(t, err, tc.description)
+				require.NotNil(t, result, "result should not be nil")
+			}
+		})
+	}
+}
+
+// TestImageArgsPattern tests the pattern matching functionality in imageArgs.
+func TestImageArgsPattern(t *testing.T) {
+	testcases := []struct {
+		name     string
+		pattern  string
+		images   []string
+		expected []string
+	}{
+		{
+			name:     "match all images",
+			pattern:  ".*",
+			images:   []string{"nginx:latest", "redis:7", "ubuntu:22.04"},
+			expected: []string{"nginx:latest", "redis:7", "ubuntu:22.04"},
+		},
+		{
+			name:     "match nginx only",
+			pattern:  "nginx.*",
+			images:   []string{"nginx:latest", "nginx:alpine", "redis:7"},
+			expected: []string{"nginx:latest", "nginx:alpine"},
+		},
+		{
+			name:     "match specific version",
+			pattern:  ".*:latest",
+			images:   []string{"nginx:latest", "redis:7", "ubuntu:latest"},
+			expected: []string{"nginx:latest", "ubuntu:latest"},
+		},
+		{
+			name:     "no match",
+			pattern:  "^redis.*",
+			images:   []string{"nginx:latest", "ubuntu:22.04"},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Compile pattern
+			pattern, err := regexp.Compile(tc.pattern)
+			require.NoError(t, err, "pattern should be valid")
+
+			// Filter images
+			var filtered []string
+			for _, img := range tc.images {
+				if pattern.MatchString(img) {
+					filtered = append(filtered, img)
+				}
+			}
+
+			require.Equal(t, tc.expected, filtered)
+		})
+	}
+}
+
+// TestImageAuth tests the imageAuth struct functionality.
+func TestImageAuth(t *testing.T) {
+	testcases := []struct {
+		name         string
+		auth         imageAuth
+		expectedJSON string
+	}{
+		{
+			name: "auth with all fields",
+			auth: imageAuth{
+				Registry:      "docker.io",
+				Username:      "user",
+				Password:      "pass",
+				SkipTLSVerify: func(b bool) *bool { return &b }(false),
+				PlainHTTP:     func(b bool) *bool { return &b }(false),
+			},
+			expectedJSON: `{"registry":"docker.io","username":"user","password":"pass","skip_tls_verify":false,"plain_http":false}`,
+		},
+		{
+			name: "auth with minimal fields",
+			auth: imageAuth{
+				Registry: "registry.example.com",
+			},
+			expectedJSON: `{"registry":"registry.example.com","username":"","password":"","skip_tls_verify":null,"plain_http":null}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonBytes, err := json.Marshal(tc.auth)
+			require.NoError(t, err, "marshaling should succeed")
+			require.JSONEq(t, tc.expectedJSON, string(jsonBytes))
+		})
+	}
 }

--- a/pkg/modules/image/repository.go
+++ b/pkg/modules/image/repository.go
@@ -1,0 +1,378 @@
+// Package image provides functionality for managing container image operations in KubeKey.
+// This file contains repository-related code for handling both remote OCI registries and local
+// directory storage of container images.
+//
+// The repository module supports:
+// - Remote registry connections with authentication
+// - Local directory-based image storage (OCI layout)
+// - HTTP transport layer for local image operations
+package image
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"k8s.io/klog/v2"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+// repoCache caches *remote.Repository instances per local directory path.
+// This improves performance by reusing repository connections for the same local directory.
+var repoCache sync.Map
+
+// newRepository creates a remote repository handle for image operations.
+// It determines whether the URL refers to a local directory or remote registry
+// and creates the appropriate repository instance with authentication.
+func newRepository(url, img string, auths []imageAuth) (*remote.Repository, error) {
+	if strings.HasPrefix(url, "local://") {
+		// Source is local directory
+		return newLocalRepository(img, strings.TrimPrefix(url, "local://"))
+	} else if strings.HasPrefix(url, "oci://") {
+		// Source is remote registry
+		return newRemoteRepository(img, auths)
+	} else {
+		return nil, errors.New("invalid source image reference")
+	}
+
+}
+
+// newRemoteRepository creates a remote repository connection to an OCI registry.
+// It configures the repository with authentication credentials, TLS settings,
+// and HTTP options based on the provided auth configuration.
+func newRemoteRepository(reference string, auths []imageAuth) (*remote.Repository, error) {
+	repository, err := remote.NewRepository(reference)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get remote repository %q", reference)
+	}
+	// Find matching auth for this host
+	var matchedAuth *imageAuth
+	for i := range auths {
+		if strings.Split(auths[i].Registry, "/")[0] == reference {
+			matchedAuth = &auths[i]
+			break
+		}
+	}
+
+	// Get TLS and HTTP settings from matched auth, use defaults if not found
+	skipTLSVerify := false
+	plainHTTP := false
+	if matchedAuth != nil {
+		if matchedAuth.SkipTLSVerify != nil {
+			skipTLSVerify = *matchedAuth.SkipTLSVerify
+		}
+		if matchedAuth.PlainHTTP != nil {
+			plainHTTP = *matchedAuth.PlainHTTP
+		}
+	}
+
+	repository.Client = &auth.Client{
+		Client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: skipTLSVerify,
+				},
+			},
+		},
+		Cache: auth.NewCache(),
+		Credential: func(_ context.Context, hostport string) (auth.Credential, error) {
+			if matchedAuth != nil {
+				return auth.Credential{
+					Username: matchedAuth.Username,
+					Password: matchedAuth.Password,
+				}, nil
+			}
+			return auth.Credential{}, nil
+		},
+	}
+	repository.PlainHTTP = plainHTTP
+	return repository, nil
+}
+
+// newLocalRepository creates a repository handle for local directory-based image storage.
+// It implements an OCI layout-compatible storage backend using a custom HTTP transport.
+// The repository is cached per local directory to improve performance.
+func newLocalRepository(reference, localDir string) (*remote.Repository, error) {
+	// Try to get from cache
+	if cached, ok := repoCache.Load(localDir); ok {
+		repo := cached.(*remote.Repository)
+		// Update reference in case it changed
+		ref, err := registry.ParseReference(reference)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse reference %q", reference)
+		}
+		repo.Reference = ref
+		return repo, nil
+	}
+
+	// Create new repository
+	ref, err := registry.ParseReference(reference)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse reference %q", reference)
+	}
+
+	repo := &remote.Repository{
+		Reference: ref,
+		Client:    &http.Client{Transport: &imageTransport{baseDir: localDir}},
+	}
+
+	// Store in cache
+	repoCache.Store(localDir, repo)
+
+	return repo, nil
+}
+
+var responseNotFound = &http.Response{Proto: "Local", StatusCode: http.StatusNotFound}
+var responseNotAllowed = &http.Response{Proto: "Local", StatusCode: http.StatusMethodNotAllowed}
+var responseServerError = &http.Response{Proto: "Local", StatusCode: http.StatusInternalServerError}
+var responseCreated = &http.Response{Proto: "Local", StatusCode: http.StatusCreated}
+var responseOK = &http.Response{Proto: "Local", StatusCode: http.StatusOK}
+
+// const domain = "internal"
+const apiPrefix = "/v2/"
+
+type imageTransport struct {
+	baseDir string
+}
+
+// RoundTrip handles HTTP requests for local directory-based image storage.
+// It routes requests to appropriate handlers based on the HTTP method (HEAD, GET, POST, PUT).
+func (i imageTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	var resp *http.Response
+
+	switch request.Method {
+	case http.MethodHead:
+		resp = i.head(request)
+	case http.MethodPost:
+		resp = i.post(request)
+	case http.MethodPut:
+		resp = i.put(request)
+	case http.MethodGet:
+		resp = i.get(request)
+	default:
+		resp = responseNotAllowed
+	}
+
+	if resp != nil {
+		resp.Request = request
+	}
+
+	return resp, nil
+}
+
+// head handles HTTP HEAD requests for checking the existence of blobs and manifests
+// in the local directory storage.
+func (i imageTransport) head(request *http.Request) *http.Response {
+	if strings.HasSuffix(filepath.Dir(request.URL.Path), "blobs") { // blobs
+		filename := filepath.Join(i.baseDir, "blobs", filepath.Base(request.URL.Path))
+		if _, err := os.Stat(filename); err != nil {
+			klog.V(4).ErrorS(err, "failed to stat blobs", "filename", filename)
+
+			return responseNotFound
+		}
+
+		return responseOK
+	} else if strings.HasSuffix(filepath.Dir(request.URL.Path), "manifests") { // manifests
+		filename := filepath.Join(i.baseDir, request.Host, strings.TrimPrefix(request.URL.Path, apiPrefix))
+		if _, err := os.Stat(filename); err != nil {
+			klog.V(4).ErrorS(err, "failed to stat blobs", "filename", filename)
+
+			return responseNotFound
+		}
+
+		file, err := os.ReadFile(filename)
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to read file", "filename", filename)
+
+			return responseServerError
+		}
+
+		var data map[string]any
+		if err := json.Unmarshal(file, &data); err != nil {
+			klog.V(4).ErrorS(err, "failed to unmarshal file", "filename", filename)
+
+			return responseServerError
+		}
+
+		mediaType, ok := data["mediaType"].(string)
+		if !ok {
+			klog.V(4).ErrorS(nil, "unknown mediaType", "filename", filename)
+
+			return responseServerError
+		}
+
+		return &http.Response{
+			Proto:      "Local",
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{mediaType},
+			},
+			ContentLength: int64(len(file)),
+		}
+	}
+
+	return responseNotAllowed
+}
+
+// post handles HTTP POST requests for initiating blob uploads.
+// Returns an accepted response with the upload location.
+func (i imageTransport) post(request *http.Request) *http.Response {
+	if strings.HasSuffix(request.URL.Path, "/uploads/") {
+		return &http.Response{
+			Proto:      "Local",
+			StatusCode: http.StatusAccepted,
+			Header: http.Header{
+				"Location": []string{filepath.Dir(request.URL.Path)},
+			},
+			Request: request,
+		}
+	}
+
+	return responseNotAllowed
+}
+
+// put handles HTTP PUT requests for uploading blobs and manifests to local directory storage.
+// It creates files in the blobs directory or manifests directory based on the request path.
+func (i imageTransport) put(request *http.Request) *http.Response {
+	if strings.HasSuffix(request.URL.Path, "/uploads") { // blobs
+		defer request.Body.Close()
+
+		filename := filepath.Join(i.baseDir, "blobs", request.URL.Query().Get("digest"))
+		if err := os.MkdirAll(filepath.Dir(filename), os.ModePerm); err != nil {
+			klog.V(4).ErrorS(err, "failed to create dir", "dir", filepath.Dir(filename))
+
+			return responseServerError
+		}
+
+		file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to create file", "filename", filename)
+			return responseServerError
+		}
+
+		defer func() {
+			if err = file.Sync(); err != nil {
+				klog.V(4).ErrorS(err, "failed to sync file", "filename", filename)
+			}
+			if err = file.Close(); err != nil {
+				klog.V(4).ErrorS(err, "failed to close file", "filename", filename)
+			}
+		}()
+
+		if _, err = io.Copy(file, request.Body); err != nil {
+			klog.V(4).ErrorS(err, "failed to write file", "filename", filename)
+
+			return responseServerError
+		}
+
+		return responseCreated
+	} else if strings.HasSuffix(filepath.Dir(request.URL.Path), "/manifests") { // manifests
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to read request")
+
+			return responseServerError
+		}
+		defer request.Body.Close()
+
+		filename := filepath.Join(i.baseDir, request.Host, strings.TrimPrefix(request.URL.Path, apiPrefix))
+		if err := os.MkdirAll(filepath.Dir(filename), os.ModePerm); err != nil {
+			klog.V(4).ErrorS(err, "failed to create dir", "dir", filepath.Dir(filename))
+
+			return responseServerError
+		}
+
+		if err := os.WriteFile(filename, body, os.ModePerm); err != nil {
+			klog.V(4).ErrorS(err, "failed to write file", "filename", filename)
+
+			return responseServerError
+		}
+
+		return responseCreated
+	}
+
+	return responseNotAllowed
+}
+
+// get handles HTTP GET requests for retrieving blobs and manifests from local directory storage.
+func (i imageTransport) get(request *http.Request) *http.Response {
+	if strings.HasSuffix(filepath.Dir(request.URL.Path), "blobs") { // blobs
+		filename := filepath.Join(i.baseDir, "blobs", filepath.Base(request.URL.Path))
+		if _, err := os.Stat(filename); err != nil {
+			klog.V(4).ErrorS(err, "failed to stat blobs", "filename", filename)
+
+			return responseNotFound
+		}
+
+		file, err := os.Open(filename)
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to read file", "filename", filename)
+
+			return responseServerError
+		}
+
+		fStat, err := file.Stat()
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to read file", "filename", filename)
+
+			return responseServerError
+		}
+
+		return &http.Response{
+			Proto:         "Local",
+			StatusCode:    http.StatusOK,
+			ContentLength: fStat.Size(),
+			Body:          file,
+		}
+	} else if strings.HasSuffix(filepath.Dir(request.URL.Path), "manifests") { // manifests
+		filename := filepath.Join(i.baseDir, request.Host, strings.TrimPrefix(request.URL.Path, apiPrefix))
+		if _, err := os.Stat(filename); err != nil {
+			klog.V(4).ErrorS(err, "failed to stat blobs", "filename", filename)
+
+			return responseNotFound
+		}
+
+		file, err := os.ReadFile(filename)
+		if err != nil {
+			klog.V(4).ErrorS(err, "failed to read file", "filename", filename)
+
+			return responseServerError
+		}
+
+		var data map[string]any
+		if err := json.Unmarshal(file, &data); err != nil {
+			klog.V(4).ErrorS(err, "failed to unmarshal file data", "filename", filename)
+
+			return responseServerError
+		}
+
+		mediaType, ok := data["mediaType"].(string)
+		if !ok {
+			klog.V(4).ErrorS(nil, "unknown mediaType", "filename", filename)
+
+			return responseServerError
+		}
+
+		return &http.Response{
+			Proto:      "Local",
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{mediaType},
+			},
+			ContentLength: int64(len(file)),
+			Body:          io.NopCloser(bytes.NewReader(file)),
+		}
+	}
+
+	return responseNotAllowed
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
## Summary

Refactor the `image` module to support a new, unified specification format while maintaining backward compatibility with the legacy format.

## Changes

### 1. Code Changes (`pkg/modules/image/image.go`)

- Added new policy constants:
  - `PolicyStrict` (default): All requested platforms must exist in the image, otherwise return error
  - `PolicyWarn`: Log warning if some platforms are missing, but continue copying
- Removed `PolicyIgnore` (deprecated)
- Refactored platform filtering logic:
  - Iterate through requested platforms and find matches in image manifests
  - Track missing platforms and handle based on policy
  - Strict mode: returns error if any requested platform is missing
  - Warn mode: logs warning but continues with available platforms

### 2. Documentation Updates

- Updated `docs/en/custom/modules/image.md` with new module specification
- Updated `docs/zh/custom/modules/image.md` with Chinese translation
- New parameter `policy` added with `strict` (default) and `warn` options

## New Module Specification

The image module now supports a cleaner format:
```yaml
image:
  manifests:           # required: list of images
    - "image:tag"
  platform:            # optional: ["linux/amd64", "linux/arm64"]
  policy:              # optional: "strict" (default) or "warn"
  pattern:             # optional: regex to match images
  auths: [...]         # optional: registry authentication
  src: "docker.io"                    # source (remote or local://)
  dest: "local:///tmp/images/"        # destination (local or remote)
```
## Backward Compatibility
The legacy format (pull, push, copy) is still supported.
Operation type is determined by src and dest:
pull: src = remote registry, dest = local directory
push: src = local directory, dest = remote registry
copy: src = local directory, dest = local directory


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
new image specification
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
