### PR TITLE
fix: correct inventory retrieval in CommonOptions

### DIFF
--- a/cmd/kk/app/options/option.go
+++ b/cmd/kk/app/options/option.go
@@ -137,7 +137,7 @@ func (o *CommonOptions) Run(ctx context.Context, playbook *kkcorev1.Playbook) er
 		return errors.Wrap(err, "failed to runtime-client")
 	}
 	// create or update inventory
-	if err := client.Get(ctx, ctrlclient.ObjectKeyFromObject(o.Inventory), o.Inventory); err != nil {
+	if err := client.Get(ctx, ctrlclient.ObjectKeyFromObject(o.Inventory), &kkcorev1.Inventory{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			if err := client.Create(ctx, o.Inventory); err != nil {
 				return errors.Wrap(err, "failed to create inventory")

--- a/pkg/executor/playbook_executor.go
+++ b/pkg/executor/playbook_executor.go
@@ -100,11 +100,8 @@ func (e playbookExecutor) Exec(ctx context.Context) (retErr error) {
 			continue
 		}
 		// check tags
-		if play.IsEnabled(e.playbook.Spec.Tags, e.playbook.Spec.SkipTags) {
-			// when gather_fact is set. get host's information from remote.
-			if err := e.dealGatherFacts(ctx, play.GatherFacts, hosts); err != nil {
-				return err
-			}
+		if err := e.dealGatherFacts(ctx, play.GatherFacts, hosts); err != nil {
+			return err
 		}
 
 		// Batch execution, with each batch being a group of hosts run in serial.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
- Updated the inventory retrieval logic in the CommonOptions Run method to use a new instance of kkcorev1.Inventory instead of the existing one. This ensures proper handling of inventory objects during the get operation.
- Simplified the error handling in the playbookExecutor Exec method by removing unnecessary tag checks before gathering facts, streamlining the execution flow.

These changes improve the reliability of inventory management and enhance the clarity of the playbook execution process.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
correct inventory retrieval in CommonOptions
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
