### PR TITLE
refactor: standardize template parsing function usage

### DIFF
--- a/pkg/converter/tmpl/template.go
+++ b/pkg/converter/tmpl/template.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var (
+	StringFunc = func(b []byte) string { return string(b) }
+)
+
 // ParseFunc parses a template string using the provided context and parse function.
 // It takes a context map C, an input string that may contain template syntax,
 // and a parse function that converts the template result to the desired Output type.

--- a/pkg/converter/tmpl/template_test.go
+++ b/pkg/converter/tmpl/template_test.go
@@ -750,7 +750,7 @@ a2:
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := ParseFunc(tc.variable, tc.input, func(b []byte) string { return string(b) })
+			output, err := ParseFunc(tc.variable, tc.input, StringFunc)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/modules/internal/options.go
+++ b/pkg/modules/internal/options.go
@@ -74,7 +74,7 @@ func (o ExecOptions) GetConnector(ctx context.Context) (connector.Connector, err
 
 	host := o.Host
 	if o.Task.Spec.DelegateTo != "" {
-		host, err = tmpl.ParseFunc(ha, o.Task.Spec.DelegateTo, func(b []byte) string { return string(b) })
+		host, err = tmpl.ParseFunc(ha, o.Task.Spec.DelegateTo, tmpl.StringFunc)
 		if err != nil {
 			return nil, errors.Errorf("failed to delegate %q to %q", o.Host, o.Task.Spec.DelegateTo)
 		}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -195,7 +195,7 @@ func (f *project) dealImportPlaybook(p kkprojectv1.Play, basePlaybook string) er
 func (f *project) dealVarsFiles(p *kkprojectv1.Play, basePlaybook string) error {
 	for _, varsFileStr := range p.VarsFiles {
 		// load vars from vars_files
-		varsFile, err := tmpl.ParseFunc(f.config, varsFileStr, func(b []byte) string { return string(b) })
+		varsFile, err := tmpl.ParseFunc(f.config, varsFileStr, tmpl.StringFunc)
 		if err != nil {
 			return errors.Errorf("failed to parse varFile %q", varsFileStr)
 		}

--- a/pkg/variable/helper.go
+++ b/pkg/variable/helper.go
@@ -212,7 +212,7 @@ func StringVar(ctx map[string]any, args map[string]any, keys ...string) (string,
 		return "", errors.Errorf("cannot find variable %q", strings.Join(keys, "."))
 	}
 
-	return tmpl.ParseFunc(ctx, sv, func(b []byte) string { return string(b) })
+	return tmpl.ParseFunc(ctx, sv, tmpl.StringFunc)
 }
 
 // StringSliceVar get string slice value by key
@@ -229,7 +229,7 @@ func StringSliceVar(ctx map[string]any, args map[string]any, keys ...string) ([]
 	case []string:
 		var ss []string
 		for _, a := range valv {
-			as, err := tmpl.ParseFunc(ctx, a, func(b []byte) string { return string(b) })
+			as, err := tmpl.ParseFunc(ctx, a, tmpl.StringFunc)
 			if err != nil {
 				return nil, err
 			}
@@ -247,7 +247,7 @@ func StringSliceVar(ctx map[string]any, args map[string]any, keys ...string) ([]
 				return nil, nil
 			}
 
-			as, err := tmpl.ParseFunc(ctx, av, func(b []byte) string { return string(b) })
+			as, err := tmpl.ParseFunc(ctx, av, tmpl.StringFunc)
 			if err != nil {
 				return nil, err
 			}
@@ -298,7 +298,7 @@ func IntVar(ctx map[string]any, args map[string]any, keys ...string) (*int, erro
 	case reflect.Float32, reflect.Float64:
 		return ptr.To(int(v.Float())), nil
 	case reflect.String:
-		vs, err := tmpl.ParseFunc(ctx, v.String(), func(b []byte) string { return string(b) })
+		vs, err := tmpl.ParseFunc(ctx, v.String(), tmpl.StringFunc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/variable/variable_get.go
+++ b/pkg/variable/variable_get.go
@@ -34,7 +34,7 @@ var GetHostnames = func(name []string) GetFunc {
 		var hs []string
 		for _, n := range name {
 			// Try to parse hostname using configuration variables as template context
-			if pn, err := tmpl.ParseFunc(Extension2Variables(vv.value.Config.Spec), n, func(b []byte) string { return string(b) }); err == nil {
+			if pn, err := tmpl.ParseFunc(Extension2Variables(vv.value.Config.Spec), n, tmpl.StringFunc); err == nil {
 				n = pn
 			}
 			// Add direct hostname if it exists in the hosts map


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind design

### What this PR does / why we need it:
- Replaced inline function definitions with a centralized StringFunc for template parsing across multiple files. This change enhances code readability and maintainability by ensuring consistent usage of the string conversion function in the ParseFunc calls.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
refactor: standardize template parsing function usage
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
