### PR TITLE
fix: adjust variable priority to make group vars override spec.vars

### DIFF
--- a/pkg/variable/variable_get.go
+++ b/pkg/variable/variable_get.go
@@ -50,7 +50,7 @@ var GetHostnames = func(name []string) GetFunc {
 			}
 
 			// Handle indexed group access (e.g., "group[0]")
-			regexForIndex := regexp.MustCompile(`^(.*?)\[(\d+)\]$`)
+			regexForIndex := regexp.MustCompile(`^(.*?)\[(\d+)]$`)
 			if match := regexForIndex.FindStringSubmatch(strings.TrimSpace(n)); match != nil {
 				index, err := strconv.Atoi(match[2])
 				if err != nil {
@@ -136,7 +136,9 @@ var GetAllVariable = func(hostname string) GetFunc {
 		globalHosts := make(map[string]any)
 		for hostname := range v.value.Hosts {
 			hostVars := make(map[string]any)
-			// Set group variables for hosts that belong to groups
+			// Merge inventory-level variables first (lower priority than group vars)
+			hostVars = CombineVariables(hostVars, Extension2Variables(v.value.Inventory.Spec.Vars))
+			// Set group variables for hosts that belong to groups (override spec.vars)
 			for _, gv := range v.value.Inventory.Spec.Groups {
 				if slices.Contains(gv.Hosts, hostname) {
 					hostVars = CombineVariables(hostVars, Extension2Variables(gv.Vars))
@@ -147,9 +149,7 @@ var GetAllVariable = func(hostname string) GetFunc {
 			// Merge runtime variables (variables set during playbook execution)
 			hostVars = CombineVariables(hostVars, v.value.Hosts[hostname].RuntimeVars)
 
-			// Merge inventory-level variables
-			hostVars = CombineVariables(hostVars, Extension2Variables(v.value.Inventory.Spec.Vars))
-			// Merge host-specific variables from inventory
+			// Merge host-specific variables from inventory (override group vars)
 			hostVars = CombineVariables(hostVars, Extension2Variables(v.value.Inventory.Spec.Hosts[hostname]))
 			// Merge configuration variables
 			hostVars = CombineVariables(hostVars, Extension2Variables(v.value.Config.Spec))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:

-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
