### PR TITLE
fix: include port in controlPlaneEndpoint for kubeadm templates

### DIFF
--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta2
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta2
@@ -30,7 +30,7 @@ imageRepository: {{ .kubernetes.image_repository }}
 kubernetesVersion: {{ .kubernetes.kube_version }}
 certificatesDir: /etc/kubernetes/pki
 clusterName: {{ .kubernetes.cluster_name }}
-controlPlaneEndpoint: {{ .kubernetes.control_plane_endpoint.host }}
+controlPlaneEndpoint: {{ .kubernetes.control_plane_endpoint.host }}:{{ .kubernetes.control_plane_endpoint.port }}
 networking:
   dnsDomain: {{ .dns.dns_domain }}
   podSubnet: {{ .cni.pod_cidr }}

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
@@ -29,7 +29,7 @@ imageRepository: {{ .kubernetes.image_repository }}
 kubernetesVersion: {{ .kubernetes.kube_version }}
 certificatesDir: /etc/kubernetes/pki
 clusterName: {{ .kubernetes.cluster_name }}
-controlPlaneEndpoint: {{ .kubernetes.control_plane_endpoint.host }}
+controlPlaneEndpoint: {{ .kubernetes.control_plane_endpoint.host }}:{{ .kubernetes.control_plane_endpoint.port }}
 networking:
   dnsDomain: {{ .dns.dns_domain }}
   podSubnet: {{ .cni.pod_cidr }}

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
@@ -30,7 +30,7 @@ imageRepository: {{ .kubernetes.image_repository }}
 kubernetesVersion: {{ .kubernetes.kube_version }}
 certificatesDir: /etc/kubernetes/pki
 clusterName: {{ .kubernetes.cluster_name }}
-controlPlaneEndpoint: {{ .kubernetes.control_plane_endpoint.host }}
+controlPlaneEndpoint: {{ .kubernetes.control_plane_endpoint.host }}:{{ .kubernetes.control_plane_endpoint.port }}
 networking:
   dnsDomain: {{ .dns.dns_domain }}
   podSubnet: {{ .cni.pod_cidr }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Updated the controlPlaneEndpoint field in kubeadm-init.v1beta2, v1beta3, and v1beta4 templates to append the port from the control_plane_endpoint configuration. This change ensures proper endpoint specification for Kubernetes cluster initialization.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 
https://github.com/kubesphere/kubekey/issues/3021
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
include port in controlPlaneEndpoint for kubeadm templates
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
