### PR TITLE
feat: enhance local DNS configuration for Kubernetes control plane

### DIFF
--- a/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
+++ b/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
@@ -78,6 +78,10 @@ kubernetes:
     #   - On control-plane nodes: 127.0.0.1 {{ .kubernetes.control_plane_endpoint.host }}
     #   - On worker nodes: {{ .init_kubernetes_node }} {{ .kubernetes.control_plane_endpoint.host }}
     type: local
+    local:
+      # When using 'local' as load balancing, you can specify an external load balancer address here.
+      # Note: You must set up the actual load balancing yourself; this setting is only for DNS resolution.
+      address: ""
     kube_vip:
       # The IP address of the node's network interface (e.g., "eth0").
       address: ""

--- a/builtin/core/roles/kubernetes/init-kubernetes/tasks/init_kubernetes.yaml
+++ b/builtin/core/roles/kubernetes/init-kubernetes/tasks/init_kubernetes.yaml
@@ -38,6 +38,7 @@
 # preventing failures for tasks that execute kubectl apply on the current node.
 - name: Init | Reset local DNS for control_plane_endpoint
   loop: "{{ .native.localDNS | toJson }}"
+  when: or (.kubernetes.control_plane_endpoint.type | ne "local") (.kubernetes.control_plane_endpoint.local.address | empty)
   command: |
     sed -i ':a;$!{N;ba};s@# kubekey kubernetes control_plane_endpoint BEGIN.*# kubekey kubernetes control_plane_endpoint END@@' {{ .item }}
     cat >> {{ .item }} <<EOF

--- a/builtin/core/roles/kubernetes/init-kubernetes/tasks/main.yaml
+++ b/builtin/core/roles/kubernetes/init-kubernetes/tasks/main.yaml
@@ -1,6 +1,7 @@
 ---
 - name: InitKubernetes | Configure control_plane_endpoint in local DNS files
   when: 
+    - or (.kubernetes.control_plane_endpoint.type | ne "local") (.kubernetes.control_plane_endpoint.local.address | empty)
     - or (.kubernetes.control_plane_endpoint.type | eq "local") (.kubernetes.control_plane_endpoint.type | eq "haproxy")
     - .inventory_hostname | eq .init_kubernetes_node | not
   loop: "{{ .native.localDNS | toJson }}"

--- a/builtin/core/roles/kubernetes/join-kubernetes/tasks/main.yaml
+++ b/builtin/core/roles/kubernetes/join-kubernetes/tasks/main.yaml
@@ -56,6 +56,7 @@
   block:
     - name: Join | Reset local DNS on control plane nodes
       when:
+        - or (.kubernetes.control_plane_endpoint.type | ne "local") (.kubernetes.control_plane_endpoint.local.address | empty)
         - .groups.kube_control_plane | default list | has .inventory_hostname
       loop: "{{ .native.localDNS | toJson }}"
       command: |
@@ -68,6 +69,7 @@
         EOF
     - name: Join | Reset local DNS on worker nodes (for haproxy endpoint)
       when:
+        - or (.kubernetes.control_plane_endpoint.type | ne "local") (.kubernetes.control_plane_endpoint.local.address | empty)
         - .groups.kube_worker | default list | has .inventory_hostname
         - .kubernetes.control_plane_endpoint.type | eq "haproxy"
       loop: "{{ .native.localDNS | toJson }}"

--- a/builtin/core/roles/native/dns/tasks/main.yaml
+++ b/builtin/core/roles/native/dns/tasks/main.yaml
@@ -89,6 +89,10 @@
 # High Availability: Local DNS configuration for each .kubernetes.control_plane_endpoint.type
 #
 # For 'local' endpoint type:
+#   When local.address is not empty (external load balancer address):
+#     - Control plane: {{ .kubernetes.control_plane_endpoint.local.address }} {{ .kubernetes.control_plane_endpoint.host }}
+#     - Worker:        {{ .kubernetes.control_plane_endpoint.local.address }} {{ .kubernetes.control_plane_endpoint.host }}
+#
 #   Before cluster initialization:
 #     - Control plane: 127.0.0.1 {{ .kubernetes.control_plane_endpoint.host }}
 #     - Worker:        127.0.0.1 {{ .kubernetes.control_plane_endpoint.host }}
@@ -129,6 +133,7 @@
 #   After joining cluster:
 #     - Control plane: 127.0.0.1 {{ .kubernetes.control_plane_endpoint.host }}
 #     - Worker:        127.0.0.1 {{ .kubernetes.control_plane_endpoint.host }}
+#
 
 - name: DNS | Set local DNS for kubernetes control plane endpoint
   loop: "{{ .native.localDNS | toJson }}"
@@ -145,6 +150,9 @@
     {{- else }}
     127.0.0.1 {{ .kubernetes.control_plane_endpoint.host }}
     ::1 {{ .kubernetes.control_plane_endpoint.host }}
+    {{- end }}
+    {{- if and (.kubernetes.control_plane_endpoint.type | eq "local") (.kubernetes.control_plane_endpoint.local.address | empty | not) }}
+    {{ .kubernetes.control_plane_endpoint.local.address }} {{ .kubernetes.control_plane_endpoint.host }}
     {{- end }}
     # kubekey kubernetes control_plane_endpoint END
     EOF


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
When using an external load balancer (LB) as the control plane endpoint, you can configure local DNS resolution to map the control plane domain name to the LB address. For example:
```yaml
kubernetes:
  control_plane_endpoint:
    host: lb.kubernetes.local
    type: local
    local:
      address: 10.0.0.1
```
Expected behavior：During deployment, Kubekey will automatically add the following entry to the local hosts file (/etc/hosts) on each node:
```text
10.0.0.1 lb.kubernetes.local
```
This ensures that all nodes resolve lb.kubernetes.local to the specified LB address 10.0.0.1 without relying on an external DNS service.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/kubekey/issues/3022
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
enhance local DNS configuration for Kubernetes control plane
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
