### PR TITLE
feat: enhance image manifest handling in download configuration

### DIFF
--- a/builtin/core/roles/defaults/templates/manifests.yaml
+++ b/builtin/core/roles/defaults/templates/manifests.yaml
@@ -578,6 +578,11 @@ download:
   iso: {{ .download.iso | default list | toJson }}
   images:
     manifests:
+{{- if .download.images.manifests | empty | not }}
+  {{- range .download.images.manifests }}
+      - {{ . }}
+  {{- end }}
+{{- else }}
       # kubernetes
       ## kubernetes/dns
       - {{ if .download.images.registry | empty | not }}{{ .download.images.registry }}/coredns/coredns:v1.8.6{{ else }}registry.k8s.io/coredns/coredns:v1.8.6{{ end }}
@@ -685,6 +690,7 @@ download:
   {{- range .download.cni.multus.image.tag | default (list "v4.2.4") }}
       - {{ if $.download.images.registry | empty | not }}{{ $.download.images.registry }}{{ else }}ghcr.io{{ end }}/{{ $.download.cni.multus.image.repository | default "k8snetworkplumbingwg/multus-cni" }}:{{ . }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- if .image_manifests | empty | not }}
       # External images


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
- Added conditional logic to include custom image manifests in the download section, improving flexibility for users to specify additional images.
- Ensured fallback to default Kubernetes images if no custom manifests are provided.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
