### PR TITLE
feat: add ApplyConfigureOS flag and improve initOS.sh script for bett…

### DIFF
--- a/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
+++ b/cmd/kk/apis/kubekey/v1alpha2/cluster_types.go
@@ -94,13 +94,14 @@ type CustomScripts struct {
 
 // System defines the system config for each node in cluster.
 type System struct {
-	NtpServers      []string        `yaml:"ntpServers" json:"ntpServers,omitempty"`
-	Timezone        string          `yaml:"timezone" json:"timezone,omitempty"`
-	Rpms            []string        `yaml:"rpms" json:"rpms,omitempty"`
-	Debs            []string        `yaml:"debs" json:"debs,omitempty"`
-	PreInstall      []CustomScripts `yaml:"preInstall" json:"preInstall,omitempty"`
-	PostInstall     []CustomScripts `yaml:"postInstall" json:"postInstall,omitempty"`
-	SkipConfigureOS bool            `yaml:"skipConfigureOS" json:"skipConfigureOS,omitempty"`
+	NtpServers       []string        `yaml:"ntpServers" json:"ntpServers,omitempty"`
+	Timezone         string          `yaml:"timezone" json:"timezone,omitempty"`
+	Rpms             []string        `yaml:"rpms" json:"rpms,omitempty"`
+	Debs             []string        `yaml:"debs" json:"debs,omitempty"`
+	PreInstall       []CustomScripts `yaml:"preInstall" json:"preInstall,omitempty"`
+	PostInstall      []CustomScripts `yaml:"postInstall" json:"postInstall,omitempty"`
+	SkipConfigureOS  bool            `yaml:"skipConfigureOS" json:"skipConfigureOS,omitempty"`
+	ApplyConfigureOS bool            `yaml:"applyConfigureOS" json:"applyConfigureOS,omitempty"`
 }
 
 // RegistryConfig defines the configuration information of the image's repository.
@@ -146,7 +147,7 @@ func (cfg *ClusterSpec) GenerateCertSANs() []string {
 		if InternalIPv4Address != host.Address && InternalIPv4Address != cfg.ControlPlaneEndpoint.Address {
 			extraCertSANs = append(extraCertSANs, InternalIPv4Address)
 		}
-		if len(nodeAddresses)==2 {
+		if len(nodeAddresses) == 2 {
 			InternalIPv6Address := nodeAddresses[1]
 			extraCertSANs = append(extraCertSANs, InternalIPv6Address)
 		}

--- a/cmd/kk/pkg/bootstrap/os/module.go
+++ b/cmd/kk/pkg/bootstrap/os/module.go
@@ -47,7 +47,6 @@ func (c *ConfigureOSModule) Init() {
 		Name:     "GetOSData",
 		Desc:     "Get OS release",
 		Hosts:    c.Runtime.GetAllHosts(),
-		Prepare:  &kubernetes.NodeInCluster{Not: true},
 		Action:   new(GetOSData),
 		Parallel: true,
 	}
@@ -56,16 +55,14 @@ func (c *ConfigureOSModule) Init() {
 		Name:     "InitOS",
 		Desc:     "Prepare to init OS",
 		Hosts:    c.Runtime.GetAllHosts(),
-		Prepare:  &kubernetes.NodeInCluster{Not: true},
 		Action:   new(NodeConfigureOS),
 		Parallel: true,
 	}
 
 	GenerateScript := &task.RemoteTask{
-		Name:    "GenerateScript",
-		Desc:    "Generate init os script",
-		Hosts:   c.Runtime.GetAllHosts(),
-		Prepare: &kubernetes.NodeInCluster{Not: true},
+		Name:  "GenerateScript",
+		Desc:  "Generate init os script",
+		Hosts: c.Runtime.GetAllHosts(),
 		Action: &action.Template{
 			Template: templates.InitOsScriptTmpl,
 			Dst:      filepath.Join(common.KubeScriptDir, "initOS.sh"),
@@ -81,7 +78,6 @@ func (c *ConfigureOSModule) Init() {
 		Name:     "ExecScript",
 		Desc:     "Exec init os script",
 		Hosts:    c.Runtime.GetAllHosts(),
-		Prepare:  &kubernetes.NodeInCluster{Not: true},
 		Action:   new(NodeExecScript),
 		Parallel: true,
 	}

--- a/cmd/kk/pkg/bootstrap/os/tasks.go
+++ b/cmd/kk/pkg/bootstrap/os/tasks.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/bootstrap/os/repository"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/common"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/connector"
+	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/kubernetes"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/utils"
 	"github.com/kubesphere/kubekey/v3/util/osrelease"
 )
@@ -122,12 +123,34 @@ type NodeExecScript struct {
 }
 
 func (n *NodeExecScript) Execute(runtime connector.Runtime) error {
+	host := runtime.RemoteHost()
+	nodeInCluster := false
+	if v, ok := n.PipelineCache.Get(common.ClusterStatus); ok {
+		cluster := v.(*kubernetes.KubernetesStatus)
+		var versionOk bool
+		if res, ok := cluster.NodesInfo[host.GetName()]; ok && res != "" {
+			versionOk = true
+		}
+		_, ipOk := cluster.NodesInfo[host.GetInternalAddress()]
+		nodeInCluster = versionOk || ipOk
+	}
 	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chmod +x %s/initOS.sh", common.KubeScriptDir), false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to chmod +x init os script")
 	}
-
-	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s/initOS.sh", common.KubeScriptDir), true); err != nil {
-		return errors.Wrap(errors.WithStack(err), "Failed to configure operating system")
+	// New nodes (not in cluster): always execute actual init script
+	// Existing nodes (in cluster): execute dry-run check if DryRunConfigureOS is enabled, otherwise skip
+	if !nodeInCluster {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s/initOS.sh", common.KubeScriptDir), false); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to configure operating system")
+		}
+	} else if n.KubeConf.Cluster.System.ApplyConfigureOS {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s/initOS.sh", common.KubeScriptDir), true); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to configure operating system")
+		}
+	} else {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s/initOS.sh --dry-run", common.KubeScriptDir), true); err != nil {
+			return errors.Wrap(errors.WithStack(err), "Failed to configure operating system")
+		}
 	}
 	return nil
 }

--- a/cmd/kk/pkg/bootstrap/os/templates/init_script.go
+++ b/cmd/kk/pkg/bootstrap/os/templates/init_script.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/bootstrap/registry"
-
 	"github.com/lithammer/dedent"
 
+	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/bootstrap/registry"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/common"
 	"github.com/kubesphere/kubekey/v3/cmd/kk/pkg/core/connector"
 )
@@ -46,6 +45,173 @@ var InitOsScriptTmpl = template.Must(template.New("initOS.sh").Parse(
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DRYRUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRYRUN=true ;;
+    esac
+done
+
+# Update /etc/hosts in both dry-run and normal mode
+sed -i ':a;$!{N;ba};s@# kubekey hosts BEGIN.*# kubekey hosts END@@' /etc/hosts
+sed -i '/^$/N;/\n$/N;//D' /etc/hosts
+
+cat >>/etc/hosts<<EOF
+# kubekey hosts BEGIN
+{{- range .Hosts }}
+{{ . }}
+{{- end }}
+# kubekey hosts END
+EOF
+
+check_sysctl_conf() {
+    local key="$1"
+    local expected="$2"
+    local current
+    current=$(sysctl -n "$key" 2>/dev/null)
+    if [ -z "$current" ]; then
+        echo "${key} expect ${expected} but not set"
+    elif [ "$current" != "$expected" ]; then
+        echo "${key} expect ${expected} but got ${current}"
+    fi
+}
+
+check_limits_conf() {
+    local domain="$1"
+    local type="$2"
+    local item="$3"
+    local expected="$4"
+    local current
+    current=$(awk -v d="$domain" -v t="$type" -v i="$item" '$1 == d && $2 == t && $3 == i {print $4; exit}' /etc/security/limits.conf 2>/dev/null)
+    if [ -z "$current" ]; then
+        echo "${domain} ${type} ${item} expect ${expected} but not set"
+    elif [ "$current" != "$expected" ]; then
+        echo "${domain} ${type} ${item} expect ${expected} but got ${current}"
+    fi
+}
+
+if [ "$DRYRUN" = true ]; then
+    echo "check begin"
+
+    # swap
+    if grep -q '^/' /proc/swaps 2>/dev/null; then
+        echo "swap expect disabled but is enabled"
+    fi
+    if grep -q '^[^#]*swap' /etc/fstab 2>/dev/null; then
+        echo "/etc/fstab swap entries expect commented but are active"
+    fi
+
+    # selinux
+    if [ -f /etc/selinux/config ]; then
+        current=$(grep '^SELINUX=' /etc/selinux/config 2>/dev/null | sed 's/^SELINUX=//')
+        if [ -n "$current" ] && [ "$current" != "disabled" ]; then
+            echo "SELINUX expect disabled but got ${current} in /etc/selinux/config"
+        fi
+    fi
+    if command -v getenforce > /dev/null 2>&1; then
+        current=$(getenforce 2>/dev/null)
+        if [ -n "$current" ] && [ "$current" != "Disabled" ] && [ "$current" != "Permissive" ]; then
+            echo "SELinux expect Disabled or Permissive but got ${current}"
+        fi
+    fi
+
+    # sysctl
+    check_sysctl_conf "net.ipv4.ip_forward" "1"
+    check_sysctl_conf "net.bridge.bridge-nf-call-arptables" "1"
+    check_sysctl_conf "net.bridge.bridge-nf-call-ip6tables" "1"
+    check_sysctl_conf "net.bridge.bridge-nf-call-iptables" "1"
+    check_sysctl_conf "net.ipv4.ip_local_reserved_ports" "30000-32767"
+    check_sysctl_conf "net.core.netdev_max_backlog" "65535"
+    check_sysctl_conf "net.core.rmem_max" "33554432"
+    check_sysctl_conf "net.core.wmem_max" "33554432"
+    check_sysctl_conf "net.core.somaxconn" "32768"
+    check_sysctl_conf "net.ipv4.tcp_max_syn_backlog" "1048576"
+    check_sysctl_conf "net.ipv4.neigh.default.gc_thresh1" "512"
+    check_sysctl_conf "net.ipv4.neigh.default.gc_thresh2" "2048"
+    check_sysctl_conf "net.ipv4.neigh.default.gc_thresh3" "4096"
+    check_sysctl_conf "net.ipv4.tcp_retries2" "15"
+    check_sysctl_conf "net.ipv4.tcp_max_tw_buckets" "1048576"
+    check_sysctl_conf "net.ipv4.tcp_max_orphans" "65535"
+    check_sysctl_conf "net.ipv4.udp_rmem_min" "131072"
+    check_sysctl_conf "net.ipv4.udp_wmem_min" "131072"
+    check_sysctl_conf "net.ipv4.conf.all.rp_filter" "1"
+    check_sysctl_conf "net.ipv4.conf.default.rp_filter" "1"
+    check_sysctl_conf "net.ipv4.conf.all.arp_accept" "1"
+    check_sysctl_conf "net.ipv4.conf.default.arp_accept" "1"
+    check_sysctl_conf "net.ipv4.conf.all.arp_ignore" "1"
+    check_sysctl_conf "net.ipv4.conf.default.arp_ignore" "1"
+    check_sysctl_conf "vm.max_map_count" "262144"
+    check_sysctl_conf "vm.swappiness" "0"
+    check_sysctl_conf "vm.overcommit_memory" "1"
+    check_sysctl_conf "fs.inotify.max_user_instances" "524288"
+    check_sysctl_conf "fs.inotify.max_user_watches" "10240001"
+    check_sysctl_conf "fs.pipe-max-size" "4194304"
+    check_sysctl_conf "fs.aio-max-nr" "262144"
+    check_sysctl_conf "kernel.pid_max" "4194304"
+    check_sysctl_conf "kernel.watchdog_thresh" "5"
+    check_sysctl_conf "kernel.hung_task_timeout_secs" "5"
+    # net.ipv4.tcp_tw_recycle is removed in Linux 4.12+, only check if it exists
+    if sysctl -n net.ipv4.tcp_tw_recycle 2>/dev/null; then
+        check_sysctl_conf "net.ipv4.tcp_tw_recycle" "0"
+    fi
+    check_sysctl_conf "net.ipv4.tcp_tw_reuse" "0"
+    check_sysctl_conf "net.ipv4.conf.eth0.arp_accept" "1"
+{{- if .IPv6Support }}
+    check_sysctl_conf "net.ipv6.conf.all.disable_ipv6" "0"
+    check_sysctl_conf "net.ipv6.conf.default.disable_ipv6" "0"
+    check_sysctl_conf "net.ipv6.conf.lo.disable_ipv6" "0"
+    check_sysctl_conf "net.ipv6.conf.all.forwarding" "1"
+    check_sysctl_conf "net.ipv6.conf.default.accept_dad" "0"
+    check_sysctl_conf "net.ipv6.route.max_size" "65536"
+    check_sysctl_conf "net.ipv6.neigh.default.retrans_time_ms" "1000"
+{{- end}}
+
+    # limits
+    check_limits_conf "*" "soft" "nofile" "1048576"
+    check_limits_conf "*" "hard" "nofile" "1048576"
+    check_limits_conf "*" "soft" "nproc" "65536"
+    check_limits_conf "*" "hard" "nproc" "65536"
+    check_limits_conf "*" "soft" "memlock" "unlimited"
+    check_limits_conf "*" "hard" "memlock" "unlimited"
+
+    # firewall
+    if systemctl list-unit-files firewalld.service 2>/dev/null | grep -q 'firewalld.service'; then
+        if systemctl is-active firewalld 2>/dev/null | grep -q 'active'; then
+            echo "firewalld expect disabled but is active"
+        fi
+    fi
+    if systemctl list-unit-files ufw.service 2>/dev/null | grep -q 'ufw.service'; then
+        if systemctl is-active ufw 2>/dev/null | grep -q 'active'; then
+            echo "ufw expect disabled but is active"
+        fi
+    fi
+
+    # modules
+    modinfo br_netfilter > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        if ! lsmod 2>/dev/null | grep -q 'br_netfilter'; then
+            echo "module br_netfilter expect loaded but is not"
+        fi
+    fi
+    modinfo overlay > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        if ! lsmod 2>/dev/null | grep -q 'overlay'; then
+            echo "module overlay expect loaded but is not"
+        fi
+    fi
+    for mod in ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh; do
+        if ! lsmod 2>/dev/null | grep -q "$mod"; then
+            echo "module ${mod} expect loaded but is not"
+        fi
+    done
+    if ! lsmod 2>/dev/null | grep -q 'nf_conntrack_ipv4' && ! lsmod 2>/dev/null | grep -q 'nf_conntrack'; then
+        echo "module nf_conntrack_ipv4 or nf_conntrack expect loaded but is not"
+    fi
+
+    echo "check end"
+    exit 0
+fi
+
 swapoff -a
 sed -i /^[^#]*swap*/s/^/\#/g /etc/fstab
 
@@ -61,99 +227,73 @@ then
   getenforce
 fi
 
-echo 'net.ipv4.ip_forward = 1' >> /etc/sysctl.conf
-echo 'net.bridge.bridge-nf-call-arptables = 1' >> /etc/sysctl.conf
-echo 'net.bridge.bridge-nf-call-ip6tables = 1' >> /etc/sysctl.conf
-echo 'net.bridge.bridge-nf-call-iptables = 1' >> /etc/sysctl.conf
-echo 'net.ipv4.ip_local_reserved_ports = 30000-32767' >> /etc/sysctl.conf
-echo 'net.core.netdev_max_backlog = 65535' >> /etc/sysctl.conf
-echo 'net.core.rmem_max = 33554432' >> /etc/sysctl.conf
-echo 'net.core.wmem_max = 33554432' >> /etc/sysctl.conf
-echo 'net.core.somaxconn = 32768' >> /etc/sysctl.conf
-echo 'net.ipv4.tcp_max_syn_backlog = 1048576' >> /etc/sysctl.conf
-echo 'net.ipv4.neigh.default.gc_thresh1 = 512' >> /etc/sysctl.conf
-echo 'net.ipv4.neigh.default.gc_thresh2 = 2048' >> /etc/sysctl.conf
-echo 'net.ipv4.neigh.default.gc_thresh3 = 4096' >> /etc/sysctl.conf
-echo 'net.ipv4.tcp_retries2 = 15' >> /etc/sysctl.conf
-echo 'net.ipv4.tcp_max_tw_buckets = 1048576' >> /etc/sysctl.conf
-echo 'net.ipv4.tcp_max_orphans = 65535' >> /etc/sysctl.conf
-echo 'net.ipv4.udp_rmem_min = 131072' >> /etc/sysctl.conf
-echo 'net.ipv4.udp_wmem_min = 131072' >> /etc/sysctl.conf
-echo 'net.ipv4.conf.all.rp_filter = 1' >> /etc/sysctl.conf
-echo 'net.ipv4.conf.default.rp_filter = 1' >> /etc/sysctl.conf
-echo 'net.ipv4.conf.all.arp_accept = 1' >> /etc/sysctl.conf
-echo 'net.ipv4.conf.default.arp_accept = 1' >> /etc/sysctl.conf
-echo 'net.ipv4.conf.all.arp_ignore = 1' >> /etc/sysctl.conf
-echo 'net.ipv4.conf.default.arp_ignore = 1' >> /etc/sysctl.conf
-echo 'vm.max_map_count = 262144' >> /etc/sysctl.conf
-echo 'vm.swappiness = 1' >> /etc/sysctl.conf
-echo 'vm.overcommit_memory = 1' >> /etc/sysctl.conf
-echo 'fs.inotify.max_user_instances = 524288' >> /etc/sysctl.conf
-echo 'fs.inotify.max_user_watches = 10240001' >> /etc/sysctl.conf
-echo 'fs.pipe-max-size = 4194304' >> /etc/sysctl.conf
-echo 'fs.aio-max-nr = 262144' >> /etc/sysctl.conf
-echo 'kernel.pid_max = 4194304' >> /etc/sysctl.conf
-echo 'kernel.watchdog_thresh = 5' >> /etc/sysctl.conf
-echo 'kernel.hung_task_timeout_secs = 5' >> /etc/sysctl.conf
+# Helper function to safely set sysctl config
+# Adds the config if not exists, or updates it if exists (including commented ones)
+set_sysctl_config() {
+    local key="$1"
+    local value="$2"
+    # Check if key exists (including commented lines)
+    if grep -qE "^[#[:space:]]*${key}\s*=" /etc/sysctl.conf 2>/dev/null; then
+        # Key exists, update it (remove comment if present and set value)
+        sed -r -i "s@^[#[:space:]]*${key}\s*=.*@${key} = ${value}@g" /etc/sysctl.conf
+    else
+        # Key doesn't exist, append it
+        echo "${key} = ${value}" >> /etc/sysctl.conf
+    fi
+}
+
+set_sysctl_config "net.ipv4.ip_forward" "1"
+set_sysctl_config "net.bridge.bridge-nf-call-arptables" "1"
+set_sysctl_config "net.bridge.bridge-nf-call-ip6tables" "1"
+set_sysctl_config "net.bridge.bridge-nf-call-iptables" "1"
+set_sysctl_config "net.ipv4.ip_local_reserved_ports" "30000-32767"
+set_sysctl_config "net.core.netdev_max_backlog" "65535"
+set_sysctl_config "net.core.rmem_max" "33554432"
+set_sysctl_config "net.core.wmem_max" "33554432"
+set_sysctl_config "net.core.somaxconn" "32768"
+set_sysctl_config "net.ipv4.tcp_max_syn_backlog" "1048576"
+set_sysctl_config "net.ipv4.neigh.default.gc_thresh1" "512"
+set_sysctl_config "net.ipv4.neigh.default.gc_thresh2" "2048"
+set_sysctl_config "net.ipv4.neigh.default.gc_thresh3" "4096"
+set_sysctl_config "net.ipv4.tcp_retries2" "15"
+set_sysctl_config "net.ipv4.tcp_max_tw_buckets" "1048576"
+set_sysctl_config "net.ipv4.tcp_max_orphans" "65535"
+set_sysctl_config "net.ipv4.udp_rmem_min" "131072"
+set_sysctl_config "net.ipv4.udp_wmem_min" "131072"
+set_sysctl_config "net.ipv4.conf.all.rp_filter" "1"
+set_sysctl_config "net.ipv4.conf.default.rp_filter" "1"
+set_sysctl_config "net.ipv4.conf.all.arp_accept" "1"
+set_sysctl_config "net.ipv4.conf.default.arp_accept" "1"
+set_sysctl_config "net.ipv4.conf.all.arp_ignore" "1"
+set_sysctl_config "net.ipv4.conf.default.arp_ignore" "1"
+set_sysctl_config "vm.max_map_count" "262144"
+set_sysctl_config "vm.swappiness" "0"
+set_sysctl_config "vm.overcommit_memory" "1"
+set_sysctl_config "fs.inotify.max_user_instances" "524288"
+set_sysctl_config "fs.inotify.max_user_watches" "10240001"
+set_sysctl_config "fs.pipe-max-size" "4194304"
+set_sysctl_config "fs.aio-max-nr" "262144"
+set_sysctl_config "kernel.pid_max" "4194304"
+set_sysctl_config "kernel.watchdog_thresh" "5"
+set_sysctl_config "kernel.hung_task_timeout_secs" "5"
 
 {{- if .IPv6Support }}
 #add for ipv6
-echo 'net.ipv6.conf.all.disable_ipv6 = 0' >> /etc/sysctl.conf
-echo 'net.ipv6.conf.default.disable_ipv6 = 0' >> /etc/sysctl.conf
-echo 'net.ipv6.conf.lo.disable_ipv6 = 0' >> /etc/sysctl.conf
-echo 'net.ipv6.conf.all.forwarding=1' >> /etc/sysctl.conf
-echo 'net.ipv6.conf.default.accept_dad=0' >> /etc/sysctl.conf
-echo 'net.ipv6.route.max_size=65536' >> /etc/sysctl.conf
-echo 'net.ipv6.neigh.default.retrans_time_ms=1000' >> /etc/sysctl.conf
+set_sysctl_config "net.ipv6.conf.all.disable_ipv6" "0"
+set_sysctl_config "net.ipv6.conf.default.disable_ipv6" "0"
+set_sysctl_config "net.ipv6.conf.lo.disable_ipv6" "0"
+set_sysctl_config "net.ipv6.conf.all.forwarding" "1"
+set_sysctl_config "net.ipv6.conf.default.accept_dad" "0"
+set_sysctl_config "net.ipv6.route.max_size" "65536"
+set_sysctl_config "net.ipv6.neigh.default.retrans_time_ms" "1000"
 {{- end}}
 
 #See https://help.aliyun.com/document_detail/118806.html#uicontrol-e50-ddj-w0y
-sed -r -i "s@#{0,}?net.ipv4.tcp_tw_recycle ?= ?(0|1|2)@net.ipv4.tcp_tw_recycle = 0@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv4.tcp_tw_reuse ?= ?(0|1)@net.ipv4.tcp_tw_reuse = 0@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv4.conf.all.rp_filter ?= ?(0|1|2)@net.ipv4.conf.all.rp_filter = 1@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv4.conf.default.rp_filter ?= ?(0|1|2)@net.ipv4.conf.default.rp_filter = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.ip_forward ?= ?(0|1)@net.ipv4.ip_forward = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.bridge.bridge-nf-call-arptables ?= ?(0|1)@net.bridge.bridge-nf-call-arptables = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.bridge.bridge-nf-call-ip6tables ?= ?(0|1)@net.bridge.bridge-nf-call-ip6tables = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.bridge.bridge-nf-call-iptables ?= ?(0|1)@net.bridge.bridge-nf-call-iptables = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.ip_local_reserved_ports ?= ?([0-9]{1,}-{0,1},{0,1}){1,}@net.ipv4.ip_local_reserved_ports = 30000-32767@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?vm.max_map_count ?= ?([0-9]{1,})@vm.max_map_count = 262144@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?vm.swappiness ?= ?([0-9]{1,})@vm.swappiness = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?fs.inotify.max_user_instances ?= ?([0-9]{1,})@fs.inotify.max_user_instances = 524288@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?kernel.pid_max ?= ?([0-9]{1,})@kernel.pid_max = 4194304@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?vm.overcommit_memory ?= ?(0|1|2)@vm.overcommit_memory = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?fs.inotify.max_user_watches ?= ?([0-9]{1,})@fs.inotify.max_user_watches = 524288@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?fs.pipe-max-size ?= ?([0-9]{1,})@fs.pipe-max-size = 4194304@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.core.netdev_max_backlog ?= ?([0-9]{1,})@net.core.netdev_max_backlog = 65535@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.core.rmem_max ?= ?([0-9]{1,})@net.core.rmem_max = 33554432@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.core.wmem_max ?= ?([0-9]{1,})@net.core.wmem_max = 33554432@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.tcp_max_syn_backlog ?= ?([0-9]{1,})@net.ipv4.tcp_max_syn_backlog = 1048576@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.neigh.default.gc_thresh1 ?= ?([0-9]{1,})@net.ipv4.neigh.default.gc_thresh1 = 512@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.neigh.default.gc_thresh2 ?= ?([0-9]{1,})@net.ipv4.neigh.default.gc_thresh2 = 2048@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.neigh.default.gc_thresh3 ?= ?([0-9]{1,})@net.ipv4.neigh.default.gc_thresh3 = 4096@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.core.somaxconn ?= ?([0-9]{1,})@net.core.somaxconn = 32768@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv4.conf.eth0.arp_accept ?= ?(0|1)@net.ipv4.conf.eth0.arp_accept = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?fs.aio-max-nr ?= ?([0-9]{1,})@fs.aio-max-nr = 262144@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.tcp_retries2 ?= ?([0-9]{1,})@net.ipv4.tcp_retries2 = 15@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.tcp_max_tw_buckets ?= ?([0-9]{1,})@net.ipv4.tcp_max_tw_buckets = 1048576@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.tcp_max_orphans ?= ?([0-9]{1,})@net.ipv4.tcp_max_orphans = 65535@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.udp_rmem_min ?= ?([0-9]{1,})@net.ipv4.udp_rmem_min = 131072@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.udp_wmem_min ?= ?([0-9]{1,})@net.ipv4.udp_wmem_min = 131072@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.conf.all.arp_ignore ?= ??(0|1|2)@net.ipv4.conf.all.arp_ignore = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?net.ipv4.conf.default.arp_ignore ?= ??(0|1|2)@net.ipv4.conf.default.arp_ignore = 1@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?kernel.watchdog_thresh ?= ?([0-9]{1,})@kernel.watchdog_thresh = 5@g" /etc/sysctl.conf
-sed -r -i  "s@#{0,}?kernel.hung_task_timeout_secs ?= ?([0-9]{1,})@kernel.hung_task_timeout_secs = 5@g" /etc/sysctl.conf
-
-{{- if .IPv6Support }}
-#add for ipv6
-sed -r -i "s@#{0,}?net.ipv6.conf.all.disable_ipv6 ?= ?([0-9]{1,})@net.ipv6.conf.all.disable_ipv6 = 0@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv6.conf.default.disable_ipv6 ?= ?([0-9]{1,})@net.ipv6.conf.default.disable_ipv6 = 0@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv6.conf.lo.disable_ipv6 ?= ?([0-9]{1,})@net.ipv6.conf.lo.disable_ipv6 = 0@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv6.conf.all.forwarding ?= ?([0-9]{1,})@net.ipv6.conf.all.forwarding = 1@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv6.conf.default.accept_dad ?= ?([0-9]{1,})@net.ipv6.conf.default.accept_dad = 0@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv6.route.max_size ?= ?([0-9]{1,})@net.ipv6.route.max_size = 65536@g" /etc/sysctl.conf
-sed -r -i "s@#{0,}?net.ipv6.neigh.default.retrans_time_ms ?= ?([0-9]{1,})@net.ipv6.neigh.default.retrans_time_ms = 1000@g" /etc/sysctl.conf
-{{- end}}
+# net.ipv4.tcp_tw_recycle is removed in Linux 4.12+, only set if it exists
+if sysctl -n net.ipv4.tcp_tw_recycle 2>/dev/null; then
+    set_sysctl_config "net.ipv4.tcp_tw_recycle" "0"
+fi
+set_sysctl_config "net.ipv4.tcp_tw_reuse" "0"
 
 
 tmpfile="$$.tmp"
@@ -161,19 +301,29 @@ awk ' !x[$0]++{print > "'$tmpfile'"}' /etc/sysctl.conf
 mv $tmpfile /etc/sysctl.conf
 
 # ulimit
-echo "* soft nofile 1048576" >> /etc/security/limits.conf
-echo "* hard nofile 1048576" >> /etc/security/limits.conf
-echo "* soft nproc 65536" >> /etc/security/limits.conf
-echo "* hard nproc 65536" >> /etc/security/limits.conf
-echo "* soft memlock unlimited" >> /etc/security/limits.conf
-echo "* hard memlock unlimited" >> /etc/security/limits.conf
+# Helper function to safely set limits config
+# Adds the config if not exists, or updates it if exists (including commented ones)
+set_limits_config() {
+    local domain="$1"
+    local type="$2"
+    local item="$3"
+    local value="$4"
+    # Check if entry exists (including commented lines)
+    if grep -qE "^[#[:space:]]*${domain}\s+${type}\s+${item}\s+" /etc/security/limits.conf 2>/dev/null; then
+        # Entry exists, update it (remove comment if present and set value)
+        sed -r -i "s@^[#[:space:]]*${domain}\s+${type}\s+${item}\s+.*@${domain} ${type} ${item} ${value}@g" /etc/security/limits.conf
+    else
+        # Entry doesn't exist, append it
+        echo "${domain} ${type} ${item} ${value}" >> /etc/security/limits.conf
+    fi
+}
 
-sed -r -i  "s@#{0,}?\* soft nofile ?([0-9]{1,})@\* soft nofile 1048576@g" /etc/security/limits.conf
-sed -r -i  "s@#{0,}?\* hard nofile ?([0-9]{1,})@\* hard nofile 1048576@g" /etc/security/limits.conf
-sed -r -i  "s@#{0,}?\* soft nproc ?([0-9]{1,})@\* soft nproc 65536@g" /etc/security/limits.conf
-sed -r -i  "s@#{0,}?\* hard nproc ?([0-9]{1,})@\* hard nproc 65536@g" /etc/security/limits.conf
-sed -r -i  "s@#{0,}?\* soft memlock ?([0-9]{1,}([TGKM]B){0,1}|unlimited)@\* soft memlock unlimited@g" /etc/security/limits.conf
-sed -r -i  "s@#{0,}?\* hard memlock ?([0-9]{1,}([TGKM]B){0,1}|unlimited)@\* hard memlock unlimited@g" /etc/security/limits.conf
+set_limits_config "*" "soft" "nofile" "1048576"
+set_limits_config "*" "hard" "nofile" "1048576"
+set_limits_config "*" "soft" "nproc" "65536"
+set_limits_config "*" "hard" "nproc" "65536"
+set_limits_config "*" "soft" "memlock" "unlimited"
+set_limits_config "*" "hard" "memlock" "unlimited"
 
 tmpfile="$$.tmp"
 awk ' !x[$0]++{print > "'$tmpfile'"}' /etc/security/limits.conf
@@ -218,17 +368,6 @@ else
 fi
 sysctl -p
 
-sed -i ':a;$!{N;ba};s@# kubekey hosts BEGIN.*# kubekey hosts END@@' /etc/hosts
-sed -i '/^$/N;/\n$/N;//D' /etc/hosts
-
-cat >>/etc/hosts<<EOF
-# kubekey hosts BEGIN
-{{- range .Hosts }}
-{{ . }}
-{{- end }}
-# kubekey hosts END
-EOF
-
 sync
 echo 3 > /proc/sys/vm/drop_caches
 
@@ -252,16 +391,20 @@ func GenerateHosts(runtime connector.ModuleRuntime, kubeConf *common.KubeConf) [
 
 	for _, host := range runtime.GetAllHosts() {
 		if host.GetName() != "" {
-			hostsList = append(hostsList, fmt.Sprintf("%s  %s.%s %s",
-				host.GetInternalIPv4Address(),
-				host.GetName(),
-				kubeConf.Cluster.Kubernetes.ClusterName,
-				host.GetName()))
-			hostsList = append(hostsList, fmt.Sprintf("%s  %s.%s %s",
-				host.GetInternalIPv6Address(),
-				host.GetName(),
-				kubeConf.Cluster.Kubernetes.ClusterName,
-				host.GetName()))
+			if host.GetInternalIPv4Address() != "" {
+				hostsList = append(hostsList, fmt.Sprintf("%s  %s.%s %s",
+					host.GetInternalIPv4Address(),
+					host.GetName(),
+					kubeConf.Cluster.Kubernetes.ClusterName,
+					host.GetName()))
+			}
+			if host.GetInternalIPv6Address() != "" {
+				hostsList = append(hostsList, fmt.Sprintf("%s  %s.%s %s",
+					host.GetInternalIPv6Address(),
+					host.GetName(),
+					kubeConf.Cluster.Kubernetes.ClusterName,
+					host.GetName()))
+			}
 		}
 	}
 


### PR DESCRIPTION
…er configuration handling

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
if node is exist in cluster.
when applyConfigureOS is true, will execute init os script.
when applyConfigureOS is false, only check init os script.
the config-sample.yaml like this:
```yaml
kind: Cluster
metadata:
  name: sample
spec:
  system:
    applyConfigureOS: true
```
the check result like this:
<img width="635" height="145" alt="截屏2026-04-15 18 14 46" src="https://github.com/user-attachments/assets/29602453-b2ef-49b9-be68-20586124cab3" />

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
