### PR TITLE
fix: update image fetching logic to use FetchReference 

### DIFF
--- a/pkg/modules/image/image.go
+++ b/pkg/modules/image/image.go
@@ -456,19 +456,16 @@ func (i *imageArgs) copyWithPlatformFilter(ctx context.Context, src, dst *remote
 			return errors.Errorf("failed to get config from manifest for %s", img)
 		}
 
-		// Get config digest and mediaType
+		// Get config digest, mediaType, and size
 		configDigest, ok := config["digest"].(string)
 		if !ok {
 			return errors.Errorf("failed to get config digest from manifest for %s", img)
 		}
-		configMediaType, _ := config["mediaType"].(string)
 
 		// Fetch config to get platform info
-		configDesc := ocispec.Descriptor{
-			MediaType: configMediaType,
-			Digest:    digest.Digest(configDigest),
-		}
-		configRC, err := src.Blobs().Fetch(ctx, configDesc)
+		// Use FetchReference instead of Fetch to avoid Content-Length validation issues
+		// Some registries return different Content-Length than what the manifest declares
+		_, configRC, err := src.Blobs().FetchReference(ctx, configDigest)
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch config for %s", img)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
skip content-length check
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
