### PR TITLE
fix: reorder variable merging logic in GetAllVariable for clarity and…

### DIFF
--- a/pkg/variable/variable_get.go
+++ b/pkg/variable/variable_get.go
@@ -130,29 +130,28 @@ var GetAllVariable = func(hostname string) GetFunc {
 		}
 	}
 
-	// getHostsVariable builds a complete variable map for all hosts
-	// by combining variables from multiple sources in a specific order
 	getHostsVariable := func(v *variable) map[string]any {
 		globalHosts := make(map[string]any)
 		for hostname := range v.value.Hosts {
 			hostVars := make(map[string]any)
-			// Merge inventory-level variables first (lower priority than group vars)
+
+			// 1. Merge remote variables (lowest priority)
+			hostVars = CombineVariables(hostVars, v.value.Hosts[hostname].RemoteVars)
+			// 2. Merge runtime variables
+			hostVars = CombineVariables(hostVars, v.value.Hosts[hostname].RuntimeVars)
+			// 3. Merge inventory-level variables (vars)
 			hostVars = CombineVariables(hostVars, Extension2Variables(v.value.Inventory.Spec.Vars))
-			// Set group variables for hosts that belong to groups (override spec.vars)
+			// 4. Merge group variables (groups > vars)
 			for _, gv := range v.value.Inventory.Spec.Groups {
 				if slices.Contains(gv.Hosts, hostname) {
 					hostVars = CombineVariables(hostVars, Extension2Variables(gv.Vars))
 				}
 			}
-			// Merge remote variables (variables collected from the actual host)
-			hostVars = CombineVariables(hostVars, v.value.Hosts[hostname].RemoteVars)
-			// Merge runtime variables (variables set during playbook execution)
-			hostVars = CombineVariables(hostVars, v.value.Hosts[hostname].RuntimeVars)
-
-			// Merge host-specific variables from inventory (override group vars)
+			// 5. Merge host-specific variables from inventory (host > groups)
 			hostVars = CombineVariables(hostVars, Extension2Variables(v.value.Inventory.Spec.Hosts[hostname]))
-			// Merge configuration variables
+			// 6. Merge configuration variables (highest priority)
 			hostVars = CombineVariables(hostVars, Extension2Variables(v.value.Config.Spec))
+
 			// Set default variables for localhost
 			defaultHostVariable(hostname, hostVars)
 			globalHosts[hostname] = hostVars


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Fix variable priority: config > inventory(host > groups > vars) > runtime > remote


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
