### PR TITLE
fix: streamline image registry role tags and enhance delete options

### DIFF
--- a/builtin/core/playbooks/artifact_images.yaml
+++ b/builtin/core/playbooks/artifact_images.yaml
@@ -15,6 +15,6 @@
   roles:
     - role: download
     - role: image-registry/pull
-      tags: ["pull", "image_registry"]
+      tags: ["pull"]
     - role: image-registry/push
-      tags: ["push", "image_registry"]
+      tags: ["push"]

--- a/builtin/core/playbooks/delete_registry.yaml
+++ b/builtin/core/playbooks/delete_registry.yaml
@@ -16,3 +16,13 @@
    - image_registry
   roles:
     - role: uninstall/image-registry
+  post_tasks:
+    - name: DeleteImageRegistry | Clean up local DNS configuration files
+      ignore_errors: true
+      loop: "{{ .native.localDNS | toJson }}"
+      command: |
+        sed -i '/# kubekey hosts BEGIN/,/# kubekey hosts END/d' {{ .item }}
+        sed -i '/# kubekey kubernetes control_plane_endpoint BEGIN/,/# kubekey kubernetes control_plane_endpoint END/d' {{ .item }}
+        sed -i '/# kubekey image_registry control_plane_endpoint BEGIN/,/# kubekey image_registry control_plane_endpoint END/d' {{ .item }}
+      when: 
+        - .delete.dns

--- a/builtin/core/playbooks/init_registry.yaml
+++ b/builtin/core/playbooks/init_registry.yaml
@@ -26,6 +26,6 @@
     - image_registry
   tags: ["always"]
   roles:
-    - role: native/dns
     - role: native/init
+    - role: native/dns
     - role: image-registry

--- a/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
+++ b/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
@@ -31,13 +31,13 @@ image_registry:
         {{- end -}}
       {{- end -}}
     username: >-
-      {{- if .zone | ne "cn" -}}
+      {{- if .image_registry.type | empty | not -}}
       admin
-      {{- end -}}
+      {{- end }}
     password: >-
-      {{- if .zone | ne "cn" -}}
+      {{- if .image_registry.type | empty | not -}}
       Harbor12345
-      {{- end -}}
+      {{- end }}
     skip_tls_verify: >-
       {{- .image_registry.type | empty -}}
     ca_file: >-

--- a/builtin/core/roles/defaults/tasks/main.yaml
+++ b/builtin/core/roles/defaults/tasks/main.yaml
@@ -7,7 +7,7 @@
     mkdir -m 777 -p {{ .tmp_dir }}
 
 - name: Defaults | Load defaults based on Kubernetes version
-  tags: ["package", "image_registry"]
+  tags: ["always"]
   block:
     - name: Defaults | Load version-specific settings for Kubernetes
       when: .kubernetes.kube_version | empty | not

--- a/builtin/core/roles/defaults/templates/manifests.yaml
+++ b/builtin/core/roles/defaults/templates/manifests.yaml
@@ -582,13 +582,11 @@ download:
   {{- range .download.images.manifests }}
       - {{ . }}
   {{- end }}
-{{- else }}
-{{- if .download.kubernetes.kube_version | empty | not }}
+{{- else if .download.kubernetes.kube_version | empty | not }}
       # kubernetes
       ## kubernetes/high-availability
       - {{ if .download.images.registry | empty | not }}{{ .download.images.registry }}/library/haproxy:2.9.6-alpine{{ else }}docker.io/library/haproxy:2.9.6-alpine{{ end }}
       - {{ if .download.images.registry | empty | not }}{{ .download.images.registry }}/plndr/kube-vip:v0.7.2{{ else }}docker.io/plndr/kube-vip:v0.7.2{{ end }}
-{{- end }}
 {{- range .download.kubernetes.kube_version }}
       ## kubernetes/{{ . }}
       - {{ if $.download.images.registry | empty | not }}{{ $.download.images.registry }}/kubernetes/kube-apiserver:{{ . }}{{ else }}registry.k8s.io/kube-apiserver:{{ . }}{{ end }}
@@ -734,10 +732,10 @@ download:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- end }}
 {{- if .image_manifests | empty | not }}
       # External images
     {{- range .image_manifests }}
       - {{ . }}
     {{- end }}
-{{- end }}
 {{- end }}

--- a/builtin/core/roles/download/tasks/binary.yaml
+++ b/builtin/core/roles/download/tasks/binary.yaml
@@ -119,6 +119,7 @@
     timeout: "{{ .download.timeout }}"
 
 - name: Binary | Ensure Docker binary is present
+  tags: ["image_registry"]
   loop: >
     {{- $result := list -}}
     {{- range $arch := .download.arch }}
@@ -213,6 +214,7 @@
     timeout: "{{ .download.timeout }}"
 
 - name: Binary | Ensure Docker Registry binary is present
+  tags: ["image_registry"]
   loop: >
     {{- $result := list -}}
     {{- range $arch := .download.arch }}
@@ -231,6 +233,7 @@
     timeout: "{{ .download.timeout }}"
 
 - name: Binary | Ensure docker-compose binary is present
+  tags: ["image_registry"]
   loop: >
     {{- $result := list -}}
     {{- range $arch := .download.arch }}
@@ -249,6 +252,7 @@
     timeout: "{{ .download.timeout }}"
 
 - name: Binary | Ensure Harbor binary is present
+  tags: ["image_registry"]
   loop: >
     {{- $result := list -}}
     {{- range $arch := .download.arch }}

--- a/builtin/core/roles/image-registry/harbor/templates/harbor-replications.sh
+++ b/builtin/core/roles/image-registry/harbor/templates/harbor-replications.sh
@@ -3,15 +3,15 @@
 function createRegistries() {
 {{- range .groups.image_registry | default list }}
   {{- if ne . $.inventory_hostname }}
-  curl -k -u '{{ printf "%s:%s" $.image_registry.auth.username $.image_registry.auth.password }}' -X POST -H "Content-Type: application/json" "https://{{ $.inventory_hostname }}/api/v2.0/registries" -d "{\"name\": \"{{ . }}\", \"type\": \"harbor\", \"url\":\"https://{{ . }}:7443\", \"credential\": {\"access_key\": \"{{ $.image_registry.auth.username }}\", \"access_secret\": \"{{ $.image_registry.auth.password }}\"}, \"insecure\": true}"
+  curl -k -u '{{ printf "%s:%s" $.image_registry.auth.username $.image_registry.auth.password }}' -X POST -H "Content-Type: application/json" "https://{{ $.inventory_hostname }}/api/v2.0/registries" -d "{\"name\": \"{{ . }}\", \"type\": \"harbor\", \"url\":\"https://{{ . }}:443\", \"credential\": {\"access_key\": \"{{ $.image_registry.auth.username }}\", \"access_secret\": \"{{ $.image_registry.auth.password }}\"}, \"insecure\": true}"
   {{- end }}
 {{- end }}
 }
 
 function createReplication() {
-{{- range $index, $host := .groups.image_registry | default list }}
-  {{- if ne $host $.inventory_hostname }}
-  curl -k -u '{{ printf "%s:%s" $.image_registry.auth.username $.image_registry.auth.password }}' -X POST -H "Content-Type: application/json" "https://{{ $.inventory_hostname }}/api/v2.0/replication/policies" -d "{\"name\": \"{{ printf "%s_%s" $.inventory_hostname $host }}\", \"enabled\": true, \"deletion\":true, \"override\":true, \"replicate_deletion\":true, \"dest_registry\":{ \"id\": {{ $index }}, \"name\": \"{{ $host }}\"}, \"trigger\": {\"type\": \"event_based\"}, \"dest_namespace_replace_count\":1 }"
+{{- range .groups.image_registry | default list }}
+  {{- if ne . $.inventory_hostname }}
+  curl -k -u '{{ printf "%s:%s" $.image_registry.auth.username $.image_registry.auth.password }}' -X POST -H "Content-Type: application/json" "https://{{ $.inventory_hostname }}/api/v2.0/replication/policies" -d "{\"name\": \"{{ printf "%s_%s" $.inventory_hostname . }}\", \"enabled\": true, \"deletion\":true, \"override\":true, \"replicate_deletion\":true, \"dest_registry\":{ \"id\": 1, \"name\": \"{{ . }}\"}, \"trigger\": {\"type\": \"event_based\"}, \"dest_namespace_replace_count\":1 }"
   {{- end }}
 {{- end }}
 }

--- a/builtin/core/roles/image-registry/harbor/templates/harbor.yml
+++ b/builtin/core/roles/image-registry/harbor/templates/harbor.yml
@@ -2,7 +2,7 @@
 
 # The IP address or hostname to access admin UI and registry service.
 # DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
-hostname: {{ .image_registry.auth.registry | splitList "/" | first }}
+hostname: {{if .groups.image_registry | len | lt 1}}{{ .inventory_hostname }}{{else}}{{ .image_registry.auth.registry | splitList "/" | first }}{{ end }}
 
 # http related config
 http:

--- a/builtin/core/roles/image-registry/pull/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/pull/tasks/main.yaml
@@ -1,5 +1,5 @@
 - name: PullImage | Download container images
-  tags: ["pull","image_registry"]
+  tags: ["pull"]
   when: .download.fetch
   image:
     platform: >

--- a/builtin/core/roles/image-registry/push/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/push/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: ImageRegistry | Ensure Harbor project exists for each image
-  tags: ["push", "image_registry"]
-  when: .image_registry.type | eq "harbor"
+  tags: ["push"]
+  ignore_errors: true
   command: |
     # Traverse first-level subdirectories in images_dir, skipping 'blobs'
     registry_url="{{ .image_registry.auth.registry }}"
@@ -42,7 +42,7 @@
     fi
 
 - name: ImageRegistry | Push images package to image registry
-  tags: ["push", "image_registry"]
+  tags: ["push"]
   run_once: true
   image:
     platform: >

--- a/builtin/core/roles/native/dns/tasks/main.yaml
+++ b/builtin/core/roles/native/dns/tasks/main.yaml
@@ -36,6 +36,7 @@
     {{ index $.hostvars . "internal_ipv6" }} {{ index $.hostvars . "hostname" }}
       {{- end }}
     {{- end }}
+    # kubekey image_registry control_plane_endpoint BEGIN
     {{- if and (.image_registry.auth.registry | empty | not) (.image_registry.ha_vip | empty | not) }}
     {{ .image_registry.ha_vip }} {{ .image_registry.auth.registry | splitList "/" | first }}
     {{- else }}
@@ -48,6 +49,7 @@
         {{- end }}
       {{- end }}
     {{- end }}
+    # kubekey image_registry control_plane_endpoint END
     # NFS server nodes
     {{- range .groups.nfs | default list }}
       {{- if (index $.hostvars . "internal_ipv4") | empty | not }}

--- a/cmd/kk/app/options/builtin/artifact.go
+++ b/cmd/kk/app/options/builtin/artifact.go
@@ -148,7 +148,7 @@ func (o *ArtifactImagesOptions) Complete(cmd *cobra.Command, args []string) (*kk
 		tags = append(tags, "pull")
 	}
 	if !o.Pull && !o.Push {
-		tags = append(tags, "image_registry")
+		tags = append(tags, "pull", "push")
 	}
 
 	playbook.Spec = kkcorev1.PlaybookSpec{

--- a/cmd/kk/app/options/builtin/delete.go
+++ b/cmd/kk/app/options/builtin/delete.go
@@ -130,10 +130,10 @@ func (o *DeleteClusterOptions) completeConfig() error {
 		if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "image_registry"); err != nil {
 			return errors.Wrapf(err, "failed to set %q to config", "delete_image_registry")
 		}
-		if o.DeleteData {
-			if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "data"); err != nil {
-				return errors.Wrapf(err, "failed to set %q to config", "delete_data")
-			}
+	}
+	if o.DeleteData {
+		if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "data"); err != nil {
+			return errors.Wrapf(err, "failed to set %q to config", "delete_data")
 		}
 	}
 
@@ -248,10 +248,10 @@ func (o *DeleteNodesOptions) completeConfig(nodes []string) error {
 		if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "image_registry"); err != nil {
 			return errors.Wrapf(err, "failed to set %q to config", "delete_image_registry")
 		}
-		if o.DeleteData {
-			if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "data"); err != nil {
-				return errors.Wrapf(err, "failed to set %q to config", "delete_data")
-			}
+	}
+	if o.DeleteData {
+		if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "data"); err != nil {
+			return errors.Wrapf(err, "failed to set %q to config", "delete_data")
 		}
 	}
 
@@ -422,8 +422,9 @@ func NewDeleteRegistryOptions() *DeleteRegistryOptions {
 type DeleteRegistryOptions struct {
 	options.CommonOptions
 	// kubernetes version which the config will install.
-	Kubernetes string
-	DeleteData bool
+	Kubernetes          string
+	DeleteAllComponents bool
+	DeleteData          bool
 }
 
 // Flags returns the flag sets for DeleteImageRegistryOptions
@@ -431,6 +432,7 @@ func (o *DeleteRegistryOptions) Flags() cliflag.NamedFlagSets {
 	fss := o.CommonOptions.Flags()
 	kfs := fss.FlagSet("config")
 	kfs.StringVar(&o.Kubernetes, "with-kubernetes", o.Kubernetes, fmt.Sprintf("Specify a supported version of kubernetes. default is %s", o.Kubernetes))
+	kfs.BoolVar(&o.DeleteAllComponents, "all", o.DeleteAllComponents, "Delete all cluster components, including cri, dns.")
 	kfs.BoolVar(&o.DeleteData, "with-data", o.DeleteData, "Also delete data directories (harbor data, registry data, etc.). Use with caution.")
 
 	return fss
@@ -465,13 +467,27 @@ func (o *DeleteRegistryOptions) Complete(cmd *cobra.Command, args []string) (*kk
 		return nil, err
 	}
 
+	// Complete config specific to delete image registry
+	return playbook, o.completeConfig()
+}
+
+// completeConfig updates the configuration with container manager settings
+func (o *DeleteRegistryOptions) completeConfig() error {
 	// Set delete data option if specified
+	if o.DeleteAllComponents {
+		if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "cri"); err != nil {
+			return errors.Wrapf(err, "failed to set %q to config", "delete_cri")
+		}
+
+		if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "dns"); err != nil {
+			return errors.Wrapf(err, "failed to set %q to config", "delete_dns")
+		}
+	}
 	if o.DeleteData {
 		if err := unstructured.SetNestedField(o.Config.Value(), true, "delete", "data"); err != nil {
-			return nil, errors.Wrapf(err, "failed to set %q to config", "delete_data")
+			return errors.Wrapf(err, "failed to set %q to config", "delete_data")
 		}
 	}
 
-	// Complete config specific to delete image registry
-	return playbook, nil
+	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
When deploying Harbor in high availability (HA) mode, the current configuration has two issues:
1. **Domain conflict in HA deployment**: Both Harbor instances cannot share the same domain for deployment. This leads to conflicts and incorrect routing.
2. **Hard-coded destination registry ID**: When setting up replication policies between HA Harbor instances, the `dest_registry` id is hard-coded to `1`. This only works for fresh Harbor installations and breaks if the registry id is different.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
1. Use each node's **hostname** as its deployment domain, while the VIP (Virtual IP) maps to the configured user-facing domain.
2. Before creating a replication policy, **query the Harbor API** (`GET /api/v2.0/registries?name={name}`) to retrieve the actual registry id dynamically, and use that value as `dest_registry.id` instead of the hard-coded `1`.


### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
