### PR TITLE
fix: delete worker node error

### DIFF
--- a/builtin/core/playbooks/delete_nodes.yaml
+++ b/builtin/core/playbooks/delete_nodes.yaml
@@ -66,6 +66,7 @@
     - k8s_cluster
   pre_tasks:
     - name: DeleteNode | Remove node from Kubernetes cluster
+      delegate_to: "{{ subtractList .groups.kube_control_plane .delete_nodes | first }}"
       when: .delete_nodes | default list | has .inventory_hostname
       command: |
         if kubectl get node {{ .hostname }} > /dev/null 2>&1; then

--- a/pkg/converter/tmpl/functions.go
+++ b/pkg/converter/tmpl/functions.go
@@ -169,19 +169,43 @@ func pow(base, pow float64) (float64, error) {
 // subtractList returns a new list containing elements from list a that are not in list b.
 // It first creates a set from list b for O(1) lookups, then builds a result list by
 // including only elements from a that don't exist in the set.
-func subtractList(a, b []any) ([]any, error) {
-	set := make(map[any]struct{}, len(b))
-	for _, v := range b {
+func subtractList(a, b any) ([]any, error) {
+	aSlice, err := toAnySlice(a)
+	if err != nil {
+		return nil, err
+	}
+	bSlice, err := toAnySlice(b)
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[any]struct{}, len(bSlice))
+	for _, v := range bSlice {
 		set[v] = struct{}{}
 	}
 
-	result := make([]any, 0, len(a))
-	for _, v := range a {
+	result := make([]any, 0, len(aSlice))
+	for _, v := range aSlice {
 		if _, exists := set[v]; !exists {
 			result = append(result, v)
 		}
 	}
 
+	return result, nil
+}
+
+func toAnySlice(v any) ([]any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil, fmt.Errorf("expected slice or array, got %T", v)
+	}
+	result := make([]any, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		result[i] = rv.Index(i).Interface()
+	}
 	return result, nil
 }
 

--- a/pkg/modules/internal/options.go
+++ b/pkg/modules/internal/options.go
@@ -76,7 +76,7 @@ func (o ExecOptions) GetConnector(ctx context.Context) (connector.Connector, err
 	if o.Task.Spec.DelegateTo != "" {
 		host, err = tmpl.ParseFunc(ha, o.Task.Spec.DelegateTo, tmpl.StringFunc)
 		if err != nil {
-			return nil, errors.Errorf("failed to delegate %q to %q", o.Host, o.Task.Spec.DelegateTo)
+			return nil, errors.Errorf("failed to delegate %q to %q. error: %v", o.Host, o.Task.Spec.DelegateTo, err)
 		}
 	}
 	if val := ctx.Value(ConnKey); val != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
fix: delegate worker node removal to control plane to avoid kubeconfig missing error

Issue:
- Node deletion relies on kubectl commands which require kubeconfig
- Worker nodes lack kubeconfig, causing kubectl/drain/cordon to fail
- This results in errors during worker node removal

Fix:
- Delegate node removal tasks (kubectl cordon/drain/delete) to a control plane node
- Ensure the delegated control plane node is not in the delete_nodes list
- Fix subtractList to accept any slice type ([]string / []interface{}) to prevent template type errors


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/kubekey/issues/3104
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
