### PR TITLE
fix: install local iso failed

### DIFF
--- a/builtin/capkk/roles/init/init-os/tasks/init_repository.yaml
+++ b/builtin/capkk/roles/init/init-os/tasks/init_repository.yaml
@@ -39,8 +39,8 @@
           apt install -y socat conntrack ipset ebtables chrony ipvsadm
           # reset repository
           rm -rf /etc/apt/sources.list.d
-          mv /etc/apt/sources.list.kubekey.bak-$now /etc/apt/sources.list
-          mv /etc/apt/sources.list.d.kubekey.bak-$now /etc/apt/sources.list.d
+          mv /etc/apt/sources.list.kubekey-$now.bak /etc/apt/sources.list
+          mv /etc/apt/sources.list.d.kubekey-$now.bak /etc/apt/sources.list.d
         else
           apt-get update && apt install -y socat conntrack ipset ebtables chrony ipvsadm
         fi
@@ -71,7 +71,7 @@
           yum install -y openssl socat conntrack ipset ebtables chrony ipvsadm
           # reset repository
           rm -rf /etc/yum.repos.d
-          mv /etc/yum.repos.d.kubekey.bak-$now /etc/yum.repos.d
+          mv /etc/yum.repos.d.kubekey-$now.bak /etc/yum.repos.d
         else
           # install
           yum install -y openssl socat conntrack ipset ebtables chrony ipvsadm

--- a/builtin/core/roles/native/repository/tasks/install_package.yaml
+++ b/builtin/core/roles/native/repository/tasks/install_package.yaml
@@ -43,7 +43,7 @@
         esac
       fi
     done
-    if [ -f "{{ .tmp_dir }}/iso" ]; then
+    if [ -f "{{ .tmp_dir }}/repository.iso" ]; then
       # Backup current APT sources
       mv /etc/apt/sources.list /etc/apt/sources.list.kubekey-$now.bak
       mv /etc/apt/sources.list.d /etc/apt/sources.list.d.kubekey-$now.bak
@@ -59,8 +59,8 @@
       fi
       # Restore original APT sources
       rm -rf /etc/apt/sources.list.d
-      mv /etc/apt/sources.list.kubekey.bak-$now /etc/apt/sources.list
-      mv /etc/apt/sources.list.d.kubekey.bak-$now /etc/apt/sources.list.d
+      mv /etc/apt/sources.list.kubekey-$now.bak /etc/apt/sources.list
+      mv /etc/apt/sources.list.d.kubekey-$now.bak /etc/apt/sources.list.d
     else
       # No local ISO found, using default repositories
       apt-get update
@@ -104,7 +104,7 @@
         esac      
       fi
     done
-    if [ -f "{{ .tmp_dir }}/iso" ]; then
+    if [ -f "{{ .tmp_dir }}/repository.iso" ]; then
       # Backup current YUM repositories
       mv /etc/yum.repos.d "$BACKUP_FILE"
       mkdir -p /etc/yum.repos.d

--- a/builtin/core/roles/native/repository/tasks/main.yaml
+++ b/builtin/core/roles/native/repository/tasks/main.yaml
@@ -25,9 +25,9 @@
           {{- if .os.release.ID | unquote | eq "kylin" }}
           kylin-{{ .os.release.VERSION_ID | replace "\"" "" | unquote | trim | lower }}{{ .sp_version | trim }}
           {{- else if .os.release.ID_LIKE | unquote | eq "rhel fedora" }}
-          {{ .os.release.ID | replace "\"" "" | unquote | trim | lower  }}{{ .os.release.VERSION_ID | trim }}
+          {{ .os.release.ID | replace "\"" "" | unquote | trim | lower  }}{{ .os.release.VERSION_ID | replace "\"" "" | unquote | trim }}
           {{- else }}
-          {{ .os.release.ID | replace "\"" "" | unquote | trim | lower  }}-{{ .os.release.VERSION_ID | trim }}
+          {{ .os.release.ID | replace "\"" "" | unquote | trim | lower  }}-{{ .os.release.VERSION_ID | replace "\"" "" | unquote | trim }}
           {{- end -}}
 
     - name: Repository | Define the package file type by system info


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
This PR fixes two bugs in the offline repository installation logic that prevent KubeKey from using local ISO repositories on Debian/Ubuntu nodes.

1. **Fixes incorrect local ISO path check**:
   In `install_package.yaml`, the condition `[ -f "{{ .tmp_dir }}/iso" ]` checks a mount **directory** using the `-f` (file) test, which always returns `false`. This causes the script to skip the local repository branch and fall back to public APT mirrors (`archive.ubuntu.com`), which are unreachable in offline/air-gapped environments. The condition is changed to `[ -f "{{ .tmp_dir }}/repository.iso" ]` to correctly detect the ISO file.

2. **Fixes mismatched backup/restore filenames**:
   The backup step uses the suffix `kubekey-$now.bak` (timestamp before `.bak`), but the restore step incorrectly uses `kubekey.bak-$now` (timestamp after `.bak`). Because the filenames do not match, the original APT/YUM source configurations fail to restore after package installation.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
Please verify that:
- In `builtin/core/roles/native/repository/tasks/install_package.yaml`, both the Debian and RHEL branches now use `repository.iso` for the local source detection.
- In `builtin/capkk/roles/init/init-os/tasks/init_repository.yaml`, the backup and restore filenames are now consistent for both APT and YUM flows.

```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where offline nodes incorrectly attempted to connect to public Ubuntu repositories instead of using the local ISO repository, causing package installation to fail in air-gapped environments.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
