### PR TITLE
fix: exclude cn zone in cri config.

### DIFF
--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -61,7 +61,7 @@ state = "/run/containerd"
 {{- if or (.cri.registry.auths | empty | not) (.groups.image_registry | default list | empty | not) }}
         [plugins."io.containerd.grpc.v1.cri".registry.configs]
 {{- end }}
-{{- if .image_registry.auth.registry | empty | not }}
+{{- if and (.image_registry.auth.registry | empty | not) (ne (.image_registry.auth.registry | splitList "/" | first) "hub.kubesphere.com.cn") }}
   {{- $registry_parts := .image_registry.auth.registry | splitList "/" | first }}
           [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $registry_parts }}".auth]
             username = "{{ .image_registry.auth.username }}"

--- a/builtin/core/roles/cri/docker/templates/daemon.json
+++ b/builtin/core/roles/cri/docker/templates/daemon.json
@@ -1,7 +1,7 @@
 {
   "log-opts": {
-    "max-size": "5m",
-    "max-file":"3"
+    "max-size": "{{ .kubernetes.kubelet.container_log_max_size | toLowerByteUnit }}",
+    "max-file":"{{ .kubernetes.kubelet.container_log_max_files }}"
   },
 {{- if .cri.docker.data_root }}
   "data-root": "{{ .cri.docker.data_root }}",
@@ -10,8 +10,8 @@
   "registry-mirrors": {{ .cri.registry.mirrors | toJson }},
 {{- end }}
 {{- $insecure_registries := .cri.registry.insecure_registries | default list }} 
-{{- if and .image_registry.auth.skip_tls_verify (.image_registry.auth.registry | empty | not) }}
-  {{- $insecure_registries = append $insecure_registries .image_registry.auth.registry | splitList "/" | first }}
+{{- if and .image_registry.auth.skip_tls_verify (.image_registry.auth.registry | empty | not) (ne (.image_registry.auth.registry | splitList "/" | first) "hub.kubesphere.com.cn") }}
+  {{- $insecure_registries = append $insecure_registries (.image_registry.auth.registry | splitList "/" | first) }}
 {{- end }}
 {{- range .cri.registry.auths | default list }}
   {{- if and .skip_tls_verify (.registry | empty | not) }}

--- a/builtin/core/roles/image-registry/docker-compose/templates/daemon.json
+++ b/builtin/core/roles/image-registry/docker-compose/templates/daemon.json
@@ -1,7 +1,7 @@
 {
   "log-opts": {
-    "max-size": "5m",
-    "max-file":"3"
+    "max-size": "20m",
+    "max-file":"5"
   },
 {{- if .cri.docker.data_root | empty | not }}
   "data-root": "{{ .cri.docker.data_root }}",
@@ -9,10 +9,10 @@
 {{- if .cri.registry.mirrors | empty | not }}
   "registry-mirrors": {{ .cri.registry.mirrors | toJson }},
 {{- end }}
- {{- if .cri.registry.insecure_registries | empty | not }}
+{{- if .cri.registry.insecure_registries | empty | not }}
   "insecure-registries": {{ .cri.registry.insecure_registries | toJson }},
 {{- end }}
- {{- if .cri.docker.bridge_ip | empty | not }}
+{{- if .cri.docker.bridge_ip | empty | not }}
   "bip": "{{ .cri.docker.bridge_ip }}",
 {{- end }}
   "exec-opts": ["native.cgroupdriver={{ .cri.cgroup_driver | default "systemd" }}"]

--- a/pkg/converter/tmpl/functions.go
+++ b/pkg/converter/tmpl/functions.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -35,6 +36,7 @@ func funcMap() template.FuncMap {
 	f["fileExists"] = fileExists
 	f["unquote"] = unquote
 	f["getStringSlice"] = getStringSlice
+	f["toLowerByteUnit"] = toLowerByteUnit
 	f["mapToNamedStringArgs"] = mapToNamedStringArgs
 
 	return f
@@ -253,4 +255,16 @@ func mapToNamedStringArgs(input any) []map[string]string {
 		result = append(result, map[string]string{"name": key, "value": valueStr})
 	}
 	return result
+}
+
+// toLowerByteUnit converts storage size units from uppercase binary suffixes to lowercase.
+// For example: 5Mi -> 5m, 1Gi -> 1g, 512Ki -> 512k.
+// Inputs that are already lowercase, pure numbers, or unrecognizable formats are returned as-is.
+func toLowerByteUnit(input string) string {
+	re := regexp.MustCompile(`^(\d+)([KMGTPE]i)$`)
+	matches := re.FindStringSubmatch(input)
+	if len(matches) != 3 {
+		return input
+	}
+	return matches[1] + strings.ToLower(strings.TrimSuffix(matches[2], "i"))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
exclude cn zone in cri config.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
