### PR TITLE
fix: add client certs for image registry

### DIFF
--- a/builtin/core/roles/certs/init/tasks/main.yaml
+++ b/builtin/core/roles/certs/init/tasks/main.yaml
@@ -125,6 +125,22 @@
       {{ .binary_dir }}/pki/image_registry.crt
   when: .groups.image_registry | default list | empty | not
 
+- name: Cert | Generate the image registry client certificate file
+  tags: ["image_registry"]
+  when: .groups.image_registry | default list | empty | not
+  gen_cert:
+    root_key: >-
+      {{ .binary_dir }}/pki/root.key
+    root_cert: >-
+      {{ .binary_dir }}/pki/root.crt
+    cn: image-registry-client
+    date: "{{ .certs.image_registry.date }}"
+    policy: "{{ .certs.image_registry.gen_cert_policy }}"
+    out_key: >-
+      {{ .binary_dir }}/pki/image-registry-client.key
+    out_cert: >-
+      {{ .binary_dir }}/pki/image-registry-client.crt
+
 - name: Cert | Set ownership of the PKI directory to the sudo user
   block:
     - name: Cert | Change ownership of the PKI directory to the sudo user

--- a/builtin/core/roles/cri/containerd/tasks/main.yaml
+++ b/builtin/core/roles/cri/containerd/tasks/main.yaml
@@ -39,22 +39,22 @@
           {{ .image_registry.auth.ca_file }}
         dest: >-
           /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/ca.crt
-    - name: Containerd | Copy image registry server certificate to the remote node
+    - name: Containerd | Copy image registry client certificate to the remote node
       when:
       - .image_registry.auth.cert_file | fileExists
       copy:
         src: >-
           {{ .image_registry.auth.cert_file }}
         dest: >-
-          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/server.crt
-    - name: Containerd | Copy image registry server key to the remote node
+          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/client.crt
+    - name: Containerd | Copy image registry client key to the remote node
       when:
       - .image_registry.auth.key_file | fileExists
       copy:
         src: >-
           {{ .image_registry.auth.key_file }}
         dest: >-
-          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/server.key
+          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/client.key
 
 - name: Containerd | Generate the containerd configuration file
   when: or .upgrade.cri (or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not))

--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -70,11 +70,11 @@ state = "/run/containerd"
   {{- if printf "/etc/containerd/certs.d/%s/ca.crt" $registry_parts | fileExists }}
             ca_file = "/etc/containerd/certs.d/{{ $registry_parts }}/ca.crt"
   {{- end }}
-  {{- if printf "/etc/containerd/certs.d/%s/server.crt" $registry_parts | fileExists }}
-            cert_file = "/etc/containerd/certs.d/{{ $registry_parts }}/server.crt"
+  {{- if printf "/etc/containerd/certs.d/%s/client.crt" $registry_parts | fileExists }}
+            cert_file = "/etc/containerd/certs.d/{{ $registry_parts }}/client.crt"
   {{- end }}
-  {{- if printf "/etc/containerd/certs.d/%s/server.key" $registry_parts | fileExists }}
-            key_file = "/etc/containerd/certs.d/{{ $registry_parts }}/server.key"
+  {{- if printf "/etc/containerd/certs.d/%s/client.key" $registry_parts | fileExists }}
+            key_file = "/etc/containerd/certs.d/{{ $registry_parts }}/client.key"
   {{- end }}
             insecure_skip_verify = {{ hasKey .image_registry.auth "skip_tls_verify" | ternary .image_registry.auth.skip_tls_verify true }}
 {{- end }}

--- a/builtin/core/roles/cri/docker/tasks/main.yaml
+++ b/builtin/core/roles/cri/docker/tasks/main.yaml
@@ -52,22 +52,22 @@
           {{ .image_registry.auth.ca_file }}
         dest: >-
           /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/ca.crt
-    - name: Docker | Copy image registry server certificate to the remote node
+    - name: Docker | Copy image registry client certificate to the remote node
       when:
       - .image_registry.auth.cert_file | fileExists
       copy:
         src: >-
           {{ .image_registry.auth.cert_file }}
         dest: >-
-          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/server.crt
-    - name: Docker | Copy image registry server key to the remote node
+          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/client.crt
+    - name: Docker | Copy image registry client key to the remote node
       when:
       - .image_registry.auth.key_file | fileExists
       copy:
         src: >-
           {{ .image_registry.auth.key_file }}
         dest: >-
-          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/server.key
+          /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/client.key
 
 # install or update docker service
 - name: Docker | Generate Docker configuration file
@@ -99,4 +99,5 @@
 # Docker | Install cri-dockerd if required for Kubernetes >= v1.24.0
 - include_tasks: cridockerd.yaml
   when:
+    - .cri.container_manager | eq "docker"
     - .kubernetes.kube_version | semverCompare ">=v1.24.0"

--- a/builtin/core/roles/cri/docker/templates/config.toml
+++ b/builtin/core/roles/cri/docker/templates/config.toml
@@ -70,11 +70,11 @@ state = "/run/containerd"
   {{- if printf "/etc/containerd/certs.d/%s/ca.crt" $registry_parts | fileExists }}
             ca_file = "/etc/containerd/certs.d/{{ $registry_parts }}/ca.crt"
   {{- end }}
-  {{- if printf "/etc/containerd/certs.d/%s/server.crt" $registry_parts | fileExists }}
-            cert_file = "/etc/containerd/certs.d/{{ $registry_parts }}/server.crt"
+  {{- if printf "/etc/containerd/certs.d/%s/client.crt" $registry_parts | fileExists }}
+            cert_file = "/etc/containerd/certs.d/{{ $registry_parts }}/client.crt"
   {{- end }}
-  {{- if printf "/etc/containerd/certs.d/%s/server.key" $registry_parts | fileExists }}
-            key_file = "/etc/containerd/certs.d/{{ $registry_parts }}/server.key"
+  {{- if printf "/etc/containerd/certs.d/%s/client.key" $registry_parts | fileExists }}
+            key_file = "/etc/containerd/certs.d/{{ $registry_parts }}/client.key"
   {{- end }}
             insecure_skip_verify = {{ hasKey .image_registry.auth "skip_tls_verify" | ternary .image_registry.auth.skip_tls_verify true }}
 {{- end }}

--- a/builtin/core/roles/defaults/defaults/main/02-certs.yaml
+++ b/builtin/core/roles/defaults/defaults/main/02-certs.yaml
@@ -13,6 +13,8 @@
 # |
 # |- image_registry.cert
 # |- image_registry.key
+# |- image-registry-client.cert
+# |- image-registry-client.key
 # |
 # |- kubernetes.cert
 # |- kubernetes.key

--- a/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
+++ b/builtin/core/roles/defaults/defaults/main/02-image_registry.yaml
@@ -42,11 +42,11 @@ image_registry:
       {{- end -}}
     cert_file: >-
       {{- if .groups.image_registry | default list | empty | not -}}
-      {{ .binary_dir }}/pki/image_registry.crt
+      {{ .binary_dir }}/pki/image-registry-client.crt
       {{- end -}}
     key_file: >-
       {{- if .groups.image_registry | default list | empty | not -}}
-      {{ .binary_dir }}/pki/image_registry.key
+      {{ .binary_dir }}/pki/image-registry-client.key
       {{- end -}}
   # Registry endpoint for images from docker.io
   dockerio_registry: >-

--- a/builtin/core/roles/precheck/image-registry/network/tasks/main.yaml
+++ b/builtin/core/roles/precheck/image-registry/network/tasks/main.yaml
@@ -38,7 +38,7 @@
   when: .cert_check_input_cert_result.stdout | eq "false"
   register: cert_check_self_cert_result
   command: |
-    if /etc/kubekey/scripts/check.sh {{ .image_registry.auth.registry | splitList "/" | first }} --ca-file {{ .binary_dir }}/pki/root.crt --cert-file {{ .binary_dir }}/pki/image_registry.crt --key-file {{ .binary_dir }}/pki/image_registry.key ; then
+    if /etc/kubekey/scripts/check.sh {{ .image_registry.auth.registry | splitList "/" | first }} --ca-file {{ .binary_dir }}/pki/root.crt --cert-file {{ .binary_dir }}/pki/image-registry-client.crt --key-file {{ .binary_dir }}/pki/image-registry-client.key ; then
         echo "true"
     else
         echo "false"
@@ -53,5 +53,5 @@
       image_registry:
         auth:
           ca_file: "{{ .binary_dir }}/pki/root.crt"
-          cert_file: "{{ .binary_dir }}/pki/image_registry.crt"
-          key_file: "{{ .binary_dir }}/pki/image_registry.key"
+          cert_file: "{{ .binary_dir }}/pki/image-registry-client.crt"
+          key_file: "{{ .binary_dir }}/pki/image-registry-client.key"

--- a/docs/en/reference/config.md
+++ b/docs/en/reference/config.md
@@ -229,6 +229,8 @@ cluster_require:
 # |
 # |- image_registry.cert
 # |- image_registry.key
+# |- image-registry-client.cert
+# |- image-registry-client.key
 # |
 # |- kubernetes.cert
 # |- kubernetes.key
@@ -333,11 +335,11 @@ image_registry:
       {{- end -}}
     cert_file: >-
       {{- if .groups.image_registry | default list | empty | not -}}
-      {{ .binary_dir }}/pki/image_registry.crt
+      {{ .binary_dir }}/pki/image-registry-client.crt
       {{- end -}}
     key_file: >-
       {{- if .groups.image_registry | default list | empty | not -}}
-      {{ .binary_dir }}/pki/image_registry.key
+      {{ .binary_dir }}/pki/image-registry-client.key
       {{- end -}}
   # Registry endpoint for images from docker.io
   dockerio_registry: >-

--- a/docs/zh/reference/config.md
+++ b/docs/zh/reference/config.md
@@ -227,6 +227,8 @@ cluster_require:
 # |
 # |- image_registry.cert
 # |- image_registry.key
+# |- image-registry-client.cert
+# |- image-registry-client.key
 # |
 # |- kubernetes.cert
 # |- kubernetes.key
@@ -331,11 +333,11 @@ image_registry:
       {{- end -}}
     cert_file: >-
       {{- if .groups.image_registry | default list | empty | not -}}
-      {{ .binary_dir }}/pki/image_registry.crt
+      {{ .binary_dir }}/pki/image-registry-client.crt
       {{- end -}}
     key_file: >-
       {{- if .groups.image_registry | default list | empty | not -}}
-      {{ .binary_dir }}/pki/image_registry.key
+      {{ .binary_dir }}/pki/image-registry-client.key
       {{- end -}}
   # docker.io 来源镜像所使用的镜像仓库端点
   dockerio_registry: >-

--- a/pkg/modules/image/image.go
+++ b/pkg/modules/image/image.go
@@ -145,6 +145,9 @@ type imageAuth struct {
 	Password      string `json:"password"`
 	SkipTLSVerify *bool  `json:"skip_tls_verify"`
 	PlainHTTP     *bool  `json:"plain_http"`
+	CaFile        string `json:"ca_file"`
+	CertFile      string `json:"cert_file"`
+	KeyFile       string `json:"key_file"`
 }
 
 // imageArgs holds the configuration for image operations using the new format (src/dest/manifests).

--- a/pkg/modules/image/repository.go
+++ b/pkg/modules/image/repository.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -80,12 +81,38 @@ func newRemoteRepository(reference string, auths []imageAuth) (*remote.Repositor
 		}
 	}
 
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: skipTLSVerify,
+	}
+
+	if matchedAuth != nil {
+		// Load CA certificate
+		if matchedAuth.CaFile != "" {
+			caCert, err := os.ReadFile(matchedAuth.CaFile)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to read CA file %q", matchedAuth.CaFile)
+			}
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM(caCert) {
+				return nil, errors.Errorf("failed to append CA certificate from %q", matchedAuth.CaFile)
+			}
+			tlsConfig.RootCAs = caCertPool
+		}
+
+		// Load client certificate for mTLS
+		if matchedAuth.CertFile != "" && matchedAuth.KeyFile != "" {
+			cert, err := tls.LoadX509KeyPair(matchedAuth.CertFile, matchedAuth.KeyFile)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to load client certificate from %q and %q", matchedAuth.CertFile, matchedAuth.KeyFile)
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
+	}
+
 	repository.Client = &auth.Client{
 		Client: &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: skipTLSVerify,
-				},
+				TLSClientConfig: tlsConfig,
 			},
 		},
 		Cache: auth.NewCache(),


### PR DESCRIPTION
### What type of PR is this?
/kind bug
### What this PR does / why we need it:
Previously, the image registry client reused the server certificates (`image_registry.crt` and `image_registry.key`) for mTLS authentication with the registry, which is not best practice and may cause certificate verification issues in certain scenarios.
This PR makes the following changes:
1. **Generate a dedicated image registry client certificate**: Adds a new certificate generation task (`image-registry-client.crt` and `image-registry-client.key`) during the cert initialization phase, with CN set to `image-registry-client`.
2. **Update image registry default configuration**: Changes the default paths of `image_registry.auth.cert_file` and `key_file` from server certificates to the newly generated client certificates.
3. **Update the network precheck logic**: Updates the image registry network connectivity check to use the new client certificate paths for validation.
4. **Synchronize documentation updates**: Updates the certificate paths and related comments in both English and Chinese configuration reference docs (`docs/en/reference/config.md` and `docs/zh/config/reference/config.md`).
### Which issue(s) this PR fixes:
Fixes #
### Special notes for reviewers:
```
- This change affects certificate generation, default configuration, precheck tasks, and documentation. Please ensure all references to `image_registry.crt/key` have been replaced.
- The expiration and generation policy for the dedicated client certificate follow the existing `image_registry` certificate configuration.
```
### Does this PR introduced a user-facing change?
```release-note
Fix the issue where image registry client authentication reused the server certificate. Now a dedicated client certificate (`image-registry-client.crt` and `image-registry-client.key`) is generated and used instead.
```
### Additional documentation, usage docs, etc.:
```docs
- [Usage]: When configuring a private image registry that requires mTLS authentication, KubeKey will now automatically generate and use a dedicated client certificate for communication.
```