### PR TITLE
fix: duplicated https:// prefix for IPv6 etcd endpoints

### DIFF
--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
@@ -23,7 +23,7 @@ etcd:
       - {{ printf "https://%s:%d" $internalIPv4 $.etcd.port }}
         {{- end }}
         {{- if $internalIPv6 | empty | not }}
-      - https://{{ printf "https://[%s]:%d" $internalIPv6 $.etcd.port }}
+      - {{ printf "https://[%s]:%d" $internalIPv6 $.etcd.port }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
@@ -24,7 +24,7 @@ etcd:
       - {{ printf "https://%s:%d" $internalIPv4 $.etcd.port }}
         {{- end }}
         {{- if $internalIPv6 | empty | not }}
-      - https://{{ printf "https://[%s]:%d" $internalIPv6 $.etcd.port }}
+      - {{ printf "https://[%s]:%d" $internalIPv6 $.etcd.port }}
         {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fix duplicated ``https://`` prefix for IPv6 etcd endpoints in both ``kubeadm-init.v1beta3`` and ``kubeadm-init.v1beta4`` templates.

The IPv6 etcd endpoint line has a redundant literal ``https://`` prefix before the Go template ``printf`` call that already includes ``https://``, causing the generated endpoint URL to be ``https://https://[IPv6]:2379`` instead of ``https://[IPv6]:2379``. This breaks ``kubeadm init`` with the error:

```[ERROR ExternalEtcdVersion]: Get "https://https/%5B2409:8a20:bef2:7a00:20c:29ff:feea:cdfb%5D:2379/version": dial tcp: lookup https on 127.0.0.53:53: server misbehaving```

The IPv4 line correctly uses only ``printf`` to construct the URL, this fix makes IPv6 consistent with IPv4 behavior.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

The fix is a one-line change in each template, removing the literal ``https://`` prefix. The ``printf`` format string ``"https://[%s]:%d"`` already produces the correct URL with scheme.

### Does this PR introduced a user-facing change?

```release-note
Fix duplicated https:// prefix for IPv6 external etcd endpoints in kubeadm config templates, which caused kubeadm init to fail when using IPv6 etcd nodes.
```

### Additional documentation, usage docs, etc.:

```docs
None
```