### PR TITLE
fix: dns error when zone is cn

### DIFF
--- a/builtin/core/roles/native/dns/tasks/main.yaml
+++ b/builtin/core/roles/native/dns/tasks/main.yaml
@@ -37,6 +37,7 @@
       {{- end }}
     {{- end }}
     # kubekey image_registry control_plane_endpoint BEGIN
+    {{- if .image_registry.type | empty | not }}
     {{- if and (.image_registry.auth.registry | empty | not) (.image_registry.ha_vip | empty | not) }}
     {{ .image_registry.ha_vip }} {{ .image_registry.auth.registry | splitList "/" | first }}
     {{- else }}
@@ -48,6 +49,7 @@
     {{ index .hostvars (.groups.image_registry | first) "internal_ipv6" }} {{ .image_registry.auth.registry | splitList "/" | first }}
         {{- end }}
       {{- end }}
+    {{- end }}
     {{- end }}
     # kubekey image_registry control_plane_endpoint END
     # NFS server nodes
@@ -70,6 +72,7 @@
     # Write the latest Kubekey image registry control plane endpoint DNS configuration
     cat >> {{ .item }} <<EOF
     # kubekey image_registry control_plane_endpoint BEGIN
+    {{- if .image_registry.type | empty | not }}
     {{- if and (.image_registry.auth.registry | empty | not) (.image_registry.ha_vip | empty | not) }}
     {{ .image_registry.ha_vip }} {{ .image_registry.auth.registry | splitList "/" | first }}
     {{- else }}
@@ -81,6 +84,7 @@
     {{ index .hostvars (.groups.image_registry | first) "internal_ipv6" }} {{ .image_registry.auth.registry | splitList "/" | first }}
         {{- end }}
       {{- end }}
+    {{- end }}
     {{- end }}
     # kubekey image_registry control_plane_endpoint END
     EOF


### PR DESCRIPTION
### What type of PR is this?
/kind bug
### What this PR does / why we need it:
Fixes a DNS configuration error that occurs when the zone is set to `cn`.
When `.image_registry.type` is empty (which can happen in certain configurations, such as when `KKZONE=cn`), the DNS task in `builtin/core/roles/native/dns/tasks/main.yaml` unconditionally generates image registry related host entries. This leads to invalid or unexpected DNS entries being written to `/etc/hosts`.
This PR adds a conditional check `{{- if .image_registry.type | empty | not }}` to ensure that image registry DNS entries are only generated when the image registry type is explicitly configured.
### Which issue(s) this PR fixes:
Fixes #
### Special notes for reviewers:
```
- The fix applies to both the DNS configuration generation and the KubeKey image registry control plane endpoint DNS configuration blocks.
- Please verify that DNS entries are correctly skipped when image_registry.type is not set.
```
### Does this PR introduced a user-facing change?
```release-note
Fix DNS configuration error when zone is set to cn by skipping image registry entries when image_registry.type is not configured.
```
### Additional documentation, usage docs, etc.:
```docs
```