### PR TITLE
feat: add taint in cluster

### DIFF
--- a/builtin/core/playbooks/add_nodes.yaml
+++ b/builtin/core/playbooks/add_nodes.yaml
@@ -96,3 +96,16 @@
         - or (.add_nodes | default list | empty) (.add_nodes | default list | has .inventory_hostname)
         - .groups.kube_control_plane | default list | has .inventory_hostname
         - .kubernetes.certs.renew
+  post_tasks:
+    - name: Add custom labels to the cluster nodes
+      delegate_to: "{{ .init_kubernetes_node }}"
+      when: .kubernetes.custom_labels | empty | not
+      command: >-
+        /usr/local/bin/kubectl label --overwrite node {{ $.hostname }}
+        {{- range $k, $v := .kubernetes.custom_labels }} {{ $k }}={{ $v }}{{- end }}
+    - name: Add custom taint to the cluster nodes
+      delegate_to: "{{ .init_kubernetes_node }}"
+      when: .kubernetes.custom_taints | default list | empty | not
+      command: >-
+        /usr/local/bin/kubectl taint --overwrite nodes {{ $.hostname }}
+        {{- range .kubernetes.custom_taints }} {{ . }}{{- end }}

--- a/builtin/core/playbooks/create_cluster.yaml
+++ b/builtin/core/playbooks/create_cluster.yaml
@@ -74,11 +74,16 @@
   post_tasks:
     - name: Add custom labels to the cluster nodes
       delegate_to: "{{ .init_kubernetes_node }}"
-      command: |
-        {{- range $k, $v := .kubernetes.custom_labels }}
-        /usr/local/bin/kubectl label --overwrite node {{ $.hostname }} {{ $k }}={{ $v }}
-        {{- end }}
+      command: >-
+        /usr/local/bin/kubectl label --overwrite node {{ $.hostname }}
+        {{- range $k, $v := .kubernetes.custom_labels }} {{ $k }}={{ $v }}{{- end }}
       when: .kubernetes.custom_labels | empty | not
+    - name: Add custom taint to the cluster nodes
+      delegate_to: "{{ .init_kubernetes_node }}"
+      when: .kubernetes.custom_taints | default list | empty | not
+      command: >-
+        /usr/local/bin/kubectl taint --overwrite nodes {{ $.hostname }}
+        {{- range .kubernetes.custom_taints }} {{ . }}{{- end }}
 
 # Install Kubernetes cluster software components (CNI and storage class) on a random control plane node
 - hosts:

--- a/builtin/core/roles/defaults/defaults/main/04-cri.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cri.yaml
@@ -39,8 +39,7 @@ cri:
 
   containerd:
     config:
-      root: >
-        {{ .cri.containerd.data_root | default "/var/lib/containerd" }}
+      root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
       version: 2
       state: "/run/containerd"
       grpc:

--- a/docs/en/reference/config.md
+++ b/docs/en/reference/config.md
@@ -760,8 +760,7 @@ cri:
   containerd:
     config:
       # containerd data root directory
-      root: >
-        {{ .cri.containerd.data_root | default "/var/lib/containerd" }}
+      root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
       # containerd configuration file version
       version: 2
       # containerd runtime state directory

--- a/docs/zh/reference/config.md
+++ b/docs/zh/reference/config.md
@@ -758,8 +758,7 @@ cri:
   containerd:
     config:
       # containerd 数据根目录
-      root: >
-        {{ .cri.containerd.data_root | default "/var/lib/containerd" }}
+      root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
       # containerd 配置文件版本
       version: 2
       # containerd 运行状态目录


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature


### What this PR does / why we need it:
This PR adds support for applying custom Kubernetes taints to cluster nodes during both cluster creation and node addition workflows.

Changes made:
1. **Add custom taints during cluster creation**: Adds a post task in `builtin/core/playbooks/create_cluster.yaml` to apply `kubernetes.custom_taints` to cluster nodes after the cluster is initialized.
2. **Add custom labels and taints during node addition**: Adds post tasks in `builtin/core/playbooks/add_nodes.yaml` to apply both `kubernetes.custom_labels` and `kubernetes.custom_taints` to newly added nodes.
3. Both tasks are delegated to `{{ .init_kubernetes_node }}` and use the existing `hostname` variable to target the correct node.

### Custom taint configuration example
The following example shows how to configure custom labels and taints for cluster nodes:

```yaml
spec:
  kubernetes:
    custom_labels:
      node-role.kubernetes.io/worker: ""
      environment: production
    custom_taints:
      - dedicated=special-user:NoSchedule
      - node-role.kubernetes.io/master=:NoSchedule
```

Notes:
- `kubernetes.custom_labels` is applied using `kubectl label --overwrite`.
- `kubernetes.custom_taints` is applied using `kubectl taint --overwrite nodes`.
- Taints follow the standard Kubernetes taint format: `key=value:effect` or `key:effect`.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/kubekey/issues/3135
### Special notes for reviewers:
```
- The taint application tasks are added as post_tasks in both create_cluster.yaml and add_nodes.yaml.
- In add_nodes.yaml, the existing custom labels task is also moved/added to post_tasks to keep label and taint handling consistent.
- Both tasks are delegated to the init kubernetes node ({{ .init_kubernetes_node }}).
- Please verify that the taint format expected by kubectl is correctly documented in the configuration example.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add support for configuring custom Kubernetes taints via `kubernetes.custom_taints` during cluster creation and node addition.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: Custom taints can be configured under `spec.kubernetes.custom_taints` in the cluster configuration. Example:

```yaml
spec:
  kubernetes:
    custom_taints:
      - dedicated=special-user:NoSchedule
```
```
