### PR TITLE
fix: etcd version verify failed

### DIFF
--- a/builtin/core/roles/etcd/prepare/tasks/main.yaml
+++ b/builtin/core/roles/etcd/prepare/tasks/main.yaml
@@ -37,7 +37,7 @@
   block:
     - name: Prepare | Ensure target etcd version is not lower than installed version
       assert:
-        that: .etcd.etcd_version | semverCompare (printf ">=v%s" index .etcd_install_version "stdout" "etcd Version")
+        that: .etcd.etcd_version | semverCompare (printf ">=v%s" (index .etcd_install_version "stdout" "etcd Version"))
         fail_msg: >-
           Target etcd version: {{ .etcd.etcd_version }} is lower than installed etcd version: {{ index .etcd_install_version "stdout" "etcd Version" }}. Downgrading etcd is not supported.
 
@@ -45,8 +45,7 @@
   when: >-
     or 
       (.etcd_install_version.error | empty | not)
-      (.etcd.etcd_version | semverCompare (printf ">v%s" index .etcd_install_version "stdout" "etcd Version"))
-  block:
+      (.etcd.etcd_version | semverCompare (printf ">v%s" (index (index (.etcd_install_version | default dict) "stdout" | default (dict "etcd Version" "0.0.0")) "etcd Version")))  block:
     - name: Prepare | Copy etcd binary package to node
       copy:
         src: >-


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
the error logs like:
```shell
16:16:57 CST [roles/etcd/prepare] Prepare | Ensure target etcd version is not lower than installed version
⠋ [master]    failed   [0s] 
16:16:57 CST [Playbook default/create-cluster-4mkms] finish. total: 126,success: 122,ignored: 3,failed: 1
Error: task [Prepare | Ensure target etcd version is not lower than installed version](default/create-cluster-4mkms-dd2q4) run failed: 
[master][executor]: module run failed
[master][item=<nil>][0]: 
stdout: failed
stderr: failed to parse argument of that
error: failed to execute template '{{.etcd.etcd_version | semverCompare (printf ">=v%s" index .etcd_install_version "stdout" "etcd Version")}}': template: kubekey:1:53: executing "kubekey" at <index>: wrong number of args for index: want at least 1 got 0
task [Prepare | Ensure target etcd version is not lower than installed version](default/create-cluster-4mkms-dd2q4) run failed: 
[master][executor]: module run failed
[master][item=<nil>][0]: 
stdout: failed
stderr: failed to parse argument of that
error: failed to execute template '{{.etcd.etcd_version | semverCompare (printf ">=v%s" index .etcd_install_version "stdout" "etcd Version")}}': template: kubekey:1:53: executing "kubekey" at <index>: wrong number of args for index: want at least 1 got 0
```

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
