### PR TITLE
fix: preserve numeric types for register_type: json

### DIFF
--- a/pkg/executor/task_executor.go
+++ b/pkg/executor/task_executor.go
@@ -457,13 +457,16 @@ func (e *taskExecutor) dealRegister(host string, loopResults []kkcorev1alpha1.Lo
 		switch e.task.Spec.RegisterType {
 		case "json":
 			// Attempt to unmarshal as JSON.
-			// Use Decoder with UseNumber() to preserve large integers precision.
+			// Use Decoder with UseNumber() to preserve large integers precision,
+			// then normalize json.Number values back to int64/float64 so they
+			// are not re-marshaled as strings.
 			decoder := json.NewDecoder(strings.NewReader(s))
 			decoder.UseNumber()
 			if err := decoder.Decode(&out); err != nil {
 				klog.V(5).ErrorS(err, "failed to register json value")
 				return s
 			}
+			out = normalizeJSONNumbers(out)
 		case "yaml", "yml":
 			// Attempt to unmarshal as YAML.
 			if err := yaml.Unmarshal([]byte(s), &out); err != nil {
@@ -528,4 +531,32 @@ func (e *taskExecutor) dealRegister(host string, loopResults []kkcorev1alpha1.Lo
 	}
 
 	return resErr
+}
+
+// normalizeJSONNumbers recursively walks a value decoded with json.UseNumber
+// and converts json.Number values to int64 or float64. This preserves numeric
+// types while avoiding precision loss for large integers.
+func normalizeJSONNumbers(v any) any {
+	switch x := v.(type) {
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return i
+		}
+		if f, err := x.Float64(); err == nil {
+			return f
+		}
+		return x.String()
+	case map[string]any:
+		for k, vv := range x {
+			x[k] = normalizeJSONNumbers(vv)
+		}
+		return x
+	case []any:
+		for i, vv := range x {
+			x[i] = normalizeJSONNumbers(vv)
+		}
+		return x
+	default:
+		return v
+	}
 }

--- a/pkg/executor/task_executor_test.go
+++ b/pkg/executor/task_executor_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -94,5 +95,33 @@ func TestTaskExecutor(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestNormalizeJSONNumbers(t *testing.T) {
+	input := map[string]any{
+		"int":    json.Number("24"),
+		"float":  json.Number("3.14"),
+		"nested": map[string]any{"value": json.Number("9007199254740993")},
+		"list":   []any{json.Number("1"), json.Number("2.5")},
+		"str":    "foo",
+	}
+	out := normalizeJSONNumbers(input).(map[string]any)
+
+	if _, ok := out["int"].(int64); !ok {
+		t.Fatalf("expected int to be int64, got %T", out["int"])
+	}
+	if _, ok := out["float"].(float64); !ok {
+		t.Fatalf("expected float to be float64, got %T", out["float"])
+	}
+	if _, ok := out["nested"].(map[string]any)["value"].(int64); !ok {
+		t.Fatalf("expected large int to be int64, got %T", out["nested"].(map[string]any)["value"])
+	}
+	list := out["list"].([]any)
+	if _, ok := list[0].(int64); !ok {
+		t.Fatalf("expected list[0] to be int64, got %T", list[0])
+	}
+	if _, ok := list[1].(float64); !ok {
+		t.Fatalf("expected list[1] to be float64, got %T", list[1])
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


### What this PR does / why we need it:
When using `register_type: json`, KubeKey decodes the command stdout with `json.Decoder.UseNumber()` to avoid precision loss for large integers. However, `json.Number` is serialized back as a string when the variable is later rendered (e.g., `"size": "24"`), which breaks numeric fields in configuration files.

On the other hand, decoding without `UseNumber()` causes large integers to become `float64` and be rendered in scientific notation, which breaks use cases like the fio disk test that emits nanosecond-level latency values.

This PR adds a `normalizeJSONNumbers` helper that recursively walks the decoded JSON value and converts `json.Number` values to:
- `int64` when possible (preserves large integers as numbers),
- `float64` for decimals,
- string as a fallback for values that cannot be represented as a number.

This keeps both small configuration numbers and large metric integers as proper numeric types.

Files changed:
- `pkg/executor/task_executor.go`: call `normalizeJSONNumbers` after JSON decoding.
- `pkg/executor/task_executor_test.go`: add unit tests for the normalization logic.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*`
-->
Fixes #

### Special notes for reviewers:
```
- The normalization runs only for `register_type: json` results.
- It preserves exact integer values (e.g., fio latency) while avoiding the previous string serialization issue.
- Please verify that other modules consuming `register_type: json` still behave correctly.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue where `register_type: json` stored numeric values as strings. Large integers are now preserved as int64 and decimal numbers as float64.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```