### PR TITLE
Daemon policy

### DIFF
--- a/builtin/core/roles/cri/containerd/tasks/main.yaml
+++ b/builtin/core/roles/cri/containerd/tasks/main.yaml
@@ -56,11 +56,18 @@
         dest: >-
           /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/client.key
 
-- name: Containerd | Generate the containerd configuration file
+- name: Containerd | Configure containerd
   when: or .upgrade.cri (or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not))
-  template:
-    src: config.toml
-    dest: /etc/containerd/config.toml
+  block:
+    - name: Containerd | Read existing containerd configuration
+      when: .cri.containerd.config_policy | eq "merge"
+      ignore_errors: true
+      command: cat /etc/containerd/config.toml
+      register: containerd_config_existing
+    - name: Containerd | Generate the containerd configuration file
+      template:
+        src: config.toml
+        dest: /etc/containerd/config.toml
 - name: Containerd | Deploy the containerd systemd service file
   when: or .upgrade.cri (or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not))
   copy:

--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -52,4 +52,12 @@
 {{- $plugins := dict "io.containerd.grpc.v1.cri" $cri }}
 {{- $config = mergeOverwrite (dict "plugins" $plugins) $config }}
 {{- end }}
+{{- if and (.cri.containerd.config_policy | eq "merge") (.containerd_config_existing | default dict) }}
+  {{- $existing_stdout := .containerd_config_existing.stdout | default "" }}
+  {{- $err := .containerd_config_existing.error | default "" }}
+  {{- if and ($err | empty) ($existing_stdout | empty | not) }}
+    {{- $existing := $existing_stdout | fromTOML }}
+    {{- $config = mergeOverwrite $config $existing }}
+  {{- end }}
+{{- end }}
 {{- $config | toToml }}

--- a/builtin/core/roles/cri/docker/tasks/main.yaml
+++ b/builtin/core/roles/cri/docker/tasks/main.yaml
@@ -70,21 +70,36 @@
           /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/client.key
 
 # install or update docker service
-- name: Docker | Generate Docker configuration file
+- name: Docker | Configure Docker daemon
   when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
-  template:
-    src: daemon.json
-    dest: /etc/docker/daemon.json
+  block:
+    - name: Docker | Read existing Docker daemon configuration
+      when: .cri.docker.daemon_policy | eq "merge"
+      ignore_errors: true
+      command: cat /etc/docker/daemon.json
+      register: docker_daemon_existing
+      register_type: json
+    - name: Docker | Generate Docker configuration file
+      template:
+        src: daemon.json
+        dest: /etc/docker/daemon.json
 - name: Docker | Deploy the Docker systemd service file
   when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
   copy:
     src: docker.service
     dest: /etc/systemd/system/docker.service
-- name: Containerd | Generate the containerd configuration file
+- name: Containerd | Configure containerd
   when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
-  template:
-    src: config.toml
-    dest: /etc/containerd/config.toml
+  block:
+    - name: Containerd | Read existing containerd configuration
+      when: .cri.containerd.config_policy | eq "merge"
+      ignore_errors: true
+      command: cat /etc/containerd/config.toml
+      register: containerd_config_existing
+    - name: Containerd | Generate the containerd configuration file
+      template:
+        src: config.toml
+        dest: /etc/containerd/config.toml
 - name: Docker | Deploy the containerd systemd service file
   when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
   copy:

--- a/builtin/core/roles/cri/docker/templates/config.toml
+++ b/builtin/core/roles/cri/docker/templates/config.toml
@@ -52,4 +52,12 @@
 {{- $plugins := dict "io.containerd.grpc.v1.cri" $cri }}
 {{- $config = mergeOverwrite (dict "plugins" $plugins) $config }}
 {{- end }}
+{{- if and (.cri.containerd.config_policy | eq "merge") (.containerd_config_existing | default dict) }}
+  {{- $existing_stdout := .containerd_config_existing.stdout | default "" }}
+  {{- $err := .containerd_config_existing.error | default "" }}
+  {{- if and ($err | empty) ($existing_stdout | empty | not) }}
+    {{- $existing := $existing_stdout | fromTOML }}
+    {{- $config = mergeOverwrite $config $existing }}
+  {{- end }}
+{{- end }}
 {{- $config | toToml }}

--- a/builtin/core/roles/cri/docker/templates/daemon.json
+++ b/builtin/core/roles/cri/docker/templates/daemon.json
@@ -15,4 +15,11 @@
 {{- if .cri.docker.bridge_ip }}
 {{- $_ := set $daemon "bip" .cri.docker.bridge_ip }}
 {{- end }}
+{{- if and (.cri.docker.daemon_policy | eq "merge") (.docker_daemon_existing | default dict) }}
+  {{- $existing := .docker_daemon_existing.stdout | default dict }}
+  {{- $err := .docker_daemon_existing.error | default "" }}
+  {{- if and ($err | empty) ($existing | empty | not) }}
+    {{- $daemon = mergeOverwrite $daemon $existing }}
+  {{- end }}
+{{- end }}
 {{ $daemon | toPrettyJson }}

--- a/builtin/core/roles/defaults/defaults/main/04-cri.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cri.yaml
@@ -28,6 +28,8 @@ cri:
     #     key_file: /etc/docker/certs.d/docker.io/key.crt
 
   docker:
+    # How to handle /etc/docker/daemon.json: override (default) or merge with existing file
+    daemon_policy: override
     daemon:
       data-root: "{{ .cri.docker.data_root | default \"/var/lib/docker\" }}"
       log-opts:
@@ -38,6 +40,8 @@ cri:
         - "native.cgroupdriver={{ .cri.cgroup_driver | default \"systemd\" }}"
 
   containerd:
+    # How to handle /etc/containerd/config.toml: override (default) or merge with existing file
+    config_policy: override
     config:
       root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
       version: 2

--- a/pkg/converter/tmpl/functions.go
+++ b/pkg/converter/tmpl/functions.go
@@ -30,6 +30,7 @@ func funcMap() template.FuncMap {
 	// add custom function
 	f["toYaml"] = toYAML
 	f["fromYaml"] = fromYAML
+	f["fromTOML"] = fromTOML
 	f["ipInCIDR"] = ipInCIDR
 	f["ipFamily"] = ipFamily
 	f["isIP"] = isIP
@@ -131,6 +132,15 @@ func toYAML(v any) string {
 func fromYAML(v string) (any, error) {
 	var output any
 	err := yaml.Unmarshal([]byte(v), &output)
+
+	return output, err
+}
+
+// fromTOML takes a TOML string, unmarshals it into an interface{}, and returns the result.
+// If there is an error during unmarshaling, it will be returned along with nil for the value.
+func fromTOML(v string) (any, error) {
+	var output any
+	err := toml.Unmarshal([]byte(v), &output)
 
 	return output, err
 }

--- a/pkg/converter/tmpl/template_test.go
+++ b/pkg/converter/tmpl/template_test.go
@@ -754,6 +754,24 @@ a2:
 			},
 			excepted: "{\"a1\":\"b1\",\"a2\":{\"b2\":1}}",
 		},
+		// ======= fromTOML =======
+		{
+			name:  "fromTOML 1",
+			input: "{{ .foo | fromTOML | toJson }}",
+			variable: map[string]any{
+				"foo": `root = "/var/lib/containerd"`,
+			},
+			excepted: "{\"root\":\"/var/lib/containerd\"}",
+		},
+		{
+			name:  "fromTOML 2",
+			input: "{{ .foo | fromTOML | toJson }}",
+			variable: map[string]any{
+				"foo": `[grpc]
+  address = "/run/containerd/containerd.sock"`,
+			},
+			excepted: "{\"grpc\":{\"address\":\"/run/containerd/containerd.sock\"}}",
+		},
 		// ======= ipInCIDR =======
 		{
 			name:  "ipInCIDR true-1",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature



### What this PR does / why we need it:
This PR introduces a merge policy for Docker and containerd configuration files, allowing KubeKey to preserve existing user-defined settings while still applying required defaults. It also fixes two related issues: JSON numbers being stored as strings in registered variables, and an etcd version comparison template syntax error.

1. Support merging existing CRI configuration files
- Added `daemon_policy` for Docker (`cri.docker.daemon_policy`) and `config_policy` for containerd (`cri.containerd.config_policy`).
- Supported values: `override` (default) and `merge`.
- When set to `merge`, the existing `/etc/docker/daemon.json` or `/etc/containerd/config.toml` is read and merged with the KubeKey-generated configuration; duplicated keys use the new values.
- Added a new template function `fromTOML` to parse the existing containerd TOML configuration.
- Fixed `fileExists` usage so that remote files are checked correctly via command execution with `ignore_errors`.

Affected files:
- `builtin/core/roles/defaults/defaults/main/04-cri.yaml`
- `builtin/core/roles/cri/docker/tasks/main.yaml`
- `builtin/core/roles/cri/docker/templates/daemon.json`
- `builtin/core/roles/cri/docker/templates/config.toml`
- `builtin/core/roles/cri/containerd/tasks/main.yaml`
- `builtin/core/roles/cri/containerd/templates/config.toml`
- `pkg/converter/tmpl/functions.go`
- `pkg/converter/tmpl/template_test.go`

Example configuration:
```yaml
spec:
  cri:
    docker:
      daemon_policy: merge
    containerd:
      config_policy: merge
```


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*`
-->
Fixes #

### Special notes for reviewers:
```
- The merge policy defaults to `override`, keeping backward compatibility.
- For containerd, the existing config is read as a plain string and parsed with the new `fromTOML` template function.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add `daemon_policy` and `config_policy` options to merge existing Docker and containerd configuration files with KubeKey-generated settings. 
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: To preserve existing Docker or containerd configuration, set `cri.docker.daemon_policy: merge` or `cri.containerd.config_policy: merge` in the cluster configuration.
```
