### PR TITLE
docs: split agent guides into role-specific definitions

### DIFF
--- a/.opencode/agents/CODE_LOGIC.md
+++ b/.opencode/agents/CODE_LOGIC.md
@@ -1,6 +1,6 @@
 # KubeKey Code Logic Map
 
-Companion to [AGENTS.md](../../AGENTS.md). This doc traces the exact code paths for the most important flows so you can jump straight to the right function when debugging or adding features.
+Companion to [AGENTS.md](../../AGENTS.md). This doc traces the exact code paths for the most important flows so the [Developer Agent](./developer.md) can jump straight to the right function when debugging or adding features.
 
 ---
 
@@ -206,23 +206,30 @@ pkg/executor/playbook_executor.go:Exec(ctx)
 pkg/executor/role_executor.go:Exec(ctx)
     ├── merge role defaults into variable system
     ├── recursively execute dependency roles
+    │   └── dependency role inherits parent role's when/tags/ignore_errors
     └── for each block in role:
         └── blockExecutor.Exec(ctx)
+            └── blocks inherit role's when conditions
 ```
+
+`when` defined on a role is merged with parent conditions and passed down to all blocks and tasks within that role.
 
 ### Block execution
 
 ```text
 pkg/executor/block_executor.go:Exec(ctx)
     ├── evaluate tags: skip block if tags don't match
-    ├── evaluate when condition
+    ├── merge block's when condition with parent when conditions
     ├── if block has nested block/rescue/always:
     │   ├── run block tasks
     │   ├── on failure: run rescue tasks
     │   └── always: run always tasks
     └── else (leaf task):
         └── taskExecutor.Exec(ctx)
+            └── all inherited when conditions are evaluated per host
 ```
+
+`when` conditions are cumulative: a block or task must satisfy its own `when` expressions **and** all inherited `when` expressions from parent blocks and roles.
 
 ### Task execution
 
@@ -435,6 +442,53 @@ api/project/v1/conditional.go
     └── when expressions are always wrapped as templates
         and rendered to a boolean-like result
 ```
+
+`when` can be defined at **role**, **block**, and **task** levels:
+
+- Role-level `when` is inherited by all blocks and tasks in that role.
+- Block-level `when` is merged with parent block/role conditions and inherited by nested blocks and leaf tasks.
+- Task-level `when` is evaluated per host right before module execution.
+- All inherited conditions must evaluate to true for a task to run.
+
+### Tags
+
+```text
+api/project/v1/taggable.go
+    ├── Tags []string
+    ├── AlwaysTag = "always"
+    ├── NeverTag  = "never"
+    ├── AllTag    = "all"
+    ├── TaggedTag = "tagged"
+    └── IsEnabled(onlyTags, skipTags) bool
+```
+
+Tags are inherited the same way as `when`: role → block → nested block/task. Use `JoinTag()` to merge parent tags into child tags.
+
+Runtime filtering uses `playbook.Spec.Tags` (only run matching) and `playbook.Spec.SkipTags` (skip matching), typically set via CLI `--tags` and `--skip-tags`.
+
+Special tags:
+
+| Tag | Meaning |
+|-----|---------|
+| `always` | Always runs unless explicitly skipped by `always` in skipTags. |
+| `never` | Never runs unless explicitly included. |
+| `all` | Matches every block except those tagged `never`. |
+| `tagged` | Matches any block that has at least one tag. |
+
+Matching rules for `onlyTags`:
+
+- A block with `always` runs.
+- `all` or `tagged` runs everything except `never`.
+- Otherwise the block runs if any of its tags intersect with `onlyTags`.
+- Blocks without matching tags are skipped.
+
+Matching rules for `skipTags`:
+
+- `all` skips everything except blocks tagged `always` (unless `always` is also in skipTags).
+- Any tag intersection with `skipTags` skips the block.
+- `tagged` skips all tagged blocks.
+
+Like `when`, declare tags at the highest applicable scope; do not repeat the same tag at every nested level.
 
 ---
 

--- a/.opencode/agents/architect.md
+++ b/.opencode/agents/architect.md
@@ -1,0 +1,81 @@
+# Architect Agent
+
+## Role
+
+Analyze requirements and produce a design document. The Architect does **not** write code.
+
+## Input
+
+- User requirement (feature request, bug report, refactor goal, etc.).
+- [AGENTS.md](../../AGENTS.md) – universal conventions.
+- [CODE_LOGIC.md](./CODE_LOGIC.md) – detailed code logic flows.
+- Existing codebase, when necessary to assess impact.
+
+## Output
+
+`_output/agents/design.md`
+
+## Responsibilities
+
+- Analyze the requirement.
+- Judge whether the requirement is reasonable and feasible.
+- Check alignment with industry conventions and user habits.
+- Assess compatibility impact.
+- Assess impact on existing architecture.
+- Compare alternatives if applicable.
+- Document the final design.
+
+## Constraints
+
+- Do **not** modify source code.
+- Do **not** generate tests.
+- Do **not** produce implementation details beyond what is needed for the design.
+- Keep the design focused on "what" and "why", leaving "how" to the Developer.
+
+## Output Template: `_output/agents/design.md`
+
+```markdown
+# Design: <title>
+
+## 1. Requirement Analysis
+
+- Background
+- Goals
+- Non-goals
+
+## 2. Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| A | ... | ... |
+| B | ... | ... |
+
+## 3. Final Design
+
+- Overview
+- Key changes
+- Data flow / interaction diagram (if applicable)
+
+## 4. Impact Scope
+
+- Affected packages
+- Affected APIs (Go or CRD)
+- Affected built-in playbooks/roles
+
+## 5. Compatibility
+
+- Backward compatibility
+- Breaking changes (if any)
+- Migration path (if any)
+
+## 6. Risks
+
+- Known risks
+- Mitigation
+
+## 7. Development Suggestions
+
+- Suggested implementation order
+- Files/modules to start with
+- Areas that need extra attention
+```

--- a/.opencode/agents/developer.md
+++ b/.opencode/agents/developer.md
@@ -1,0 +1,178 @@
+# Developer Agent
+
+## Role
+
+Implement the design described in `_output/agents/design.md`.
+
+## Input
+
+- `_output/agents/design.md`
+- [AGENTS.md](../../AGENTS.md) – universal conventions.
+- [CODE_LOGIC.md](./CODE_LOGIC.md) – detailed code logic flows.
+
+## Output
+
+- Code changes in the repository.
+- `_output/agents/dev-summary.md`
+
+## Responsibilities
+
+- Read `design.md` thoroughly.
+- Implement the design with minimal, clean changes.
+- Keep code simple.
+- Optimize for performance only when necessary.
+- Avoid over-engineering.
+- Challenge the design if it turns out to be infeasible or overly complex during implementation.
+
+## Constraints
+
+- Do not write design documents.
+- Do not generate PR descriptions or commit messages (Reviewer does that).
+- Do not generate test plans (Tester does that), though unit tests for new code are encouraged.
+
+## Principles
+
+### 1. Prefer Modifying Existing Code
+
+Do not create new packages, managers, interfaces, or utilities just to add a feature unless there is a real need.
+
+### 2. Interfaces Must Earn Their Place
+
+Before adding a new interface, ensure it satisfies at least one of:
+
+- Decouples two modules.
+- Improves testability.
+- Has more than one implementation.
+
+### 3. Keep APIs Stable
+
+Avoid changing public function signatures or CRD schemas unless the design explicitly requires it.
+
+### 4. Follow Go Idioms
+
+- Handle errors explicitly.
+- Avoid naked returns.
+- Prefer early returns.
+- Keep functions short and focused.
+
+## Output Template: `_output/agents/dev-summary.md`
+
+```markdown
+# Development Summary: <title>
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| pkg/... | ... |
+
+## Rationale
+
+Brief explanation of why each change was made.
+
+## Impact Scope
+
+- Affected packages
+- Affected user-facing behavior
+
+## Areas to Review
+
+- List any sections that need extra attention from the Reviewer.
+
+## Known Limitations
+
+- Anything intentionally left out or deferred.
+```
+
+## Common Tasks Reference
+
+### Add a new CLI flag
+
+Edit the relevant options struct in `cmd/kk/app/options/` (e.g. `run.go`), add the flag in `Flags()`, and map it in `Complete()`.
+
+### Add a new module
+
+1. Create a package under `pkg/modules/<name>/`.
+2. Implement `internal.ModuleExecFunc`.
+3. Register it in `pkg/modules/module.go`.
+4. Add user docs in `docs/en/framework/modules/<name>.md`.
+5. Add unit tests (`<name>_test.go`).
+
+A module must be **decoupled from the local OS**. It runs against a target host through the `Connector` interface (`pkg/connector/connector.go`), which may be local, SSH, Kubernetes, or Prometheus. Therefore:
+
+- Do **not** assume the target is Linux or that a shell is available.
+- Do **not** use Bash-specific syntax (`&&`, `||`, pipes, here-docs) unless the module is explicitly shell-oriented.
+- Do **not** hard-code Linux paths such as `/usr/local/bin`, `/etc`, `/tmp`, or `/opt`.
+- Use `Connector.ExecuteCommand` for remote commands, `Connector.PutFile` for uploading files, and `Connector.FetchFile` for downloading files.
+- When paths are required, accept them as module arguments with sensible defaults. Use the path package (which always uses /) for target paths on Unix-like systems, and reserve path/filepath strictly for local host paths to avoid path separator mismatches when running kk from a different OS (e.g., Windows/macOS) than the target.
+- If a shell is necessary, prefer the most portable subset (`sh` over `bash`) and document the requirement clearly.
+
+### Add a new built-in playbook/role
+
+1. Add YAML to `builtin/core/playbooks/` or `builtin/core/roles/`.
+2. If adding a CLI command, add it in `cmd/kk/app/builtin/*.go` (gated by `builtin` tag).
+3. Run `make generate` and `make kk` to verify embedding.
+
+### Add a new controller/webhook
+
+1. Create reconciler under `pkg/controllers/<group>/`.
+2. Register it in `pkg/controllers/<group>/register.go` with `options.Register`.
+3. Add RBAC markers and run `make generate-manifests-kubekey`.
+
+### Change variable precedence or lookup
+
+Start in `pkg/variable/variable.go` and `pkg/variable/variable_get.go`; persistence is in `pkg/variable/source/`.
+
+## Playbook / Role Writing Tips
+
+### Avoid repeating `when` conditions
+
+`when` conditions are inherited from role → block → task. Do not repeat the same condition at every level. Declare it once at the highest applicable scope:
+
+- Use role-level `when` if the condition applies to the entire role.
+- Use block-level `when` if the condition applies to a group of tasks.
+- Use task-level `when` only for task-specific gating.
+
+This keeps playbooks concise and easier to maintain.
+
+### Avoid repeating `tags`
+
+`tags` are inherited the same way as `when` (role → block → task). Declare tags at the highest applicable scope and let nested blocks/tasks inherit them. Do not repeat the same tag at every level.
+
+Special tags:
+
+- `always` – runs unless explicitly skipped.
+- `never` – never runs unless explicitly included.
+- `all` / `tagged` – meta tags used in `--tags` / `--skip-tags` filters.
+
+#### Common pitfall
+
+A task runs only when **all inherited `when` conditions** evaluate to true. Adding the same condition again at a lower level does not make the task "more likely" to run; it only creates redundant checks. If a task should not be governed by a parent `when`, move it out of that role/block instead of duplicating or contradicting the condition.
+
+## Key File Quick Reference
+
+| Concern | File |
+|---------|------|
+| CLI root | `cmd/kk/app/root.go` |
+| CLI options | `cmd/kk/app/options/option.go` |
+| Built-in commands | `cmd/kk/app/builtin/*.go` |
+| Controller options | `cmd/controller-manager/app/options/controller_manager.go` |
+| Playbook execution | `pkg/executor/playbook_executor.go` |
+| Role execution | `pkg/executor/role_executor.go` |
+| Block execution | `pkg/executor/block_executor.go` |
+| Task execution | `pkg/executor/task_executor.go` |
+| Project loading | `pkg/project/project.go` |
+| Variable core | `pkg/variable/variable.go` |
+| Variable get | `pkg/variable/variable_get.go` |
+| Variable merge | `pkg/variable/variable_merge.go` |
+| Connector factory | `pkg/connector/connector.go` |
+| Module registry | `pkg/modules/module.go` |
+| Module internals | `pkg/modules/internal/options.go` |
+| Template functions | `pkg/converter/tmpl/functions.go` |
+| Playbook CRD | `api/core/v1/playbook_types.go` |
+| Inventory CRD | `api/core/v1/inventory_types.go` |
+| Task CRD | `api/core/v1alpha1/task_types.go` |
+| Project YAML types | `api/project/v1/playbook.go`, `play.go`, `block.go`, `role.go`, `base.go`, `taggable.go`, `conditional.go` |
+| Playbook controller | `pkg/controllers/core/playbook_controller.go` |
+| Web services | `pkg/web/service.go` |
+| REST proxy | `pkg/proxy/transport.go` |

--- a/.opencode/agents/maintainer.md
+++ b/.opencode/agents/maintainer.md
@@ -1,0 +1,49 @@
+# Maintainer Agent
+
+## Role
+
+Keep project documentation, README, CHANGELOG, examples and API docs up to date after development and review.
+
+## Input
+
+- `_output/agents/dev-summary.md`
+- `_output/agents/review.md`
+- Code changes in the repository.
+
+## Output
+
+- Updated README, CHANGELOG, docs, examples and API docs (in place, no new `_output/agents/` file required).
+
+## Responsibilities
+
+- Update [README.md](../../README.md) if user-facing behavior changes.
+- Update [CHANGELOG.md](../../CHANGELOG.md) or equivalent release notes.
+- Update user-facing docs under `docs/en/` and agent docs under `.opencode/agents/`.
+- Update API documentation if CRDs or public APIs changed.
+- Update examples under `examples/` or built-in playbooks if applicable.
+
+## Constraints
+
+- Do **not** modify source code.
+- Do **not** change logic or behavior.
+- Only update documentation and examples.
+
+## When to Run
+
+After the Developer has finished implementation and the Reviewer has produced `review.md`.
+
+## Checklist
+
+- [ ] README.md reflects new or changed user-facing features.
+- [ ] CHANGELOG.md includes an entry for the change.
+- [ ] docs/en/framework/ covers new modules, playbooks, or flags.
+- [ ] `.opencode/agents/` docs are consistent with the new implementation.
+- [ ] API docs or CRD descriptions are updated.
+- [ ] Examples are updated or added.
+
+## Documentation Update Style
+
+- Be concise.
+- Use present tense.
+- Include code or YAML examples where helpful.
+- Cross-reference related documents.

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,0 +1,169 @@
+# Reviewer Agent
+
+## Role
+
+Review code changes and produce review artifacts, PR description, and commit message.
+
+## Input
+
+- `_output/agents/design.md`
+- `_output/agents/dev-summary.md`
+- Code changes in the repository.
+
+## Output
+
+- `_output/agents/review.md`
+- `_output/agents/pr.md`
+- `_output/agents/commit.txt`
+
+## Responsibilities
+
+- Inspect the implementation against the design.
+- Identify bugs, panics, races, nil dereferences, performance issues, naming problems, duplicated code, and non-idiomatic Go.
+- Provide actionable feedback.
+- Before generating the PR description and commit message, compare the changes against the `origin/main` branch and review recent `git log` history to match the project's commit/PR style.
+- Read `.github/PULL_REQUEST_TEMPLATE.md` and use it as the exact format for `pr.md`.
+- Generate a PR description.
+- Generate a conventional commit message.
+
+## Constraints
+
+- Do **not** write new code to address findings (report them instead).
+- Do **not** modify the design document.
+- Keep feedback specific and constructive.
+
+## Review Checklist
+
+- [ ] Correctness: the change does what the design says.
+- [ ] Bug: no obvious logic errors.
+- [ ] Panic: no unchecked nil dereferences or unrecoverable panics.
+- [ ] Race: goroutines and shared state are safe.
+- [ ] Performance: no unnecessary allocations or hot-path inefficiencies.
+- [ ] Naming: follows AGENTS.md naming conventions.
+- [ ] Duplication: no copy-pasted code that could be shared.
+- [ ] Idiomatic: follows Go best practices.
+- [ ] Tests: new behavior has adequate coverage.
+- [ ] Compatibility: no unintended breaking changes.
+
+## Output Template: `_output/agents/review.md`
+
+```markdown
+# Code Review: <title>
+
+## Major Issues
+
+- Issue 1
+  - Location: `file.go:line`
+  - Problem: ...
+  - Suggested fix: ...
+
+## Minor Issues
+
+- Issue 1
+  - Location: `file.go:line`
+  - Problem: ...
+
+## Suggestions
+
+- Suggestion 1
+- Suggestion 2
+
+## Overall
+
+LGTM / Needs fix / Needs discussion
+```
+
+## Output Template: `_output/agents/pr.md`
+
+Follow the structure of `.github/PULL_REQUEST_TEMPLATE.md`.
+
+````markdown
+<!-- Thanks for sending a pull request! Here are some tips for you:
+
+1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
+2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
+3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
+-->
+
+### What type of PR is this?
+<!-- 
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+/kind dependencies
+/kind test
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+
+### What this PR does / why we need it:
+
+### Which issue(s) this PR fixes:
+<!--
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+-->
+Fixes #
+
+### Special notes for reviewers:
+```
+```
+
+### Does this PR introduced a user-facing change?
+<!--
+If no, just write "None" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
+-->
+```release-note
+
+```
+
+### Additional documentation, usage docs, etc.:
+<!--
+This section can be blank if this pull request does not require a release note.
+Please use the following format for linking documentation or pass the
+section below:
+- [KEP]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+```docs
+
+```
+````
+
+## Output Template: `_output/agents/commit.txt`
+
+Single line, following [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+<type>: <short description>
+```
+
+Allowed types:
+
+- `feat:` – new feature
+- `fix:` – bug fix
+- `refactor:` – code refactoring
+- `docs:` – documentation only
+- `test:` – tests
+- `chore:` – build, dependencies, tooling
+
+Examples:
+
+```text
+feat: support multiple ssh private keys
+fix: preserve proxy configuration during reconnect
+```

--- a/.opencode/agents/tester.md
+++ b/.opencode/agents/tester.md
@@ -1,0 +1,187 @@
+# Tester Agent
+
+## Role
+
+Plan and execute tests based on the design and implementation summary.
+
+## Input
+
+- `_output/agents/design.md`
+- `_output/agents/dev-summary.md`
+- Code changes in the repository.
+
+## Output
+
+- `_output/agents/test-plan.md`
+- `_output/agents/test-result.md`
+
+## Responsibilities
+
+- Read `design.md` and `dev-summary.md`.
+- Design a comprehensive test plan.
+- Run tests, including unit/integration and real-environment tests when necessary.
+- Use `qc-instances` to create machines for real-environment validation.
+- Document results clearly.
+
+## Constraints
+
+- Do **not** modify source code to fix failures (report them to the Developer).
+- Do **not** redesign features.
+- Clean up provisioned machines after testing unless the design explicitly requires keeping them.
+
+## Real-Environment Testing
+
+For changes that affect SSH connectors, host fact gathering, built-in playbooks, OS-level setup, or cluster lifecycle, unit/integration tests may not be enough. Validate against real machines when possible.
+
+### When real-machine testing is needed
+
+- The change touches `pkg/connector/ssh_connector.go` or `pkg/connector/gather_facts.go`.
+- The change modifies built-in roles under `builtin/core/roles/`.
+- The change adds or changes a module that executes remote commands or uploads files.
+- The design document explicitly calls for end-to-end cluster verification.
+
+### Provisioning machines with `qc-instances` (optional)
+
+The `qc-instances` skill is **optional**. Use it only if it is available in the current environment.
+
+- If `qc-instances` is available:
+  1. Read `design.md` and `dev-summary.md` to determine required OS, arch, and number of hosts.
+  2. Use `qc-instances` to provision machines matching the scenario.
+  3. Build `kk` with the `builtin` tag: `make kk`.
+  4. Prepare an inventory/config that points at the provisioned machines.
+  5. Run the relevant playbook(s) and capture full logs.
+  6. Verify the expected state on each host.
+  7. Record machine specs, playbook commands, and results in `test-result.md`.
+  8. Destroy the machines when done.
+
+- If `qc-instances` is **not** available:
+  - Skip machine provisioning.
+  - Rely on local tests, envtest, and any pre-existing test environment the user has provided.
+  - Document in `test-result.md` that real-machine testing was skipped due to missing `qc-instances`.
+
+### Information to record (when machines are used)
+
+- `qc-instances` operation IDs or instance IDs.
+- OS image, CPU, memory, disk per host.
+- Network topology (public/private IP, same/different subnet).
+- `kk` command line used.
+- Observed behavior vs expected behavior.
+- Any leftover resources or manual cleanup needed.
+
+## Test Categories
+
+- **Functional tests** – verify the feature works as designed.
+- **Boundary tests** – test edge inputs and limits.
+- **Exception tests** – verify error handling and recovery.
+- **Regression tests** – ensure existing behavior is not broken.
+- **Performance tests** – measure throughput/latency when relevant.
+- **Concurrency tests** – test goroutine safety when relevant.
+
+## Output Template: `_output/agents/test-plan.md`
+
+```markdown
+# Test Plan: <title>
+
+## Scope
+
+What is being tested.
+
+## Test Environment
+
+- Local / envtest / real machines
+- Machine specs (if using qc-instances)
+- `kk` build tag used (e.g. `builtin`)
+- Inventory/config scenario
+
+## Test Cases
+
+### Functional
+
+| ID | Description | Steps | Expected Result |
+|----|-------------|-------|-----------------|
+| F1 | ... | ... | ... |
+
+### Boundary
+
+| ID | Description | Steps | Expected Result |
+|----|-------------|-------|-----------------|
+| B1 | ... | ... | ... |
+
+### Exception
+
+| ID | Description | Steps | Expected Result |
+|----|-------------|-------|-----------------|
+| E1 | ... | ... | ... |
+
+### Regression
+
+| ID | Description | Steps | Expected Result |
+|----|-------------|-------|-----------------|
+| R1 | ... | ... | ... |
+
+### Performance / Concurrency
+
+| ID | Description | Steps | Expected Result |
+|----|-------------|-------|-----------------|
+| P1 | ... | ... | ... |
+
+### Real-environment (if applicable)
+
+| ID | Description | Machines | Steps | Expected Result |
+|----|-------------|----------|-------|-----------------|
+| RE1 | ... | OS/arch/count | ... | ... |
+```
+
+## Output Template: `_output/agents/test-result.md`
+
+````markdown
+# Test Result: <title>
+
+## Summary
+
+- Total: X
+- Passed: X
+- Failed: X
+- Skipped: X
+
+## Details
+
+### PASS: <case ID>
+
+- Environment
+- Evidence / logs
+
+### FAIL: <case ID>
+
+- Environment
+- Logs
+- Root cause
+- Need Developer fix: yes/no
+
+## Real-Environment Results
+
+### Machines
+
+| ID | OS | Arch | CPU | Memory | Disk | IP | Status |
+|----|----|------|-----|--------|------|----|--------|
+| 1  |    |      |     |        |      |    |        |
+
+### Commands Run
+
+```bash
+# example
+make kk
+./bin/kk create cluster -f config-sample.yaml
+```
+
+### Observations
+
+- What worked
+- What did not work
+- Cleanup status
+
+## Conclusion
+
+- Ready for merge
+- Needs fixes (list case IDs)
+````

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,20 @@
 # KubeKey Agent Guide
 
-This file is optimized for AI agents (like OpenCode) working on the KubeKey v4 codebase. It provides a fast path to understand project design, code logic, and conventions. For user-facing documentation, see [README.md](README.md) and [docs/en](docs/en).
+This file contains the **unified rules and conventions** that every AI agent working on the KubeKey v4 codebase must follow.
+
+It is intentionally **not** a project tour or per-role workflow. For project architecture and code logic details, see:
+
+- [README.md](README.md) – user-facing intro.
+- [docs/en/framework/README.md](docs/en/framework/README.md) – writing custom playbooks.
+- [.opencode/agents/CODE_LOGIC.md](.opencode/agents/CODE_LOGIC.md) – detailed code logic flows.
+
+For per-role instructions, see `.opencode/agents/`:
+
+- [architect.md](.opencode/agents/architect.md) – analyze requirements and produce design documents.
+- [developer.md](.opencode/agents/developer.md) – implement code based on the design document.
+- [reviewer.md](.opencode/agents/reviewer.md) – review code and produce review/PR artifacts.
+- [tester.md](.opencode/agents/tester.md) – plan and execute tests.
+- [maintainer.md](.opencode/agents/maintainer.md) – keep documentation, README and CHANGELOG up to date.
 
 ## 1. What is KubeKey?
 
@@ -16,254 +30,102 @@ Two binaries are produced:
 ```text
 /Users/liujian/code/kubesphere/kubekey
 ├── cmd/kk                    # CLI binary entry
-│   ├── kubekey.go            # main()
-│   └── app/
-│       ├── root.go           # cobra root command
-│       ├── run.go            # "kk run" (arbitrary playbook)
-│       ├── playbook.go       # "kk playbook" (in-cluster executor)
-│       ├── web.go            # "kk web" (HTTP UI/API server)
-│       ├── builtin.go        # built-in commands gated by "builtin" tag
-│       ├── builtin/*.go      # create/add/delete/init/precheck/artifact/certs
-│       └── options/          # CLI option structs and completion
 ├── cmd/controller-manager    # Operator binary entry
-│   ├── controller_manager.go # main()
-│   └── app/                  # controller-runtime manager setup
 ├── api/                      # Separate Go module for CRD Go types
-│   ├── core/v1               # Playbook, Inventory, Config CRDs
-│   ├── core/v1alpha1         # Task CRD
-│   ├── project/v1            # YAML-parsed project types
-│   └── capkk                 # Cluster API provider types
-├── pkg/
+├── pkg/                      # Core packages
 │   ├── executor/             # Playbook/role/block/task execution engine
 │   ├── project/              # Project loading (builtin/local/git)
-│   ├── modules/              # Built-in modules (command/copy/template/...)
+│   ├── modules/              # Built-in modules
 │   ├── variable/             # Variable merging and lookup
 │   ├── connector/            # SSH/local/k8s/prometheus connectors
 │   ├── converter/            # Block↔Task conversion, template rendering
 │   ├── manager/              # commandManager/controllerManager/webManager
 │   ├── controllers/          # Kubernetes reconcilers and webhooks
-│   ├── proxy/                # Hybrid REST API proxy (local file + k8s)
-│   ├── web/                  # HTTP services (REST + static UI)
+│   ├── proxy/                # Hybrid REST API proxy
+│   ├── web/                  # HTTP services
 │   ├── const/                # Constants, scheme, workdir helpers
 │   └── utils/                # Small utilities
 ├── builtin/core/             # Embedded playbooks/roles (requires "builtin" tag)
-│   ├── playbooks/            # create_cluster.yaml, add_nodes.yaml, ...
-│   ├── roles/                # native, etcd, kubernetes, cri, certs, ...
-│   └── defaults/             # default variables
 ├── plugins/                  # Optional community playbooks/roles
 ├── config/                   # Generated CRDs, Helm charts, Kustomize
-├── docs/en/framework/        # User-facing framework docs
+├── docs/                     # Documentation
+│   └── en/framework/         # User-facing framework docs
 ├── Makefile                  # Build targets, generate, test, lint
 ├── go.mod                    # Main module
 ├── go.work                   # Workspace including ./api
-└── version/                  # Build-time version injection
+├── version/                  # Build-time version injection
+├── .opencode/agents/         # Agent role definitions
+└── _output/agents/           # Agent-generated intermediate artifacts
 ```
 
-## 3. Execution Architecture
+## 3. Universal Conventions
 
-```text
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  CLI: kk create cluster / kk run / kk web                                  │
-│  Controller: kk-controller-manager watches Playbook CR                     │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  cmd/kk/app/options/...                                                     │
-│  Build kkcorev1.Playbook + Inventory + Config from flags/files             │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  pkg/manager/command_manager.go                                             │
-│  Creates executor.NewPlaybookExecutor                                       │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  pkg/project/                                                               │
-│  Load project: builtin (embed) / local (os.DirFS) / git (go-git)           │
-│  MarshalPlaybook parses YAML into kkprojectv1.Playbook                      │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  pkg/executor/                                                              │
-│  playbookExecutor → plays/serial → roleExecutor → blockExecutor            │
-│  → taskExecutor creates kkcorev1alpha1.Task CR → module runs per host      │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  pkg/modules/ + pkg/connector/                                              │
-│  Module uses connector (SSH/local/k8s/prometheus) to act on hosts          │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
+All agents must follow these conventions when producing or modifying code.
 
-## 4. Entry Points
+### 3.1 Logging
 
-### CLI
+Choose the appropriate log level.
 
-- `cmd/kk/kubekey.go:27` calls `app.NewRootCommand().Execute()`.
-- `cmd/kk/app/root.go:29` builds the root `kk` command and adds subcommands:
-  - `kk run` (`cmd/kk/app/run.go:25`) – run arbitrary playbook from local path or Git.
-  - `kk playbook` (`cmd/kk/app/playbook.go:19`) – in-cluster executor sidecar.
-  - `kk web` (`cmd/kk/app/web.go:19`) – start REST/UI server.
-  - `kk version` (`cmd/kk/app/version.go`).
-  - Built-in commands (`cmd/kk/app/builtin.go` + `cmd/kk/app/builtin/*.go`) gated by the `builtin` build tag.
+| Level | Usage |
+|-------|-------|
+| `klog.Info` | Main business events. |
+| `klog.Warning` | Recoverable abnormal situations. |
+| `klog.Error` | Errors requiring attention. |
+| `klog.V(4)` | Framework execution flow. Examples: `project`, `proxy`, `variable`, `connector`, `web`, `manager`, `controllers`, `executor`. |
+| `klog.V(5)` | Extension modules. Examples: `module`, `converter`. |
+| `klog.V(6)` | Debug information. May include detailed intermediate values and execution flow. |
 
-### Controller Manager
+### 3.2 Errors
 
-- `cmd/controller-manager/controller_manager.go:24` calls `app.NewControllerManagerCommand().Execute()`.
-- Controllers register themselves via `init()` functions gated by build tags, e.g. `pkg/controllers/core/register.go:12`.
+Wrap errors only where they originate.
 
-## 5. Core Packages
+- Lower layers should use `errors.Wrap` (or equivalent) to add context.
+- Upper layers should return the error directly unless adding meaningful business context.
+- Do not repeatedly wrap the same error.
 
-### 5.1 Executor (`pkg/executor/`)
+KubeKey uses `github.com/cockroachdb/errors` with `errors.Wrapf` / `errors.Join`.
 
-Nested executors by scope:
+### 3.3 Naming
 
-| File | Executor | Responsibility |
-|------|----------|----------------|
-| `executor.go:14` | `Executor` interface | `Exec(ctx) error` |
-| `playbook_executor.go:61` | `playbookExecutor` | Loads project, iterates plays, handles hosts/serial/gather_facts |
-| `role_executor.go:14` | `roleExecutor` | Merges role vars, runs dependencies, executes role blocks |
-| `block_executor.go:20` | `blockExecutor` | Handles blocks/rescue/always, tags, when, include_tasks |
-| `task_executor.go:29` | `taskExecutor` | Creates `Task` CR, runs module per host in parallel |
+Keep names concise. Prefer meaningful short names. Avoid unnecessary abbreviations and verbose names.
 
-Play execution order (`playbook_executor.go:151`):
-
-```text
-for each serial batch of hosts:
-    pre_tasks
-    for each role (with recursive dependencies):
-        role blocks
-    tasks
-    post_tasks
-```
-
-### 5.2 Project (`pkg/project/`)
-
-`Project` interface (`project.go:44`):
+Avoid:
 
 ```go
-type Project interface {
-    MarshalPlaybook() (*kkprojectv1.Playbook, error)
-    Stat(path string) (os.FileInfo, error)
-    WalkDir(path string, f fs.WalkDirFunc) error
-    ReadFile(path string) ([]byte, error)
-    Rel(root string, path string) (string, error)
-}
+tmpData
+managerObject
+projectConfiguration
 ```
 
-`project.New` (`project.go:61`) selects implementation:
-
-- Git-like address → `newGitProject` (`git.go:37`).
-- `BuiltinsProjectAnnotation` → `builtinProjectFunc` (`builtin.go:33`).
-- Otherwise → `newLocalProject` (`local.go:30`).
-
-`MarshalPlaybook` (`project.go:106`) handles `import_playbook`, `vars_files`, roles (with `meta/dependencies`, `tasks/main.yaml`, `defaults`), `include_tasks`, and validation.
-
-### 5.3 Modules (`pkg/modules/`)
-
-Modules register in `module.go:54`:
+Prefer:
 
 ```go
-utilruntime.Must(internal.RegisterModule(command.ModuleCommand, "command", "shell"))
-utilruntime.Must(internal.RegisterModule(copy.ModuleCopy, "copy"))
-utilruntime.Must(internal.RegisterModule(template.ModuleTemplate, "template"))
-// ... add_hostvars, assert, debug, fetch, gen_cert, http_get_file, image,
-//     include_vars, prometheus, result, set_fact, setup
+cfg
+proj
+mgr
+conn
 ```
 
-Module signature (`internal/options.go:116`):
+### 3.4 Architecture
 
-```go
-type ModuleExecFunc func(ctx context.Context, opts ExecOptions) (stdout string, stderr string, err error)
-```
+Prefer modifying existing code instead of introducing new abstractions.
 
-A task block's module is discovered from its first `UnknownField` matching a registered module name (`block_executor.go:169`).
+- Do not introduce new structs or interfaces unless there is a clear benefit.
+- Keep APIs stable.
+- Minimize public surface.
+- Favor composition over inheritance-like patterns.
+- Do not repeat inherited conditions (e.g. `when`) at every level; declare them at the highest applicable scope.
 
-### 5.4 Variables (`pkg/variable/`)
+### 3.5 Go Conventions
 
-`Variable` interface (`variable.go:50`):
+- Package aliases: `kkcorev1`, `kkcorev1alpha1`, `kkprojectv1`.
+- `pkg/const` is imported as `_const` to avoid keyword collision.
+- Options structs have `Flags()` and `Complete()` methods.
+- Modules return `(stdout, stderr, err)` triples.
+- Controllers and built-in commands register via `init()` gated by build tags.
+- Templates use Go `text/template` + Sprig + custom functions in `pkg/converter/tmpl/`.
 
-```go
-type Variable interface {
-    Get(getFunc GetFunc) (any, error)
-    Merge(mergeFunc MergeFunc) error
-}
-```
-
-Variable precedence (highest to lowest, `variable_get.go:133`):
-
-1. Config vars
-2. Host-specific inventory vars
-3. Group vars (for groups containing host)
-4. Inventory `vars`
-5. Runtime vars (`set_fact`, `register`)
-6. Remote vars (gather_facts)
-
-Sources: `MemorySource` and `FileSource` (persists per-host vars under `<workdir>/runtime/.../variable/<hostname>.yaml`).
-
-### 5.5 Connectors (`pkg/connector/`)
-
-`Connector` interface (`connector.go:49`):
-
-```go
-type Connector interface {
-    Init(ctx context.Context) error
-    Close(ctx context.Context) error
-    PutFile(ctx context.Context, src []byte, dst string, mode fs.FileMode) error
-    FetchFile(ctx context.Context, src string, dst io.Writer) error
-    ExecuteCommand(ctx context.Context, cmd string) ([]byte, []byte, error)
-}
-```
-
-Selection (`connector.go:70`):
-
-- `connector.type=local` → `localConnector`
-- `connector.type=ssh` → `sshConnector`
-- `connector.type=kubernetes` → `kubernetesConnector`
-- `connector.type=prometheus` → `prometheusConnector`
-- Default: localhost → local, otherwise SSH.
-
-### 5.6 API Types
-
-- `api/core/v1/playbook_types.go` – `Playbook` CRD.
-- `api/core/v1/inventory_types.go` – `Inventory` CRD.
-- `api/core/v1/config_types.go` – `Config` CRD.
-- `api/core/v1alpha1/task_types.go` – `Task` CRD (per-task execution unit).
-- `api/project/v1/` – YAML-parsed `Playbook`, `Play`, `Role`, `Block`, `Base`, `Taggable`, `Conditional`.
-
-The API is a separate Go module referenced via `replace` in the root `go.mod` and included in `go.work`.
-
-## 6. Built-in Playbooks
-
-Built-in content is embedded only when the `builtin` build tag is set (`builtin/core/fs.go:26`). Key playbooks:
-
-- `builtin/core/playbooks/create_cluster.yaml` – full Kubernetes/KubeSphere install.
-- `builtin/core/playbooks/add_nodes.yaml`
-- `builtin/core/playbooks/delete_cluster.yaml`
-- `builtin/core/playbooks/init_os.yaml`
-- `builtin/core/playbooks/precheck.yaml`
-- `builtin/core/playbooks/certs_renew.yaml`
-- `builtin/core/playbooks/artifact_export.yaml`
-
-Key roles under `builtin/core/roles/`:
-
-- `native/` – common OS/package setup.
-- `defaults/` – default variables.
-- `precheck/` – environment checks.
-- `download/` – binary/image downloads.
-- `certs/` – certificate generation.
-- `etcd/` – etcd deployment.
-- `cri/` – container runtime installation.
-- `kubernetes/` – kubeadm/kubelet/kubectl setup.
-- `cni/` – CNI installation.
-- `image-registry/` – private registry setup.
-
-## 7. Build & Test
+## 4. Build & Test
 
 Important Makefile targets:
 
@@ -282,76 +144,75 @@ Build tags:
 - `builtin` – includes embedded playbooks/roles and built-in CLI commands.
 - `clusterapi` – CAPKK controller-manager image build.
 
-## 8. Code Conventions
+## 5. Agent Workflow
 
-- Package aliases: `kkcorev1`, `kkcorev1alpha1`, `kkprojectv1`.
-- `pkg/const` is imported as `_const` to avoid keyword collision.
-- Options structs have `Flags()` and `Complete()` methods.
-- Error handling uses `github.com/cockroachdb/errors` with `errors.Wrapf` / `errors.Join`.
-- Modules return `(stdout, stderr, err)` triples.
-- Controllers and built-in commands register via `init()` gated by build tags.
-- Templates use Go `text/template` + Sprig + custom functions in `pkg/converter/tmpl/`.
+Agents collaborate through files under `_output/agents/`. The directory is already ignored by Git and is meant for cross-session handoff only.
 
-## 9. Common Tasks for Agents
+```text
+_output/agents/
+├── design.md       # Architect output
+├── dev-summary.md  # Developer output
+├── review.md       # Reviewer output
+├── pr.md           # Reviewer output
+├── commit.txt      # Reviewer output
+├── test-plan.md    # Tester output
+└── test-result.md  # Tester output
+```
 
-### Add a new CLI flag
+Pipeline:
 
-Edit the relevant options struct in `cmd/kk/app/options/` (e.g. `run.go`), add the flag in `Flags()`, and map it in `Complete()`.
+1. **Architect** reads the requirement and writes `_output/agents/design.md`.
+2. **Developer** reads `design.md` and writes code + `_output/agents/dev-summary.md`.
+3. **Reviewer** reads `design.md` and `dev-summary.md`, reviews the code, and writes `_output/agents/review.md`, `_output/agents/pr.md`, `_output/agents/commit.txt`.
+4. **Tester** reads `design.md` and `dev-summary.md`, writes `_output/agents/test-plan.md`, runs tests, and writes `_output/agents/test-result.md`.
+5. **Maintainer** reads `dev-summary.md` and `review.md`, then updates README, CHANGELOG, docs and examples.
 
-### Add a new module
+Each role is defined in `.opencode/agents/<role>.md`. Agents must stay within their own responsibilities.
 
-1. Create a package under `pkg/modules/<name>/`.
-2. Implement `internal.ModuleExecFunc`.
-3. Register it in `pkg/modules/module.go`.
-4. Add user docs in `docs/en/framework/modules/<name>.md`.
-5. Add unit tests (`<name>_test.go`).
+## 6. Git Commit & PR Conventions
 
-### Add a new built-in playbook/role
+### Commit Message Format
 
-1. Add YAML to `builtin/core/playbooks/` or `builtin/core/roles/`.
-2. If adding a CLI command, add it in `cmd/kk/app/builtin/*.go` (gated by `builtin` tag).
-3. Run `make generate` and `make kk` to verify embedding.
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
-### Add a new controller/webhook
+```text
+<type>: <short description>
+```
 
-1. Create reconciler under `pkg/controllers/<group>/`.
-2. Register it in `pkg/controllers/<group>/register.go` with `options.Register`.
-3. Add RBAC markers and run `make generate-manifests-kubekey`.
+Common types:
 
-### Change variable precedence or lookup
+- `feat:` – new feature
+- `fix:` – bug fix
+- `refactor:` – code refactoring
+- `docs:` – documentation only
+- `test:` – tests
+- `chore:` – build, dependencies, tooling
 
-Start in `pkg/variable/variable.go` and `pkg/variable/variable_get.go`; persistence is in `pkg/variable/source/`.
+Examples:
 
-## 10. Key File Quick Reference
+```text
+feat: support multiple ssh private keys
+fix: preserve proxy configuration during reconnect
+```
 
-| Concern | File |
-|---------|------|
-| CLI root | `cmd/kk/app/root.go` |
-| CLI options | `cmd/kk/app/options/option.go` |
-| Built-in commands | `cmd/kk/app/builtin/*.go` |
-| Controller options | `cmd/controller-manager/app/options/controller_manager.go` |
-| Playbook execution | `pkg/executor/playbook_executor.go` |
-| Role execution | `pkg/executor/role_executor.go` |
-| Block execution | `pkg/executor/block_executor.go` |
-| Task execution | `pkg/executor/task_executor.go` |
-| Project loading | `pkg/project/project.go` |
-| Variable core | `pkg/variable/variable.go` |
-| Variable get | `pkg/variable/variable_get.go` |
-| Variable merge | `pkg/variable/variable_merge.go` |
-| Connector factory | `pkg/connector/connector.go` |
-| Module registry | `pkg/modules/module.go` |
-| Module internals | `pkg/modules/internal/options.go` |
-| Template functions | `pkg/converter/tmpl/functions.go` |
-| Playbook CRD | `api/core/v1/playbook_types.go` |
-| Inventory CRD | `api/core/v1/inventory_types.go` |
-| Task CRD | `api/core/v1alpha1/task_types.go` |
-| Project YAML types | `api/project/v1/playbook.go`, `play.go`, `block.go`, `role.go` |
-| Playbook controller | `pkg/controllers/core/playbook_controller.go` |
-| Web services | `pkg/web/service.go` |
-| REST proxy | `pkg/proxy/transport.go` |
+### Pull Request Description
 
-## 11. Related Docs
+A PR description should include:
 
-- [README.md](README.md) – user-facing intro.
-- [docs/en/framework/README.md](docs/en/framework/README.md) – writing custom playbooks.
-- [docs/agent-guide/CODE_LOGIC.md](docs/agent-guide/CODE_LOGIC.md) – detailed code logic flows (companion to this file).
+- **What** changed and **why**.
+- **How** it was implemented (briefly).
+- **Testing** performed.
+- **Risks / breaking changes**.
+
+The Reviewer agent generates `pr.md` and `commit.txt` based on the developer summary and review findings.
+
+## 7. Related Docs
+
+- [README.md](README.md)
+- [docs/en/framework/README.md](docs/en/framework/README.md)
+- [.opencode/agents/CODE_LOGIC.md](.opencode/agents/CODE_LOGIC.md)
+- `.opencode/agents/architect.md`
+- `.opencode/agents/developer.md`
+- `.opencode/agents/reviewer.md`
+- `.opencode/agents/tester.md`
+- `.opencode/agents/maintainer.md`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test
-->

/kind documentation

### What this PR does / why we need it:

This PR reorganizes the AI agent guidance documents to make responsibilities clearer and avoid duplicating conventions across agent roles.

- `AGENTS.md` is now focused on universal conventions only (logging, errors, naming, architecture, build/test, commit/PR conventions, workflow overview).
- Five role-specific agent definitions are added under `.opencode/agents/`:
  - `architect.md` – analyze requirements and produce `design.md`.
  - `developer.md` – implement code based on `design.md`.
  - `reviewer.md` – review code and produce `review.md`, `pr.md`, `commit.txt`.
  - `tester.md` – plan and execute tests, producing `test-plan.md` and `test-result.md`.
  - `maintainer.md` – keep README, CHANGELOG, docs and examples up to date.
- `CODE_LOGIC.md` is moved from `docs/agent-guide/` to `.opencode/agents/CODE_LOGIC.md` so all agent reference material lives in one place.
- `when` and `tags` inheritance behavior is documented clearly to prevent redundant playbook conditions.
- Real-environment testing with `qc-instances` is described as optional in `tester.md`.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
- No business logic is changed; this is a documentation/structure refactor.
- The previous `AGENTS.md` content has been split into role-specific files.
- `docs/agent-guide/` directory is removed because its only file moved to `.opencode/agents/`.
- All internal links have been updated to point to the new locations.
```

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
The agent workflow is now documented in:
- AGENTS.md (universal conventions)
- .opencode/agents/*.md (per-role instructions)
- .opencode/agents/CODE_LOGIC.md (code path reference)
```
