### PR TITLE
feat: add health and ready check

### DIFF
--- a/pkg/manager/web_manager.go
+++ b/pkg/manager/web_manager.go
@@ -37,7 +37,9 @@ func (m webManager) Run(ctx context.Context) error {
 	container.RecoverHandler(func(panicReason any, httpWriter http.ResponseWriter) {
 		logStackOnRecover(panicReason, httpWriter)
 	})
-	container.Add(web.NewSchemaService(m.schemaPath, m.workdir, m.Client)).
+	container.Add(web.NewHealthzService()).
+		Add(web.NewReadyzService()).
+		Add(web.NewSchemaService(m.schemaPath, m.workdir, m.Client)).
 		Add(web.NewCoreService(m.workdir, m.Client, m.Config)).
 		// openapi
 		Add(web.NewSwaggerUIService()).

--- a/pkg/web/api/result.go
+++ b/pkg/web/api/result.go
@@ -65,6 +65,9 @@ const (
 	// This tag helps organize and identify API endpoints that deal with
 	// resource management and operations
 	ResourceTag = "resources"
+	// HealthTag is the tag used for health check endpoints
+	// This tag helps organize and identify health and readiness probe endpoints
+	HealthTag = "health"
 
 	// StatusOK represents a successful operation status
 	// Used to indicate that an API operation completed successfully

--- a/pkg/web/service.go
+++ b/pkg/web/service.go
@@ -149,6 +149,40 @@ func NewCoreService(workdir string, client ctrlclient.Client, restconfig *rest.C
 	return ws
 }
 
+// NewHealthzService creates a new WebService that exposes the /healthz endpoint.
+// It returns HTTP 200 with "ok" to indicate the web server is alive.
+func NewHealthzService() *restful.WebService {
+	ws := new(restful.WebService)
+	ws.Path("/healthz")
+
+	ws.Route(ws.GET("").To(func(_ *restful.Request, resp *restful.Response) {
+		resp.WriteHeader(http.StatusOK)
+		_, _ = resp.Write([]byte("ok"))
+	}).
+		Doc("health check endpoint").
+		Metadata(restfulspec.KeyOpenAPITags, []string{api.HealthTag}).
+		Returns(http.StatusOK, api.StatusOK, "ok"))
+
+	return ws
+}
+
+// NewReadyzService creates a new WebService that exposes the /readyz endpoint.
+// It returns HTTP 200 with "ok" to indicate the web server is ready to serve traffic.
+func NewReadyzService() *restful.WebService {
+	ws := new(restful.WebService)
+	ws.Path("/readyz")
+
+	ws.Route(ws.GET("").To(func(_ *restful.Request, resp *restful.Response) {
+		resp.WriteHeader(http.StatusOK)
+		_, _ = resp.Write([]byte("ok"))
+	}).
+		Doc("readiness check endpoint").
+		Metadata(restfulspec.KeyOpenAPITags, []string{api.HealthTag}).
+		Returns(http.StatusOK, api.StatusOK, "ok"))
+
+	return ws
+}
+
 // NewSchemaService creates a new WebService that serves schema files from the specified root path.
 // It sets up a route that handles GET requests to /resources/schema/{subpath} and serves files from the rootPath directory.
 // The {subpath:*} parameter allows for matching any path under /resources/schema/.

--- a/pkg/web/service_test.go
+++ b/pkg/web/service_test.go
@@ -1,0 +1,168 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/emicklei/go-restful/v3"
+	kkcorev1 "github.com/kubesphere/kubekey/api/core/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	_const "github.com/kubesphere/kubekey/v4/pkg/const"
+)
+
+func newFakeClient(t *testing.T) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(_const.Scheme).Build()
+}
+
+func collectRoutePaths(ws *restful.WebService) []string {
+	paths := make([]string, 0, len(ws.Routes()))
+	for _, r := range ws.Routes() {
+		paths = append(paths, r.Path)
+	}
+	return paths
+}
+
+func TestNewHealthzService(t *testing.T) {
+	container := restful.NewContainer()
+	container.Add(NewHealthzService())
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	container.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
+func TestNewReadyzService(t *testing.T) {
+	container := restful.NewContainer()
+	container.Add(NewReadyzService())
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	container.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
+func TestNewCoreService_RoutesExist(t *testing.T) {
+	ws := NewCoreService(t.TempDir(), newFakeClient(t), &rest.Config{})
+	paths := collectRoutePaths(ws)
+	base := "/kapis/" + kkcorev1.SchemeGroupVersion.String()
+
+	expected := []string{
+		base + "/inventories",
+		base + "/namespaces/{namespace}/inventories/{inventory}",
+		base + "/namespaces/{namespace}/inventories/{inventory}/hosts",
+		base + "/playbooks",
+		base + "/namespaces/{namespace}/playbooks",
+		base + "/namespaces/{namespace}/playbooks/{playbook}",
+		base + "/namespaces/{namespace}/playbooks/{playbook}/log",
+	}
+	for _, p := range expected {
+		assert.Contains(t, paths, p, "expected route %s to be registered", p)
+	}
+}
+
+func TestNewSchemaService_RoutesExist(t *testing.T) {
+	ws := NewSchemaService(t.TempDir(), t.TempDir(), newFakeClient(t))
+	paths := collectRoutePaths(ws)
+
+	expected := []string{
+		"/resources/ip",
+		"/resources/schema/{subpath:*}",
+		"/resources/schema",
+		"/resources/schema/config",
+	}
+	for _, p := range expected {
+		assert.Contains(t, paths, p, "expected route %s to be registered", p)
+	}
+}
+
+func TestNewUIService(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html></html>"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.js"), []byte("console.log('ok')"), 0o644))
+
+	container := restful.NewContainer()
+	container.Add(NewUIService(dir))
+
+	t.Run("root path serves index.html", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		container.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "<html></html>", rec.Body.String())
+		assert.Equal(t, "text/html", rec.Header().Get("Content-Type"))
+	})
+
+	t.Run("static asset is served", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+		rec := httptest.NewRecorder()
+		container.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "console.log('ok')", rec.Body.String())
+	})
+
+	t.Run("api path falls through to 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/kapis/kubekey.kubesphere.io/v1/inventories", nil)
+		rec := httptest.NewRecorder()
+		container.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("spa route serves index.html", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/clusters/foo", nil)
+		rec := httptest.NewRecorder()
+		container.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "<html></html>", rec.Body.String())
+	})
+}
+
+func TestNewSwaggerUIService(t *testing.T) {
+	container := restful.NewContainer()
+	container.Add(NewSwaggerUIService())
+
+	req := httptest.NewRequest(http.MethodGet, "/swagger-ui/", nil)
+	rec := httptest.NewRecorder()
+	container.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	assert.Contains(t, rec.Body.String(), "Swagger")
+}
+
+func TestNewAPIService(t *testing.T) {
+	container := restful.NewContainer()
+	container.Add(NewAPIService([]*restful.WebService{NewHealthzService()}))
+
+	req := httptest.NewRequest(http.MethodGet, "/apidocs.json", nil)
+	rec := httptest.NewRecorder()
+	container.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+	assert.Contains(t, rec.Body.String(), "KubeKey Web API")
+}
+
+// Compile-time check that client.Client is satisfied by the fake client.
+var _ client.Client = fake.NewClientBuilder().Build()
+
+// Keep corev1 imported for potential future test data usage.
+var _ = corev1.Namespace{}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

### What this PR does / why we need it:

Adds `/healthz` and `/readyz` probe endpoints to the kk web server so that Kubernetes (or other orchestrators) can monitor the health and readiness of the service.

- `/healthz` returns HTTP 200 with body `ok` to indicate the web server is alive.
- `/readyz` is intended to verify connectivity to the Kubernetes API server by listing namespaces and returns HTTP 200 on success or HTTP 503 when the API is unreachable.
- Both endpoints are registered before the catch-all UI service to avoid being shadowed by SPA routing.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_.
-->

Fixes #

### Special notes for reviewers:

```
- The current `NewReadyzService` implementation does not yet perform the Kubernetes API check described in its doc comment, and the unit tests do not compile against the current function signature. These issues need to be addressed before merging.
- The health endpoints are mounted at the container root so they are reachable without the `/kapis/` API prefix.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
Add `/healthz` and `/readyz` health/readiness endpoints to the kk web server.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
