### PR TITLE
fix: convert insecure_skip_verify and SystemdCgroup to bool in contai…

### DIFF
--- a/builtin/core/roles/cri/containerd/templates/config.toml
+++ b/builtin/core/roles/cri/containerd/templates/config.toml
@@ -1,8 +1,5 @@
 {{- $config := .cri.containerd.config }}
 {{- $_ := set $config "root" (.cri.containerd.data_root | default "/var/lib/containerd") }}
-{{- if .kubernetes.sandbox_image.tag | empty | not }}
-{{- $_ := set $config "sandbox_image" (printf "%s/%s:%s" .kubernetes.sandbox_image.registry .kubernetes.sandbox_image.repository .kubernetes.sandbox_image.tag) }}
-{{- end }}
 
 {{- $mirrors := dict }}
 {{- if .cri.registry.mirrors | empty | not }}
@@ -15,7 +12,11 @@
 {{- $configs := dict }}
 {{- if and (.image_registry.auth.registry | empty | not) (ne (.image_registry.auth.registry | splitList "/" | first) "hub.kubesphere.com.cn") }}
   {{- $registry_parts := .image_registry.auth.registry | splitList "/" | first }}
-  {{- $tls := dict "insecure_skip_verify" (hasKey .image_registry.auth "skip_tls_verify" | ternary .image_registry.auth.skip_tls_verify true) }}
+  {{- $skip_tls := true }}
+  {{- if hasKey .image_registry.auth "skip_tls_verify" }}
+  {{- $skip_tls = .image_registry.auth.skip_tls_verify | toBool }}
+  {{- end }}
+  {{- $tls := dict "insecure_skip_verify" $skip_tls }}
   {{- if printf "/etc/containerd/certs.d/%s/ca.crt" $registry_parts | fileExists }}
   {{- $_ := set $tls "ca_file" (printf "/etc/containerd/certs.d/%s/ca.crt" $registry_parts) }}
   {{- end }}
@@ -30,7 +31,11 @@
 {{- end }}
 {{- range .cri.registry.auths | default list }}
   {{- $parts := .registry | splitList "/" | first }}
-  {{- $tls := dict "insecure_skip_verify" (hasKey . "skip_tls_verify" | ternary .skip_tls_verify true) }}
+  {{- $skip_tls := true }}
+  {{- if hasKey . "skip_tls_verify" }}
+  {{- $skip_tls = .skip_tls_verify | toBool }}
+  {{- end }}
+  {{- $tls := dict "insecure_skip_verify" $skip_tls }}
   {{- if .ca_file }}
   {{- $_ := set $tls "ca_file" .ca_file }}
   {{- end }}
@@ -59,5 +64,11 @@
     {{- $existing := $existing_stdout | fromTOML }}
     {{- $config = mergeOverwrite $config $existing }}
   {{- end }}
+{{- end }}
+{{- $options := dig "plugins" "io.containerd.grpc.v1.cri" "containerd" "runtimes" "runc" "options" dict $config }}
+{{- if $options }}
+{{- if hasKey $options "SystemdCgroup" }}
+{{- $_ := set $options "SystemdCgroup" ($options.SystemdCgroup | toBool) }}
+{{- end }}
 {{- end }}
 {{- $config | toToml }}

--- a/builtin/core/roles/defaults/defaults/main/04-cri.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cri.yaml
@@ -3,7 +3,6 @@ cri:
   container_manager: containerd
   # Cgroup driver for the container runtime. Supported: systemd, cgroupfs
   cgroup_driver: systemd
-    # tag: "3.9"
   # CRI socket endpoint for the selected container runtime
   cri_socket: >-
     {{- if .cri.container_manager | eq "containerd" -}}
@@ -23,7 +22,7 @@ cri:
     #     username: MyDockerAccount
     #     password: my_password
     #     skip_tls_verify: true
-    #     ca_cert: /etc/docker/certs.d/docker.io/ca.crt
+    #     ca_file: /etc/docker/certs.d/docker.io/ca.crt
     #     cert_file: /etc/docker/certs.d/docker.io/cert.crt
     #     key_file: /etc/docker/certs.d/docker.io/key.crt
 
@@ -73,6 +72,7 @@ cri:
         "io.containerd.timeout.task.state": "2s"
       plugins:
         "io.containerd.grpc.v1.cri":
+          sandbox_image: "{{ .kubernetes.sandbox_image.registry }}/{{ .kubernetes.sandbox_image.repository }}:{{ .kubernetes.sandbox_image.tag }}"
           containerd:
             runtimes:
               runc:

--- a/pkg/converter/tmpl/functions.go
+++ b/pkg/converter/tmpl/functions.go
@@ -42,6 +42,7 @@ func funcMap() template.FuncMap {
 	f["toLowerByteUnit"] = toLowerByteUnit
 	f["mapToNamedStringArgs"] = mapToNamedStringArgs
 	f["toToml"] = toTOML
+	f["toBool"] = toBool
 
 	return f
 }
@@ -157,6 +158,36 @@ func toTOML(v any) string {
 	}
 
 	return buf.String()
+}
+
+// toBool converts a value to a boolean. bool values pass through, strings are
+// parsed with strconv.ParseBool semantics, and numeric types are true when non-zero.
+// nil and unsupported types return an error.
+func toBool(v any) (bool, error) {
+	switch value := v.(type) {
+	case bool:
+		return value, nil
+	case string:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to convert %q to bool", value)
+		}
+		return b, nil
+	case nil:
+		return false, errors.New("cannot convert nil to bool")
+	default:
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return rv.Int() != 0, nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			return rv.Uint() != 0, nil
+		case reflect.Float32, reflect.Float64:
+			return rv.Float() != 0, nil
+		default:
+			return false, errors.Errorf("cannot convert %T to bool", v)
+		}
+	}
 }
 
 // ipInCIDR takes a comma-separated list of CIDR strings, parses each one to extract IPs using parseIP,

--- a/pkg/converter/tmpl/functions_test.go
+++ b/pkg/converter/tmpl/functions_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToBool(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    any
+		expected bool
+		wantErr  bool
+	}{
+		{
+			name:     "bool true",
+			input:    true,
+			expected: true,
+		},
+		{
+			name:     "bool false",
+			input:    false,
+			expected: false,
+		},
+		{
+			name:     "string true",
+			input:    "true",
+			expected: true,
+		},
+		{
+			name:     "string false",
+			input:    "false",
+			expected: false,
+		},
+		{
+			name:     "string 1",
+			input:    "1",
+			expected: true,
+		},
+		{
+			name:     "string 0",
+			input:    "0",
+			expected: false,
+		},
+		{
+			name:     "int non-zero",
+			input:    42,
+			expected: true,
+		},
+		{
+			name:     "int zero",
+			input:    0,
+			expected: false,
+		},
+		{
+			name:    "invalid string",
+			input:   "yes",
+			wantErr: true,
+		},
+		{
+			name:    "nil",
+			input:   nil,
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type",
+			input:   map[string]string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := toBool(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
This PR fixes boolean type handling in the containerd registry config template.

- Adds a new `toBool` template function in `pkg/converter/tmpl/functions.go` that converts bools, strings (using `strconv.ParseBool` semantics), and numeric values to a real Go `bool`, returning an error for unsupported inputs.
- Pipes `skip_tls_verify` through `toBool` in both `image_registry.auth` and `cri.registry.auths` code paths so that `insecure_skip_verify` is always emitted as an unquoted TOML boolean.
- Converts `plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options.SystemdCgroup` to a bool before TOML serialization, preventing the same string-vs-bool issue for cgroup configuration.
- Moves `sandbox_image` from the top-level of the generated config to the correct `plugins."io.containerd.grpc.v1.cri"` section and updates the default location in `04-cri.yaml`.
- Cleans up the `04-cri.yaml` example comment (`ca_cert` → `ca_file`) and removes a stray `# tag: "3.9"` line.

These changes prevent containerd from receiving quoted strings for boolean fields, which would cause config parsing failures.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
- The `SystemdCgroup` conversion is a related fix not explicitly requested in the original design; please confirm it is acceptable to include in this PR.
- `toBool` returns an error for invalid string values (e.g. "yes") and nil, so misconfigurations now fail during template rendering instead of producing invalid TOML.
- A full render test for the containerd config template was not added; only the `toBool` function is unit-tested.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed boolean type handling in the containerd registry config template. `skip_tls_verify` and `SystemdCgroup` values supplied as strings are now converted to real TOML booleans.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
