### PR TITLE
fix: restart correct chrony service on Debian-based systems

### DIFF
--- a/builtin/core/roles/native/ntp/tasks/main.yaml
+++ b/builtin/core/roles/native/ntp/tasks/main.yaml
@@ -50,6 +50,7 @@
   command: |
     {{- if or (.os.release.ID | eq "ubuntu") (.os.release.ID_LIKE | eq "debian") }}
     systemctl restart chrony.service
-    {{- end }}
+    {{- else }}
     systemctl restart chronyd.service
+    {{- end }}
   when: or (and .native.ntp.enabled (.native.ntp.servers | empty | not)) (.native.timezone | empty | not)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

Fixes the NTP service restart task so that only the correct service is restarted for the target OS family.

- On Debian/Ubuntu systems the package provides `chrony.service`.
- On RHEL/CentOS/Rocky systems the package provides `chronyd.service`.

Previously the template rendered `systemctl restart chrony.service` inside the Debian branch and then unconditionally rendered `systemctl restart chronyd.service`, causing the second command to fail on Debian-based hosts where `chronyd.service` does not exist.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
A duplicate of this task exists in builtin/capkk/roles/init/init-os/tasks/init_ntpserver.yaml
and contains the same bug. Consider whether that role should be fixed in the same PR.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed the built-in NTP role so it restarts only `chrony.service` on Debian-based systems and `chronyd.service` on RHEL-based systems.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
