### PR TITLE
feat: back up kubeadm-config.yaml with timestamp on control-plane nodes

### DIFF
--- a/builtin/core/playbooks/hook/post_install.yaml
+++ b/builtin/core/playbooks/hook/post_install.yaml
@@ -1,4 +1,27 @@
 ---
+# Back up kubeadm-config.yaml on every control-plane node with a timestamp.
+- hosts:
+    - kube_control_plane
+  tasks:
+    - name: Post | Back up kubeadm-config.yaml with timestamp
+      when: .kubernetes.backup.kubeadm_config_dir | empty | not
+      command: |
+        set -e
+        BACKUP_DIR="{{ .kubernetes.backup.kubeadm_config_dir }}"
+        SRC_FILE="/etc/kubernetes/kubeadm-config.yaml"
+        BACKUP_FILE="${BACKUP_DIR}/kubeadm-config-$(date +%Y%m%d-%H%M%S).yaml"
+
+        mkdir -p "${BACKUP_DIR}"
+        chmod 0700 "${BACKUP_DIR}"
+
+        if [ ! -f "${SRC_FILE}" ]; then
+          echo "ERROR: ${SRC_FILE} not found, backup aborted" >&2
+          exit 1
+        fi
+
+        cp -f "${SRC_FILE}" "${BACKUP_FILE}"
+        chmod 0600 "${BACKUP_FILE}"
+
 - name: Post | Apply Security Enhancements
   hosts:
     - all

--- a/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
+++ b/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
@@ -134,6 +134,11 @@ kubernetes:
     # Automatically renew service certificates (Note: CA certificates cannot be renewed automatically)
     renew: true
 
+  # Backup configuration for Kubernetes disaster recovery.
+  backup:
+    # Directory for timestamped kubeadm-config backups on control-plane nodes.
+    kubeadm_config_dir: /etc/kubekey/backup/kubernetes
+
   patches: []
     # Patches applied via a directory containing patch files.
     # - name: kube-apiserver0+merge.yaml

--- a/docs/en/installation/README.md
+++ b/docs/en/installation/README.md
@@ -117,6 +117,10 @@ When installing online, KubeKey automatically downloads required Kubernetes comp
 
 Offline installation is suitable for air-gapped environments, requiring an artifact package and system dependencies in advance. For detailed steps, see [Offline Installation](offline.md).
 
+## Disaster Recovery Backup
+
+On every run of `create_cluster.yaml` and `add_nodes.yaml`, KubeKey copies `/etc/kubernetes/kubeadm-config.yaml` to a timestamped file on every control-plane node. The default backup directory is `/etc/kubekey/backup/kubernetes`; each backup is named `kubeadm-config-YYYYMMDD-HHMMSS.yaml`. You can customize the directory with `kubernetes.backup.kubeadm_config_dir` in the `Config` resource. This backup is intended for manual disaster recovery when the cluster becomes unreachable.
+
 ## Cluster Node Management
 
 After the cluster is created, you can scale nodes according to business requirements.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
After cluster creation or node addition succeeds, every control-plane node should retain a usable copy of the kubeadm cluster configuration for disaster recovery. This change adds a single backup task to `builtin/core/playbooks/hook/post_install.yaml` that creates the backup directory, verifies `/etc/kubernetes/kubeadm-config.yaml` exists, copies it to a timestamped file, and sets restrictive permissions. The backup directory is configurable via a new default variable, and the empty `backup-kubeadm-config` role directory is removed.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
- The backup task is gated by `when: .kubernetes.backup.kubeadm_config_dir | empty | not` and runs only on `kube_control_plane` hosts.
- The default backup directory is configured in `builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml`.
- The empty `builtin/core/roles/kubernetes/backup-kubeadm-config/` directory has been removed.
- Documentation is updated in `docs/en/installation/README.md`.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add timestamped backup of `/etc/kubernetes/kubeadm-config.yaml` on control-plane nodes after installation. The backup directory can be customized via `kubernetes.backup.kubeadm_config_dir` (default: `/etc/kubekey/backup/kubernetes`).
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: docs/en/installation/README.md
```
