### PR TITLE
fix: move artifact fetch default to CommonOptions

### DIFF
--- a/cmd/kk/app/options/builtin/create.go
+++ b/cmd/kk/app/options/builtin/create.go
@@ -102,13 +102,6 @@ func (o *CreateClusterOptions) completeConfig() error {
 			return errors.Wrapf(err, "failed to set %q to config", "kube_version")
 		}
 	}
-	if o.Artifact != "" { // change default value to false
-		if _, ok, _ := unstructured.NestedFieldNoCopy(o.Config.Value(), "download", "fetch"); !ok {
-			if err := unstructured.SetNestedField(o.Config.Value(), false, "download", "fetch"); err != nil {
-				return errors.Wrapf(err, "failed to set %q to config", "download.fetch")
-			}
-		}
-	}
 
 	return nil
 }

--- a/cmd/kk/app/options/option.go
+++ b/cmd/kk/app/options/option.go
@@ -250,6 +250,12 @@ func (o *CommonOptions) completeConfig() error {
 		if err := unstructured.SetNestedField(o.Config.Value(), o.Artifact, "download", "artifact_file"); err != nil {
 			return errors.Wrapf(err, "failed to set %q to config", "download.artifact_file")
 		}
+		// change default value to false
+		if _, ok, _ := unstructured.NestedFieldNoCopy(o.Config.Value(), "download", "fetch"); !ok {
+			if err := unstructured.SetNestedField(o.Config.Value(), false, "download", "fetch"); err != nil {
+				return errors.Wrapf(err, "failed to set %q to config", "download.fetch")
+			}
+		}
 	}
 	for _, s := range o.Set {
 		for _, setVal := range strings.Split(s, ",") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind dependencies
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

When an artifact file is specified via `--artifact`, KubeKey should default `download.fetch` to `false` because the offline package is already provided. Previously this default was only applied inside `CreateClusterOptions.completeConfig()`, so other commands that embed `CommonOptions` (e.g., `add nodes`, `init os`, `precheck`) did not get the same behavior.

This change moves the default into `CommonOptions.completeConfig()` so that all commands inheriting the common options apply it consistently. Explicit `--set download.fetch=true` still takes precedence because `--set` values are applied after the default.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
- The logic is moved verbatim; only the location changes.
- Create cluster behavior is preserved because CommonOptions.Complete runs before CreateClusterOptions.completeConfig.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed inconsistent default value of `download.fetch` when `--artifact` is used with commands other than `create cluster`.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
