### PR TITLE
refactor(ha): rename ambiguous 'interface' registered variable

### DIFF
--- a/builtin/core/roles/image-registry/keepalived/tasks/main.yaml
+++ b/builtin/core/roles/image-registry/keepalived/tasks/main.yaml
@@ -22,13 +22,13 @@
             printf "\n]\n";
           }
         '
-      register: interface
+      register: keepalived_interfaces
       register_type: json
     - name: Keepalived | Select interface matching HA VIP
-      set_fact: 
+      set_fact:
         ha_vip_interface: >-
           {{- $interface := "" }}
-          {{- range .interface.stdout | default list -}}
+          {{- range .keepalived_interfaces.stdout | default list -}}
             {{- if .cidr | ipInCIDR | has $.image_registry.ha_vip -}}
               {{- $interface = .interface -}}
             {{- end -}}

--- a/builtin/core/roles/kubernetes/pre-kubernetes/tasks/high-availability/kube_vip.yaml
+++ b/builtin/core/roles/kubernetes/pre-kubernetes/tasks/high-availability/kube_vip.yaml
@@ -22,13 +22,13 @@
             printf "\n]\n";
           }
         '
-      register: interface
+      register: kube_vip_interfaces
       register_type: json
     - name: Kubevip | Select network interface matching kube-vip address
-      set_fact: 
+      set_fact:
         kube_vip_interface: >-
           {{- $interface := "" }}
-          {{- range .interface.stdout | default list -}}
+          {{- range .kube_vip_interfaces.stdout | default list -}}
             {{- if .cidr | ipInCIDR | has $.kubernetes.control_plane_endpoint.kube_vip.address -}}
               {{- $interface = .interface -}}
             {{- end -}}


### PR DESCRIPTION
/kind cleanup

## What does this PR do

Rename the ambiguous `interface` registered variable to role-specific names in the HA playbooks.

### Background / Motivation

The `interface` variable registered from the shell task is overly generic and makes the HA playbooks (keepalived image-registry role and kube-vip pre-kubernetes role) harder to read and reason about. Giving it a descriptive, role-scoped name improves clarity with no functional impact.

### Implementation

Pure rename of the `register:` target and its only usage site (`.<var>.stdout`) in each file, plus removing a stray trailing space after `set_fact:`. No logic changed. The JSON data field `interface` emitted by the shell `printf` and consumed inside the `range` loop is intentionally left untouched, since it is the data structure field, not the registered variable.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/image-registry/keepalived/tasks/main.yaml` | `register: interface` → `register: keepalived_interfaces`; `.interface.stdout` → `.keepalived_interfaces.stdout`; trailing space removed after `set_fact:` |
| `builtin/core/roles/kubernetes/pre-kubernetes/tasks/high-availability/kube_vip.yaml` | `register: interface` → `register: kube_vip_interfaces`; `.interface.stdout` → `.kube_vip_interfaces.stdout`; trailing space removed after `set_fact:` |

## Impact

- **Affected modules**: HA playbooks — keepalived image-registry role, kube-vip pre-kubernetes role
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [ ] Unit tests pass (`make test`)
- [ ] Integration / E2E tests pass
- [x] Manual verification

### Steps to verify

1. Inspect the two YAML files; the registered variable name and its only usage site match within each file.
2. Run a cluster creation with HA enabled (keepalived for image-registry HA, kube-vip for control plane endpoint) to confirm VIP interface selection still resolves correctly.

### Test coverage

YAML playbook change only; no Go unit tests affected. Both files were verified to parse as valid YAML and the variable rename is consistent across each file.

## Rollback

Plain revert of the commit.

### Does this PR introduce a user-facing change?

```release-note
None
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [ ] Breaking changes marked above

## Notes for Reviewer

Pure variable rename for readability; no behavior change. The previous name `interface` was generic and could be confused with the network-interface concept, so I scoped it per role. Note the JSON data field `interface` (emitted by the shell `printf` and read inside the `range` loop) is intentionally unchanged — only the Ansible registered variable was renamed.
