### PR TITLE
feat: 支持 define 模板定义，例如自模板include复用减少重复定义计算逻辑.

### DIFF
--- a/builtin/core/fs.go
+++ b/builtin/core/fs.go
@@ -23,7 +23,7 @@ import (
 	"embed"
 )
 
-//go:embed playbooks roles
+//go:embed playbooks roles tpls
 var BuiltinPlaybook embed.FS
 
 //go:embed defaults

--- a/builtin/core/roles/native/dns/tasks/main.yaml
+++ b/builtin/core/roles/native/dns/tasks/main.yaml
@@ -7,35 +7,14 @@
     cat >> {{ .item }} <<EOF
     # kubekey hosts BEGIN
     # Kubernetes cluster nodes
-    {{- range .groups.k8s_cluster | default list }}
-      {{- $hostname := index $.hostvars . "hostname" -}}
-      {{- $clusterName := $.kubernetes.cluster_name | default "kubekey" -}}
-      {{- $dnsDomain := $.kubernetes.networking.dns_domain | default "cluster.local" -}}
-      {{- if (index $.hostvars . "internal_ipv4") | empty | not }}
-    {{ index $.hostvars . "internal_ipv4" }} {{ $hostname }} {{ printf "%s.%s" $hostname $clusterName }} {{ printf "%s.%s.%s" $hostname $clusterName $dnsDomain }}
-      {{- end }}
-      {{- if (index $.hostvars . "internal_ipv6") | empty | not }}
-    {{ index $.hostvars . "internal_ipv6" }} {{ $hostname }} {{ printf "%s.%s" $hostname $clusterName }} {{ printf "%s.%s.%s" $hostname $clusterName $dnsDomain }}
-      {{- end }}
-    {{- end }}
+    {{- $clusterName := $.kubernetes.cluster_name | default "kubernetes" -}}
+    {{- $dnsDomain := $.kubernetes.networking.dns_domain | default "cluster.local" -}}
+    {{- $hostSuffixDomains := printf "%s.%s" $clusterName $dnsDomain|list $clusterName}}
+    {{- .groups.k8s_cluster    |dict "host_suffix_domains" $hostSuffixDomains "hostvars" .hostvars "nodes"|include "ip.host.dns.list" }}
     # etcd cluster nodes
-    {{- range .groups.etcd | default list }}
-      {{- if (index $.hostvars . "internal_ipv4") | empty | not }}
-    {{ index $.hostvars . "internal_ipv4" }} {{ index $.hostvars . "hostname" }}
-      {{- end }}
-      {{- if (index $.hostvars . "internal_ipv6") | empty | not }}
-    {{ index $.hostvars . "internal_ipv6" }} {{ index $.hostvars . "hostname" }}
-      {{- end }}
-    {{- end }}
+    {{- .groups.etcd           |dict "hostvars" .hostvars "nodes"|include "ip.host.dns.list" }}
     # Image registry nodes
-    {{- range .groups.image_registry | default list }}
-      {{- if (index $.hostvars . "internal_ipv4") | empty | not }}
-    {{ index $.hostvars . "internal_ipv4" }} {{ index $.hostvars . "hostname" }}
-      {{- end }}
-      {{- if (index $.hostvars . "internal_ipv6") | empty | not }}
-    {{ index $.hostvars . "internal_ipv6" }} {{ index $.hostvars . "hostname" }}
-      {{- end }}
-    {{- end }}
+    {{- .groups.image_registry |dict "hostvars" .hostvars "nodes"|include "ip.host.dns.list" }}
     # kubekey image_registry control_plane_endpoint BEGIN
     {{- $registryHost := .image_registry.auth.registry | splitList "/" | first | splitList ":" | first }}
     {{- if and ($registryHost | empty | not) ($registryHost | isIP | not) }}
@@ -43,25 +22,14 @@
     {{ .image_registry.ha_vip }} {{ $registryHost }}
       {{- else if or (.image_registry.type | eq "harbor") (.image_registry.type | eq "docker-registry") }}
         {{- if .groups.image_registry | empty | not }}
-          {{- if (index .hostvars (.groups.image_registry | first) "internal_ipv4") | empty | not }}
-    {{ index .hostvars (.groups.image_registry | first) "internal_ipv4" }} {{ $registryHost }}
-          {{- end }}
-          {{- if (index .hostvars (.groups.image_registry | first) "internal_ipv6") | empty | not }}
-    {{ index .hostvars (.groups.image_registry | first) "internal_ipv6" }} {{ $registryHost }}
-          {{- end }}
+          {{- $node := .groups.image_registry | first }}
+          {{- dict "hostvars" .hostvars "node" $node "domains" $registryHost| include "ip.host.dns" }}
         {{- end }}
       {{- end }}
     {{- end }}
     # kubekey image_registry control_plane_endpoint END
     # NFS server nodes
-    {{- range .groups.nfs | default list }}
-      {{- if (index $.hostvars . "internal_ipv4") | empty | not }}
-    {{ index $.hostvars . "internal_ipv4" }} {{ index $.hostvars . "hostname" }}
-      {{- end }}
-      {{- if (index $.hostvars . "internal_ipv6") | empty | not }}
-    {{ index $.hostvars . "internal_ipv6" }} {{ index $.hostvars . "hostname" }}
-      {{- end }}
-    {{- end }}
+    {{- .groups.nfs            |dict "hostvars" .hostvars "nodes"|include "ip.host.dns.list" }}
     # kubekey hosts END
     EOF
 

--- a/builtin/core/tpls/common.tpl
+++ b/builtin/core/tpls/common.tpl
@@ -1,0 +1,22 @@
+{{- define "ip.host.dns.list" }}
+{{- $hostSuffixDomains := .host_suffix_domains|default list }}
+{{- range .nodes | default list }}
+  {{- dict "hostvars" $.hostvars "node" . "host_suffix_domains" $hostSuffixDomains| include "ip.host.dns" }}
+{{- end }}
+{{- end -}}
+
+{{- define "ip.host.dns" }}
+{{- $hostname := index .hostvars .node "hostname" }}
+{{- $ipv4 := index .hostvars .node "internal_ipv4" }}
+{{- $ipv6 := index .hostvars .node "internal_ipv6" }}
+{{- $domains := .domains|default $hostname }}
+{{- range .host_suffix_domains | default list}}
+  {{- $domains = printf "%s %s.%s" $domains $hostname .}}
+{{- end }}
+{{- if $ipv4 | empty | not }}
+{{ $ipv4 }} {{ $domains }}
+{{- end }}
+{{- if $ipv6 | empty | not }}
+{{ $ipv6 }} {{ $domains }}
+{{- end }}
+{{- end -}}

--- a/pkg/converter/tmpl/template.go
+++ b/pkg/converter/tmpl/template.go
@@ -18,6 +18,8 @@ package tmpl
 
 import (
 	"bytes"
+	"os"
+	"path"
 	"text/template"
 
 	"github.com/cockroachdb/errors"
@@ -42,15 +44,17 @@ func ParseFunc[C ~map[string]any, Output any](ctx C, input string, f func([]byte
 		return f([]byte(input)), nil
 	}
 
-	funcMap := funcMap()
-	includedNames := make(map[string]int)
 	tl := template.New("kubekey")
-	// Add the template-rendering functions here so we can close over t.
-	funcMap["include"] = includeFun(tl, includedNames)
-	funcMap["tpl"] = tplFun(tl, includedNames, false)
+	setupTemplateEngine(tl)
+
+	if err := loadBuiltinIncludeTemplates(tl); err != nil {
+		return f(nil), errors.Wrapf(err, "failed to parse builtin template %q", "tpls/*.tpl")
+	}
+	if err := loadIncludeTemplates(tl, ctx); err != nil {
+		return f(nil), err
+	}
 	// Parse the template string
-	_, err := tl.Funcs(funcMap).Parse(input)
-	if err != nil {
+	if _, err := tl.Parse(input); err != nil {
 		return f(nil), errors.Wrapf(err, "failed to parse template '%s'", input)
 	}
 	// Execute template with provided context
@@ -88,4 +92,37 @@ func ParseBool(ctx map[string]any, inputs ...string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func setupTemplateEngine(tl *template.Template) {
+	funcMap := funcMap()
+	includedNames := make(map[string]int)
+	// Add the template-rendering functions here so we can close over t.
+	funcMap["include"] = includeFun(tl, includedNames)
+	funcMap["tpl"] = tplFun(tl, includedNames, false)
+	_ = tl.Funcs(funcMap)
+}
+
+func loadIncludeTemplates(tl *template.Template, ctx map[string]any) error {
+	includesDir, ok := ctx["include_tpls"]
+	if !ok {
+		return nil
+	}
+	includesDirStr, ok := includesDir.(string)
+	if !ok || includesDirStr == "" {
+		return nil
+	}
+	fileInfo, err := os.Stat(includesDirStr)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get include_tpls fileinfo %q", includesDir)
+	}
+	if fileInfo.IsDir() {
+		_, err = tl.ParseGlob(path.Join(includesDirStr, "*.tpl"))
+	} else {
+		_, err = tl.ParseFiles(includesDirStr)
+	}
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse include template %q", includesDirStr)
+	}
+	return nil
 }

--- a/pkg/converter/tmpl/tpls_parse_builtin.go
+++ b/pkg/converter/tmpl/tpls_parse_builtin.go
@@ -1,0 +1,19 @@
+//go:build builtin
+// +build builtin
+
+package tmpl
+
+import (
+	"text/template"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/kubesphere/kubekey/v4/builtin/core"
+)
+
+func loadBuiltinIncludeTemplates(tl *template.Template) (err error) {
+	if _, err = tl.ParseFS(core.BuiltinPlaybook, "tpls/*.tpl"); err != nil {
+		err = errors.Wrapf(err, "failed to parse builtin template %q", "tpls/*.tpl")
+	}
+	return
+}

--- a/pkg/converter/tmpl/tpls_parse_no_builtin.go
+++ b/pkg/converter/tmpl/tpls_parse_no_builtin.go
@@ -1,0 +1,12 @@
+//go:build !builtin
+// +build !builtin
+
+package tmpl
+
+import (
+	"text/template"
+)
+
+func loadBuiltinIncludeTemplates(tl *template.Template) error {
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

## What does this PR do

Introduce `define` sub-template support with `include` reuse, so that repeated template rendering/computation logic can be shared instead of being duplicated inline.

### Background / Motivation

The built-in playbooks repeatedly render the same host/IP/DNS mapping logic inline across multiple node groups (k8s_cluster, etcd, image_registry, nfs). This duplication makes the templates harder to maintain and more error-prone. A reusable template definition mechanism reduces this repetition.

### Implementation

Add support for `define`/`include` sub-templates in the template engine:

- The template engine now loads built-in `*.tpl` include templates (embedded via `builtin/core/tpls/`) and, when configured, user-provided include templates (via an `include_tpls` context value pointing to a directory of `*.tpl` files or a single file).
- Built-in include template loading is gated by the `builtin` build tag (a no-op stub is provided for non-builtin builds).
- The DNS role task was refactored to use the new `ip.host.dns` / `ip.host.dns.list` sub-templates instead of repeating the inline host/IP/DNS rendering for each node group.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/fs.go` | Embed the new `tpls` directory in `BuiltinPlaybook` |
| `builtin/core/tpls/common.tpl` | New file: defines `ip.host.dns` and `ip.host.dns.list` reusable sub-templates |
| `builtin/core/roles/native/dns/tasks/main.yaml` | Refactored to use `include "ip.host.dns.list"` / `include "ip.host.dns"` instead of repeated inline rendering |
| `pkg/converter/tmpl/template.go` | Load builtin and user include templates (`include_tpls`) before parsing; extract template engine setup into `setupTemplateEngine` |
| `pkg/converter/tmpl/tpls_parse_builtin.go` | New file (`builtin` tag): loads builtin `tpls/*.tpl` via `ParseFS` |
| `pkg/converter/tmpl/tpls_parse_no_builtin.go` | New file (`!builtin` tag): no-op stub for builtin include template loading |

## Impact

- **Affected modules**: `pkg/converter/tmpl`, `builtin/core`
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: New optional `include_tpls` context value to load user-provided `*.tpl` include templates (a directory path or a single file path)
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Testing

### Verification performed

- [ ] Unit tests pass (`<command>`)
- [ ] Integration / E2E tests pass (`<command>`)
- [ ] Manual verification

### Steps to verify

1. <step>
2. <step>
3. <expected result>

### Test coverage

<New / modified test cases, or why no tests are needed>

## Rollback

<How to roll back if it goes wrong: plain revert / additional steps (data rollback, config restore, toggle off)>

### Does this PR introduce a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

## Checklist

- [ ] Code self-reviewed, no debug code or commented-out dead code
- [ ] No secrets, tokens, or `.env` files committed
- [ ] Commit message follows Conventional Commits
- [ ] All commits have DCO sign-off (`Signed-off-by`)
- [ ] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [ ] Breaking changes marked above

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

## Notes for Reviewer

<What you want the reviewer to focus on, known trade-offs or open questions; N/A if none>