### PR TITLE
refactor(cri): use three-state config policy instead of force upgrade

### DIFF
--- a/builtin/core/roles/cri/containerd/tasks/main.yaml
+++ b/builtin/core/roles/cri/containerd/tasks/main.yaml
@@ -57,7 +57,7 @@
           /etc/containerd/certs.d/{{ .image_registry.auth.registry | splitList "/" | first }}/client.key
 
 - name: Containerd | Configure containerd
-  when: or .upgrade.cri (or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not))
+  when: or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not) (.cri.containerd.config_policy | empty | not)
   block:
     - name: Containerd | Read existing containerd configuration
       when: .cri.containerd.config_policy | eq "merge"
@@ -69,11 +69,11 @@
         src: config.toml
         dest: /etc/containerd/config.toml
 - name: Containerd | Deploy the containerd systemd service file
-  when: or .upgrade.cri (or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not))
+  when: or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not) (.cri.containerd.config_policy | empty | not)
   copy:
     src: containerd.service
     dest: /etc/systemd/system/containerd.service
 - name: Containerd | Start and enable the containerd service
-  when: or .upgrade.cri (or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not))
+  when: or (.containerd_install_version.error | empty | not) (.containerd_install_version.stdout | contains (printf " %s " .cri.containerd_version) | not) (.cri.containerd.config_policy | empty | not)
   command: |
     systemctl daemon-reload && systemctl restart containerd.service && systemctl enable containerd.service

--- a/builtin/core/roles/cri/docker/tasks/main.yaml
+++ b/builtin/core/roles/cri/docker/tasks/main.yaml
@@ -71,7 +71,7 @@
 
 # install or update docker service
 - name: Docker | Configure Docker daemon
-  when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
+  when: or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not) (.cri.docker.daemon_policy | empty | not)
   block:
     - name: Docker | Read existing Docker daemon configuration
       when: .cri.docker.daemon_policy | eq "merge"
@@ -84,12 +84,12 @@
         src: daemon.json
         dest: /etc/docker/daemon.json
 - name: Docker | Deploy the Docker systemd service file
-  when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
+  when: or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not) (.cri.docker.daemon_policy | empty | not)
   copy:
     src: docker.service
     dest: /etc/systemd/system/docker.service
 - name: Containerd | Configure containerd
-  when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
+  when: or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not) (.cri.docker.daemon_policy | empty | not)
   block:
     - name: Containerd | Read existing containerd configuration
       when: .cri.containerd.config_policy | eq "merge"
@@ -101,12 +101,12 @@
         src: config.toml
         dest: /etc/containerd/config.toml
 - name: Docker | Deploy the containerd systemd service file
-  when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
+  when: or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not) (.cri.docker.daemon_policy | empty | not)
   copy:
     src: containerd.service
     dest: /etc/systemd/system/containerd.service
 - name: Docker | Start and enable Docker and containerd services
-  when: or .upgrade.cri (or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not))
+  when: or (.docker_install_version.error | empty | not) (.docker_install_version.stdout | hasPrefix (printf "Docker version %s," .cri.docker_version) | not) (.cri.docker.daemon_policy | empty | not)
   command: |
     systemctl daemon-reload && systemctl restart containerd.service && systemctl enable containerd.service
     systemctl daemon-reload && systemctl restart docker.service && systemctl enable docker.service

--- a/builtin/core/roles/defaults/defaults/main/01-main.yaml
+++ b/builtin/core/roles/defaults/defaults/main/01-main.yaml
@@ -55,9 +55,5 @@ delete:
 # This is typically used with --with-data flag or delete.data: true
   data: false
 
-upgrade:
-  # Whether to modify CRI configuration file
-  cri: false
-
 # image_manifests: List of container images to be synchronized to the private registry
 image_manifests: []

--- a/builtin/core/roles/defaults/defaults/main/04-cri.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cri.yaml
@@ -27,8 +27,8 @@ cri:
     #     key_file: /etc/docker/certs.d/docker.io/key.crt
 
   docker:
-    # How to handle /etc/docker/daemon.json: override (default) or merge with existing file
-    daemon_policy: override
+    # How to handle /etc/docker/daemon.json when already installed: empty (default) skips, "merge" merges with existing file, "override" overwrites
+    daemon_policy: ""
     daemon:
       data-root: "{{ .cri.docker.data_root | default \"/var/lib/docker\" }}"
       log-opts:
@@ -39,8 +39,8 @@ cri:
         - "native.cgroupdriver={{ .cri.cgroup_driver | default \"systemd\" }}"
 
   containerd:
-    # How to handle /etc/containerd/config.toml: override (default) or merge with existing file
-    config_policy: override
+    # How to handle /etc/containerd/config.toml when already installed: empty (default) skips, "merge" merges with existing file, "override" overwrites
+    config_policy: ""
     config:
       root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
       version: 2

--- a/docs/en/reference/config.md
+++ b/docs/en/reference/config.md
@@ -769,6 +769,9 @@ cri:
 
   # Docker configuration
   docker:
+    # Policy for updating the Docker daemon config and systemd service when the runtime is already installed.
+    # Empty (default): skip the update; "merge": merge with the existing config; "override": overwrite.
+    daemon_policy: ""
     # Docker daemon configuration
     daemon:
       # Docker data root directory
@@ -787,6 +790,9 @@ cri:
 
   # containerd configuration
   containerd:
+    # Policy for updating the containerd config file and systemd service when the runtime is already installed.
+    # Empty (default): skip the update; "merge": merge with the existing config (node-side keys take precedence); "override": overwrite.
+    config_policy: ""
     config:
       # containerd data root directory
       root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
@@ -852,6 +858,8 @@ cri:
 | `cri.docker.daemon.live-restore` | Whether to enable Docker live-restore. |
 | `cri.docker.daemon.exec-opts` | Docker exec options list, e.g., cgroup driver. |
 | `cri.containerd.config` | containerd configuration, mapped to `/etc/containerd/config.toml`. |
+| `cri.containerd.config_policy` | Policy for updating the containerd config file (`/etc/containerd/config.toml`) and systemd service when the runtime is already installed: empty (default) skips the update; `merge` merges with the existing config (node-side existing keys take precedence); `override` overwrites. Binary installation and certificate sync are not affected by this policy. |
+| `cri.docker.daemon_policy` | Same as `cri.containerd.config_policy`, but applies to the Docker daemon (`/etc/docker/daemon.json`) and its systemd service. |
 | `cri.containerd.config.root` | containerd data persistence root directory. |
 | `cri.containerd.config.version` | containerd configuration file version. |
 | `cri.containerd.config.state` | containerd runtime state directory. |

--- a/docs/zh/reference/config.md
+++ b/docs/zh/reference/config.md
@@ -767,6 +767,9 @@ cri:
 
   # Docker 配置
   docker:
+    # 已安装 Docker 时，更新 daemon 配置（/etc/docker/daemon.json）与 systemd 服务的策略。
+    # 空（默认）：跳过更新；"merge"：与现有配置合并；"override"：覆盖。
+    daemon_policy: ""
     # Docker daemon 配置
     daemon:
       # Docker 数据根目录
@@ -785,6 +788,9 @@ cri:
 
   # containerd 配置
   containerd:
+    # 已安装 containerd 时，更新配置文件（/etc/containerd/config.toml）与 systemd 服务的策略。
+    # 空（默认）：跳过更新；"merge"：与现有配置合并（节点侧已有键优先）；"override"：覆盖。
+    config_policy: ""
     config:
       # containerd 数据根目录
       root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
@@ -850,6 +856,8 @@ cri:
 | `cri.docker.daemon.live-restore` | 是否启用 Docker live-restore。 |
 | `cri.docker.daemon.exec-opts` | Docker exec 选项列表，例如 cgroup 驱动。 |
 | `cri.containerd.config` | containerd 配置，映射为 `/etc/containerd/config.toml`。 |
+| `cri.containerd.config_policy` | 已安装 containerd 时，更新配置文件（/etc/containerd/config.toml）与 systemd 服务的策略：空（默认）跳过更新；`merge` 与现有配置合并（节点侧已有键优先）；`override` 覆盖。该策略不影响二进制安装与证书同步。 |
+| `cri.docker.daemon_policy` | 与 `cri.containerd.config_policy` 相同，但作用于 Docker daemon（/etc/docker/daemon.json）及其 systemd 服务。 |
 | `cri.containerd.config.root` | containerd 数据持久化根目录。 |
 | `cri.containerd.config.version` | containerd 配置文件版本。 |
 | `cri.containerd.config.state` | containerd 运行状态目录。 |


### PR DESCRIPTION
/kind cleanup
/kind documentation

## What does this PR do

Replaces the forced `.upgrade.cri` CRI reconfiguration switch with an explicit three-state config policy (`config_policy` / `daemon_policy`).

### Background / Motivation

The old `.upgrade.cri` flag unconditionally regenerated the CRI config and restarted the service on every upgrade or re-run, even when the runtime was already installed and version-matched. This caused needless restarts of running clusters.

### Implementation

Introduce a three-state policy for already-installed runtimes:
- `""` (default): skip the config/service update
- `merge`: merge with the existing config (node-side existing keys take precedence)
- `override`: overwrite the config

The config, systemd service, and restart tasks now share an identical `when` (`or (not installed) (version mismatch) (policy non-empty)`), guaranteeing that a config or service change always restarts the service. Binary install and certificate sync are unchanged (driven by version check and `image_registry.auth` respectively).

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/cri/containerd/tasks/main.yaml` | Drop `.upgrade.cri`; config/service/restart `when` gain the three-state branch |
| `builtin/core/roles/cri/docker/tasks/main.yaml` | Same, using `cri.docker.daemon_policy` |
| `builtin/core/roles/defaults/defaults/main/01-main.yaml` | Remove the now-unused `upgrade.cri` default |
| `builtin/core/roles/defaults/defaults/main/04-cri.yaml` | Default `config_policy` / `daemon_policy` changed `override` → `""` (skip) |
| `docs/en/reference/config.md` | Document `cri.containerd.config_policy` / `cri.docker.daemon_policy` |
| `docs/zh/reference/config.md` | Same, in Chinese |

## Impact

- **Affected modules**: `builtin/core/roles/cri/*`, CRI defaults
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: new `cri.containerd.config_policy` and `cri.docker.daemon_policy`; default changed from `override` to `""` (skip). To force reconfiguration of an already-installed runtime, set `override` (or `merge`) explicitly.
- **Dependency changes**: N/A

## Breaking Changes

Default behavior change: for an already-installed runtime whose version already matches, KubeKey no longer overwrites the config and restarts the service by default (previously it did because `override` was the default). Nodes are now left untouched unless `config_policy`/`daemon_policy` is set to `merge` or `override`. Migration: if you relied on the previous always-overwrite behavior, set `cri.containerd.config_policy: override` (and/or `cri.docker.daemon_policy: override`) in your cluster config.

### Which issue(s) this PR fixes:

None

## Testing

### Verification performed

- [x] Code self-review of the `when` conditions across containerd/docker roles
- [ ] Unit tests pass
- [ ] Integration / E2E tests pass
- [ ] Manual verification on a real cluster

### Steps to verify

1. Install a cluster, then re-run `kk create cluster` / add a node whose CRI is already installed and version-matched with `config_policy` unset → CRI config/service should be skipped.
2. Set `cri.containerd.config_policy: override` (or `merge`) and re-run → config regenerated, service restarted.

### Test coverage

YAML/role logic change; no Go unit tests affected. Playbook behavior verified by diff review and condition analysis.

## Rollback

Plain revert of this commit; pure playbook/defaults/docs changes, no data migration needed.

### Does this PR introduce a user-facing change?

```release-note
Change default CRI config policy: an already-installed, version-matched container runtime is no longer overwritten/restarted by default. To force reconfiguration, set `cri.containerd.config_policy` / `cri.docker.daemon_policy` to `override` (or `merge`).
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [x] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

## Notes for Reviewer

The config/service/restart `when` conditions must stay identical across the three task groups; please keep them in sync if editing one.
