### PR TITLE
fix(download): include actual host architectures in binary download list

### DIFF
--- a/builtin/core/roles/download/tasks/main.yaml
+++ b/builtin/core/roles/download/tasks/main.yaml
@@ -11,6 +11,19 @@
   when: printf "%s/manifests.yaml" .binary_dir | fileExists
   include_vars: "{{ .binary_dir }}/manifests.yaml"
 
+- name: Artifact | Include actual host architectures in the download list
+  tags: ["always"]
+  set_fact:
+    download:
+      arch: >-
+        {{- $archs := .download.arch -}}
+        {{- range $.hostvars }}
+          {{- if .binary_type }}
+            {{- $archs = append $archs .binary_type }}
+          {{- end }}
+        {{- end }}
+        {{- $archs | uniq | toJson }}
+
 - name: Artifact | Download required binaries and images
   when: .download.fetch
   block:

--- a/pkg/modules/set_fact/set_fact_test.go
+++ b/pkg/modules/set_fact/set_fact_test.go
@@ -260,3 +260,54 @@ func TestSetFactModule(t *testing.T) {
 		})
 	}
 }
+
+// TestSetFactDownloadArchFromHostvars reproduces the download role's
+// "Include actual host architectures in the download list" task: download.arch
+// defaults to ["amd64"], so on an arm64-only cluster the required binaries are
+// never fetched unless the actual host architectures (gathered via .hostvars)
+// are folded in.
+func TestSetFactDownloadArchFromHostvars(t *testing.T) {
+	ctx := context.Background()
+	hosts := []string{"localhost", "node-amd64", "node-arm64"}
+	testVar := NewTestVariable(hosts, map[string]any{
+		"download": map[string]any{"arch": []any{"amd64"}},
+	})
+
+	for host, arch := range map[string]string{"node-amd64": "amd64", "node-arm64": "arm64"} {
+		_, _, err := ModuleSetFact(ctx, internal.ExecOptions{
+			Host:     host,
+			Variable: testVar,
+			Args:     createRawArgs(map[string]any{"binary_type": arch}),
+		})
+		require.NoError(t, err)
+	}
+
+	args := createRawArgs(map[string]any{
+		"download": map[string]any{
+			"arch": "{{- $archs := .download.arch -}}\n" +
+				"{{- range $.hostvars }}\n" +
+				"  {{- if .binary_type }}\n" +
+				"    {{- $archs = append $archs .binary_type }}\n" +
+				"  {{- end }}\n" +
+				"{{- end }}\n" +
+				"{{- $archs | uniq | toJson }}",
+		},
+	})
+
+	stdout, stderr, err := ModuleSetFact(ctx, internal.ExecOptions{
+		Host:     "localhost",
+		Variable: testVar,
+		Args:     args,
+	})
+	require.NoError(t, err)
+	require.Equal(t, internal.StdoutSuccess, stdout)
+	require.Empty(t, stderr)
+
+	result, err := testVar.Get(variable.GetAllVariable("localhost"))
+	require.NoError(t, err)
+	hostVars, ok := result.(map[string]any)
+	require.True(t, ok)
+	download, ok := hostVars["download"].(map[string]any)
+	require.True(t, ok)
+	require.ElementsMatch(t, []any{"amd64", "arm64"}, download["arch"])
+}


### PR DESCRIPTION
Now I'll produce the filled template.

### What type of PR is this?

/kind bug

## What does this PR do

Fix the download role to include each host's actual architecture in the binary download list, instead of always downloading only `amd64` binaries.

### Background / Motivation

On a cluster with arm64 hosts, KubeKey can end up fetching only amd64 binaries for kubeadm/kubelet/kubectl/etcd/CNI/CRI/etc., because the default `download.arch` list (`builtin/core/roles/defaults/defaults/main/10-download.yaml`) is hardcoded to `["amd64"]`. Each host's real CPU architecture is already auto-detected via SSH and normalized into a per-host `binary_type` fact (`builtin/core/roles/defaults/tasks/main.yaml`), and later per-host install tasks correctly select the binary for that host's `binary_type` — but the download role that populates the local binary cache never looks at those facts. Unless a user manually overrides `download.arch`, an arm64 node's required binaries are simply never downloaded and the later copy step fails with a missing file. This is the current-code counterpart of the "kubekey pulls x86 packages on arm64" symptom described in the linked report.

### Implementation

Added a task to the download role that unions `download.arch` with the `binary_type` of every host already known via `.hostvars` (populated by the defaults role, which always runs on all hosts before download runs on localhost in every playbook that uses it), deduplicating with sprig's `uniq`. This is additive only — it never removes the configured default, so existing amd64-only clusters are unaffected and mixed-architecture clusters now get every architecture they actually need.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/download/tasks/main.yaml` | Added a `set_fact` task that appends each host's `binary_type` (from `.hostvars`) into `download.arch` and deduplicates with `uniq`, before the download/fetch block runs |
| `pkg/modules/set_fact/set_fact_test.go` | Added `TestSetFactDownloadArchFromHostvars`, which runs the exact template above through the real `set_fact` module with a 3-host in-memory variable store (localhost + one amd64 node + one arm64 node) |

## Impact

- **Affected modules**: `builtin/core/roles/download` (Ansible-style playbook role), `pkg/modules/set_fact` (test coverage only)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: `download.arch` is now computed at runtime as the union of its configured default and all hosts' `binary_type` values, rather than staying fixed at the user-supplied/default value; no new config keys and no change to defaults
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

Fixes https://github.com/kubesphere/kubekey/issues/2361

## Testing

### Verification performed

- [x] Unit tests pass (`go test ./pkg/modules/... ./pkg/variable/...`)
- [ ] Integration / E2E tests pass (`<command>`)
- [ ] Manual verification

### Steps to verify

1. Run `go build ./...` to confirm the build is clean.
2. Run `go test ./pkg/modules/... ./pkg/variable/...`, including the new `TestSetFactDownloadArchFromHostvars` case.
3. Expected result: with the fix applied, `download.arch` for a cluster with an arm64 host resolves to `["amd64", "arm64"]` (order aside); reverting the template to drop the hostvars aggregation makes the same test fail with `download.arch` staying `["amd64"]`.

### Test coverage

Added `pkg/modules/set_fact/set_fact_test.go: TestSetFactDownloadArchFromHostvars`, which exercises the exact template added to the download role through the real `set_fact` module and a 3-host in-memory variable store (localhost + one amd64 node + one arm64 node). No live `kk create cluster` run against real arm64 hardware/VMs was performed — no such environment was available; the fix is validated at the template/variable-merge level the download role relies on, not via a live end-to-end install.

## Rollback

Plain revert of this commit; no data or config migration is involved. Reverting restores the prior hardcoded-default behavior (`download.arch` stays `["amd64"]` unless manually overridden).

### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where KubeKey would only download amd64 binaries (kubeadm, kubelet, kubectl, etcd, CNI, CRI, etc.) even when the cluster included arm64 hosts, causing the copy step to fail with a missing file. The download role now includes every host's actual detected architecture in the download list in addition to the configured default.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [ ] All commits are GPG-signed (GitHub shows Verified)
- [x] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

Please double check the Go template logic in `builtin/core/roles/download/tasks/main.yaml` (range over `.hostvars`, `append`, `uniq`, `toJson`) — this mirrors the pattern validated in `TestSetFactDownloadArchFromHostvars`, but I'd like a second look at whether `.hostvars` is guaranteed populated for every playbook that invokes the download role (not just the ones I traced), since that's the key assumption this fix depends on. No live arm64 hardware/VM test was run; only the template/variable-merge logic was validated via unit test.

---
AI assistance: this change was drafted with Claude Code.

Fixes #2361