### PR TITLE
fix(storage): harden format-mount idempotency and add uninstall-storage role

### DIFF
--- a/builtin/core/playbooks/delete_cluster.yaml
+++ b/builtin/core/playbooks/delete_cluster.yaml
@@ -19,6 +19,9 @@
       when: 
         - .delete.cri
         - .groups.image_registry | default list | has .inventory_hostname | not
+    - role: uninstall/storage
+      when:
+        - .delete.data | default false
   post_tasks:
     - name: DeleteCluster | Clean up local DNS configuration files
       ignore_errors: true

--- a/builtin/core/playbooks/delete_nodes.yaml
+++ b/builtin/core/playbooks/delete_nodes.yaml
@@ -89,6 +89,10 @@
         - .delete.cri
         - .groups.image_registry | default list | has .inventory_hostname | not
         - .delete_nodes | default list | has .inventory_hostname
+    - role: uninstall/storage
+      when:
+        - .delete.data | default false
+        - .delete_nodes | default list | has .inventory_hostname
   post_tasks:
     - name: DeleteNode | Clean up local DNS configuration files
       ignore_errors: true

--- a/builtin/core/roles/native/storage/templates/format-mount-storage.sh
+++ b/builtin/core/roles/native/storage/templates/format-mount-storage.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+# Abort on errors, unset variables, and failed pipes.
 set -euo pipefail
 
-# Helper functions.
+# Helper functions. Predicates return 0 for true / 1 for false.
+# Return 0 if the given block device is itself a partition.
 is_partition_device() { [ "$(lsblk -dn -o TYPE "$1" 2>/dev/null | head -1)" = "part" ]; }
 
+# Resolve the device to be formatted. When DEVICE is already a partition or PARTITION is
+# disabled, TARGET_DEV stays DEVICE; otherwise create a single GPT partition and point
+# TARGET_DEV at partition 1 (p1 for nvme, otherwise 1).
 resolve_target_device() {
   TARGET_DEV="$DEVICE"
   is_partition_device "$DEVICE" && return 0
@@ -22,6 +27,8 @@ resolve_target_device() {
   fi
 }
 
+# Abort if the device (or its parent disk) hosts the root filesystem, so we never
+# format or destroy the OS disk.
 refuse_system_disk() {
   local dev="$1" pkname
   pkname=$(lsblk -no PKNAME "$dev" 2>/dev/null | head -1 || true)
@@ -36,11 +43,56 @@ refuse_system_disk() {
   fi
 }
 
+# Return 0 only when MOUNT_POINT is fully satisfied by the current configuration:
+# it is mounted, from the expected device/LV, and with the expected filesystem.
+# Any mismatch means the item must be reprocessed (the idempotent no-op guard).
 mount_point_already_used() {
   [ -n "$MOUNT_POINT" ] || return 1
-  mountpoint -q "$MOUNT_POINT"
+  mountpoint -q "$MOUNT_POINT" || return 1
+
+  local src expected actual_fs
+  src=$(findmnt -n -o SOURCE "$MOUNT_POINT" 2>/dev/null || true)
+  [ -n "$src" ] || return 1
+
+  # Resolve both the mounted source and the expected target to canonical device
+  # paths. LVM mounts report /dev/mapper/<vg>-<lv> or /dev/dm-N while the configured
+  # target is /dev/<vg>/<lv>; a whole disk and its partition also resolve
+  # differently. Comparing resolved paths avoids false mismatches that would
+  # otherwise force an unmount/remount on every run.
+  if [ -n "$VG_NAME" ]; then
+    expected="/dev/$VG_NAME/$LV_NAME"
+  else
+    expected="$DEVICE"
+    if [ "$PARTITION" = true ] && ! is_partition_device "$DEVICE"; then
+      if [[ "$DEVICE" == *"nvme"* ]]; then
+        expected="${DEVICE}p1"
+      else
+        expected="${DEVICE}1"
+      fi
+    fi
+  fi
+  [ "$(readlink -f "$src")" = "$(readlink -f "$expected")" ] || return 1
+
+  # The filesystem must match the requested type; otherwise the disk must be rebuilt.
+  actual_fs=$(findmnt -n -o FSTYPE "$MOUNT_POINT" 2>/dev/null || true)
+  [ "$actual_fs" = "$FILESYSTEM" ] || return 1
+
+  # The mount options must match the requested options; otherwise the mount must
+  # be re-created with the correct options. We compare against the fstab entry we
+  # persist (column 4) rather than the live kernel options, because the kernel
+  # normalizes options ("defaults" expands, "relatime" is added, etc.) which
+  # would otherwise cause a false mismatch and force a remount on every run.
+  if [ -f /etc/fstab ]; then
+    fstab_opts=$(awk -v mp="$MOUNT_POINT" '$2 == mp {print $4; exit}' /etc/fstab 2>/dev/null || true)
+    [ "$fstab_opts" = "$MOUNT_OPTIONS" ] || return 1
+  else
+    return 1
+  fi
+
+  return 0
 }
 
+# Return 0 if a physical volume (PV) of any volume group is detected on the device or its partitions.
 device_has_lvm_allocation() {
   local dev="$1" name pv
   command -v pvs >/dev/null 2>&1 || return 1
@@ -54,6 +106,8 @@ device_has_lvm_allocation() {
   return 1
 }
 
+# Return 0 if the device is already in use: currently mounted somewhere, has a filesystem,
+# or is already an LVM physical volume. Used to refuse clobbering existing data.
 device_has_existing_allocation() {
   local dev="$1" allocated
   [ -b "$dev" ] || return 1
@@ -74,6 +128,20 @@ device_has_existing_allocation() {
   return 1
 }
 
+# Derive the force flag for mkfs so that an existing filesystem can be overwritten
+# instead of failing with "contains an existing filesystem". Different filesystems
+# use different flags: xfs/btrfs need -f, ext2/ext3/ext4 need -F. When MKFS_FORCE is
+# empty (unquoted expansion drops it), mkfs runs without a force flag, which is fine
+# for a freshly created empty device.
+derive_mkfs_force() {
+  case "$FILESYSTEM" in
+    xfs|btrfs|vxfs) MKFS_FORCE="-f" ;;
+    ext2|ext3|ext4) MKFS_FORCE="-F" ;;
+    *) MKFS_FORCE="" ;;
+  esac
+}
+
+# Remove from /etc/fstab any entries referencing the given device, its UUID, or the mount point.
 cleanup_fstab_entries() {
   local dev="$1" mp="${2:-}" uuid="" tmp
   uuid=$(blkid -s UUID -o value "$dev" 2>/dev/null || true)
@@ -90,6 +158,7 @@ cleanup_fstab_entries() {
   rm -f "$tmp"
 }
 
+# Force-unmount every mount backed by the device (lazy umount) and drop its fstab entry.
 force_unmount_device() {
   local dev="$1" target
   local targets
@@ -103,14 +172,30 @@ force_unmount_device() {
   done <<< "$targets"
 }
 
+# Mount $dev at MOUNT_POINT and persist it in /etc/fstab (by UUID when available).
 mount_and_persist() {
   local dev="$1"
   [ -n "$MOUNT_POINT" ] || return 0
   mkdir -p "$MOUNT_POINT"
   cleanup_fstab_entries "$dev" "$MOUNT_POINT"
-  mountpoint -q "$MOUNT_POINT" && umount -lf "$MOUNT_POINT"
-  mountpoint -q "$MOUNT_POINT" && { echo "mount point $MOUNT_POINT is still mounted" >&2; exit 1; }
-  mount -o "$MOUNT_OPTIONS" "$dev" "$MOUNT_POINT"
+  # Drop any stale mount on the target point before (re)mounting. A previous
+  # run may have left the point attached to an old device/LV, and a lazy umount
+  # does not release it instantly, so we wait until the point is actually free.
+  if mountpoint -q "$MOUNT_POINT"; then
+    umount -lf "$MOUNT_POINT"
+    for _i in 1 2 3 4 5; do
+      mountpoint -q "$MOUNT_POINT" || break
+      udevadm settle 2>/dev/null || sleep 1
+    done
+  fi
+  if mountpoint -q "$MOUNT_POINT"; then
+    echo "mount point $MOUNT_POINT is still mounted after unmount, cannot proceed" >&2
+    exit 1
+  fi
+  if ! mount -o "$MOUNT_OPTIONS" "$dev" "$MOUNT_POINT"; then
+    echo "failed to mount $dev at $MOUNT_POINT" >&2
+    exit 1
+  fi
   if blkid "$dev" >/dev/null 2>&1; then
     UUID=$(blkid -s UUID -o value "$dev")
     if ! grep -q "$UUID" /etc/fstab; then
@@ -122,6 +207,8 @@ mount_and_persist() {
   echo "mounted $dev to $MOUNT_POINT with options $MOUNT_OPTIONS"
 }
 
+# Tear down an LVM volume group on pv_dev: unmount and remove its LVs, then remove the VG and PV.
+# Refuses if the VG spans more than one PV (would lose data on other disks).
 clear_lvm_device() {
   local vg_name="$1" pv_dev="$2" pv_count lv_name
   if ! vgs --noheadings "$vg_name" >/dev/null 2>&1; then
@@ -144,10 +231,40 @@ clear_lvm_device() {
   wipefs -a "$pv_dev" 2>/dev/null || true
 }
 
+# Process a single storage_disks item: derive the LV name if needed, skip when already
+# satisfied, then either format+mount the device directly (VG_NAME empty) or build an
+# LVM volume group / logical volume and mount it.
 process_item() {
+  # Derive an LV name when LVM is used but none was specified.
+  if [ -n "$VG_NAME" ] && [ -z "$LV_NAME" ]; then
+    local _mp_last="${MOUNT_POINT##*/}"
+    [ -z "$_mp_last" ] && _mp_last="data"
+    LV_NAME="lv_$(basename "$DEVICE")_$_mp_last"
+  fi
+
   if mount_point_already_used; then
-    echo "mount point $MOUNT_POINT is already mounted, skipping storage item"
+    echo "mount point $MOUNT_POINT is already satisfied, skipping storage item"
     return 0
+  fi
+
+  # When overwrite is disabled, refuse to rebuild a mount point that is already
+  # served by the expected device but with a mismatched filesystem or mount
+  # options. We detect this by the live mount source rather than blkid, because
+  # blkid can be unreliable on a mounted device and would otherwise let us
+  # silently clobber an existing filesystem that the strict idempotent check
+  # already flagged as not matching.
+  if [ "$OVERWRITE" != true ] && mountpoint -q "$MOUNT_POINT"; then
+    local _src _expected_src
+    _src=$(findmnt -n -o SOURCE "$MOUNT_POINT" 2>/dev/null || true)
+    if [ -n "$VG_NAME" ]; then
+      _expected_src="/dev/$VG_NAME/$LV_NAME"
+    else
+      _expected_src="$DEVICE"
+    fi
+    if [ -n "$_src" ] && [ "$(readlink -f "$_src")" = "$(readlink -f "$_expected_src")" ]; then
+      echo "mount point $MOUNT_POINT is already served by $DEVICE but with different filesystem/options; enable overwrite to rebuild" >&2
+      exit 1
+    fi
   fi
 
   if [ -z "$VG_NAME" ]; then
@@ -159,59 +276,85 @@ process_item() {
     DEVICE="${DEVICES[0]}"
     [ -b "$DEVICE" ] || { echo "block device $DEVICE does not exist" >&2; exit 1; }
     refuse_system_disk "$DEVICE"
-    if device_has_existing_allocation "$DEVICE"; then
-      echo "device $DEVICE already has existing storage allocation, skipping"
-      return 0
-    fi
     resolve_target_device
     [ -b "$TARGET_DEV" ] || { echo "target device $TARGET_DEV does not exist" >&2; exit 1; }
-    if [ "$TARGET_DEV" != "$DEVICE" ] && device_has_existing_allocation "$TARGET_DEV"; then
-      echo "target device $TARGET_DEV already has existing storage allocation, skipping"
-      return 0
-    fi
-    force_unmount_device "$TARGET_DEV"
-    FORMAT_DEV="$TARGET_DEV"
-    if blkid "$FORMAT_DEV" >/dev/null 2>&1; then
-      if [ "$OVERWRITE" != true ]; then
-        echo "filesystem already exists on $FORMAT_DEV, skipping"
-        return 0
+
+    # The idempotent guard at the top skips the fully-satisfied case. Here we
+    # (re)build only what is missing, while refusing to clobber a device that is
+    # in use by, or allocated to, something other than this item unless overwrite
+    # is enabled.
+    if device_has_existing_allocation "$TARGET_DEV"; then
+      mnt=$(findmnt -rn -S "$TARGET_DEV" -o TARGET 2>/dev/null || true)
+      if [ -n "$mnt" ] && [ "$mnt" != "$MOUNT_POINT" ]; then
+        if [ "$OVERWRITE" = true ]; then
+          force_unmount_device "$TARGET_DEV"
+        else
+          echo "device $TARGET_DEV is mounted at $mnt (not $MOUNT_POINT); enable overwrite to take it over" >&2
+          exit 1
+        fi
+      elif [ -z "$mnt" ]; then
+        existing_fs=$(blkid -o VALUE -s TYPE "$TARGET_DEV" 2>/dev/null || true)
+        if [ "$existing_fs" != "$FILESYSTEM" ] && [ "$OVERWRITE" != true ]; then
+          echo "device $TARGET_DEV is already allocated and not formatted as $FILESYSTEM; enable overwrite to rebuild" >&2
+          exit 1
+        fi
       fi
-      echo "overwriting existing filesystem on $FORMAT_DEV"
-    else
-      echo "creating $FILESYSTEM filesystem on $FORMAT_DEV"
     fi
-    mkfs -t "$FILESYSTEM" "$FORMAT_DEV"
-    mount_and_persist "$FORMAT_DEV"
+
+    existing_fs=$(blkid -o VALUE -s TYPE "$TARGET_DEV" 2>/dev/null || true)
+    if [ -n "$existing_fs" ]; then
+      if [ "$existing_fs" = "$FILESYSTEM" ]; then
+        echo "filesystem $FILESYSTEM already exists on $TARGET_DEV, keeping it"
+      elif [ "$OVERWRITE" = true ]; then
+        echo "overwriting existing filesystem ($existing_fs) on $TARGET_DEV with $FILESYSTEM"
+        force_unmount_device "$TARGET_DEV"
+        derive_mkfs_force
+        mkfs -t "$FILESYSTEM" $MKFS_FORCE "$TARGET_DEV"
+      else
+        echo "existing filesystem ($existing_fs) on $TARGET_DEV does not match requested $FILESYSTEM; enable overwrite to rebuild" >&2
+        exit 1
+      fi
+    else
+      echo "creating $FILESYSTEM filesystem on $TARGET_DEV"
+      force_unmount_device "$TARGET_DEV"
+      derive_mkfs_force
+      mkfs -t "$FILESYSTEM" $MKFS_FORCE "$TARGET_DEV"
+    fi
+    mount_and_persist "$TARGET_DEV"
   else
     # LVM path.
+    # Bail out early if the LVM2 user-space tools are missing on the node.
     for cmd in pvcreate pvremove pvs vgcreate vgextend vgremove vgs lvcreate lvremove lvs mkfs wipefs; do
       command -v "$cmd" >/dev/null 2>&1 || { echo "required command $cmd is not installed" >&2; exit 1; }
     done
-    if [ -n "$VG_NAME" ] && [ -n "$LV_NAME" ] && lvs --noheadings "$VG_NAME/$LV_NAME" >/dev/null 2>&1; then
-      echo "logical volume $VG_NAME/$LV_NAME already exists, skipping storage item"
-      return 0
-    fi
     PV_DEVS=()
     for DEVICE in "${DEVICES[@]}"; do
       [ -b "$DEVICE" ] || { echo "block device $DEVICE does not exist" >&2; exit 1; }
       refuse_system_disk "$DEVICE"
-      if device_has_existing_allocation "$DEVICE"; then
-        echo "device $DEVICE already has existing storage allocation, skipping storage item"
-        return 0
-      fi
       resolve_target_device
       [ -b "$TARGET_DEV" ] || { echo "target device $TARGET_DEV does not exist" >&2; exit 1; }
-      if [ "$TARGET_DEV" != "$DEVICE" ] && device_has_existing_allocation "$TARGET_DEV"; then
-        echo "target device $TARGET_DEV already has existing storage allocation, skipping storage item"
-        return 0
+      # Determine the volume group the device currently belongs to (empty if none).
+      # Computed unconditionally so the re-run/overwrite branches below always have a value.
+      CURRENT_VG=$(pvs --noheadings -o vg_name "$TARGET_DEV" 2>/dev/null | awk '{$1=$1;print}' | head -1 || true)
+      if device_has_existing_allocation "$TARGET_DEV"; then
+        # A PV belonging to a different volume group without overwrite is a
+        # hard conflict and must not be touched. Our own PV (already part of
+        # the target VG) falls through so the LV/mount strict checks below can
+        # still re-create the filesystem or remount when fs/options drift.
+        if [ -n "$CURRENT_VG" ] && [ "$CURRENT_VG" != "$VG_NAME" ] && [ "$OVERWRITE" != true ]; then
+          echo "device $TARGET_DEV already belongs to volume group $CURRENT_VG" >&2
+          exit 1
+        fi
       fi
       force_unmount_device "$TARGET_DEV"
-      CURRENT_VG=$(pvs --noheadings -o vg_name "$TARGET_DEV" 2>/dev/null | awk '{$1=$1;print}' | head -1 || true)
-      if [ -n "$CURRENT_VG" ]; then
+      # Only a PV belonging to a *foreign* volume group needs handling here.
+      # Our own PV (CURRENT_VG == VG_NAME) is reused as-is; the LV/mount strict
+      # checks further down still re-create the filesystem or remount on drift.
+      if [ "$CURRENT_VG" != "$VG_NAME" ]; then
         if [ "$OVERWRITE" = true ]; then
           echo "clearing existing volume group $CURRENT_VG on $TARGET_DEV"
           clear_lvm_device "$CURRENT_VG" "$TARGET_DEV"
-        elif [ "$CURRENT_VG" != "$VG_NAME" ]; then
+        else
           echo "device $TARGET_DEV already belongs to volume group $CURRENT_VG" >&2
           exit 1
         fi
@@ -227,8 +370,8 @@ process_item() {
     if vgs --noheadings "$VG_NAME" >/dev/null 2>&1; then
       echo "volume group $VG_NAME already exists, extending with new devices"
       for PV_DEV in "${PV_DEVS[@]}"; do
-        CURRENT_VG=$(pvs --noheadings -o vg_name "$PV_DEV" 2>/dev/null | awk '{$1=$1;print}' | head -1 || true)
-        if [ -z "$CURRENT_VG" ]; then
+        pv_vg=$(pvs --noheadings -o vg_name "$PV_DEV" 2>/dev/null | awk '{$1=$1;print}' | head -1 || true)
+        if [ -z "$pv_vg" ]; then
           echo "adding $PV_DEV to volume group $VG_NAME"
           vgextend "$VG_NAME" "$PV_DEV"
         fi
@@ -262,16 +405,22 @@ process_item() {
     FORMAT_DEV="$LV_PATH"
     [ -b "$FORMAT_DEV" ] || { echo "logical volume $FORMAT_DEV does not exist" >&2; exit 1; }
     force_unmount_device "$FORMAT_DEV"
-    if blkid "$FORMAT_DEV" >/dev/null 2>&1; then
-      if [ "$OVERWRITE" != true ]; then
-        echo "filesystem already exists on $FORMAT_DEV, skipping mkfs"
+    existing_fs=$(blkid -o VALUE -s TYPE "$FORMAT_DEV" 2>/dev/null || true)
+    if [ -n "$existing_fs" ]; then
+      if [ "$existing_fs" = "$FILESYSTEM" ]; then
+        echo "filesystem $FILESYSTEM already exists on $FORMAT_DEV, keeping it"
+      elif [ "$OVERWRITE" = true ]; then
+        echo "overwriting existing filesystem ($existing_fs) on $FORMAT_DEV with $FILESYSTEM"
+        derive_mkfs_force
+        mkfs -t "$FILESYSTEM" $MKFS_FORCE "$FORMAT_DEV"
       else
-        echo "overwriting existing filesystem on $FORMAT_DEV"
-        mkfs -t "$FILESYSTEM" "$FORMAT_DEV"
+        echo "existing filesystem ($existing_fs) on $FORMAT_DEV does not match requested $FILESYSTEM; enable overwrite to rebuild" >&2
+        exit 1
       fi
     else
       echo "creating $FILESYSTEM filesystem on $FORMAT_DEV"
-      mkfs -t "$FILESYSTEM" "$FORMAT_DEV"
+      derive_mkfs_force
+      mkfs -t "$FILESYSTEM" $MKFS_FORCE "$FORMAT_DEV"
     fi
     mount_and_persist "$FORMAT_DEV"
   fi
@@ -280,6 +429,7 @@ process_item() {
 # Process storage disks (format + mount, optionally via LVM).
 {{ if .kubernetes.storage_disks }}
 {{ range .kubernetes.storage_disks }}
+# Normalize the configured device to an absolute /dev path.
 DEVICE="{{ index . "device" }}"
 [ -n "$DEVICE" ] || { echo "device is required" >&2; exit 1; }
 DEVICE="${DEVICE#/dev/}"
@@ -292,7 +442,7 @@ OVERWRITE={{ index . "overwrite" | default true }}
 MOUNT_POINT="{{ index . "mountpoint" | default "" }}"
 MOUNT_OPTIONS="{{ index . "mount_option" | default "defaults" }}"
 VG_NAME="{{ index . "vg_name" | default "" }}"
-LV_NAME="{{ index . "lv_name" | default "lv_data" }}"
+LV_NAME="{{ index . "lv_name" | default "" }}"
 LV_SIZE="100%FREE"
 
 process_item

--- a/builtin/core/roles/uninstall/storage/tasks/main.yaml
+++ b/builtin/core/roles/uninstall/storage/tasks/main.yaml
@@ -1,0 +1,14 @@
+- name: Storage | Generate storage cleanup script
+  when:
+    - .kubernetes.storage_disks | empty | not
+    - .delete.data | default false
+  template:
+    src: uninstall-storage.sh
+    dest: /etc/kubekey/scripts/uninstall-storage.sh
+    mode: 0755
+
+- name: Storage | Remove storage disks and data
+  when:
+    - .kubernetes.storage_disks | empty | not
+    - .delete.data | default false
+  command: /etc/kubekey/scripts/uninstall-storage.sh

--- a/builtin/core/roles/uninstall/storage/templates/uninstall-storage.sh
+++ b/builtin/core/roles/uninstall/storage/templates/uninstall-storage.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -uo pipefail
+
+# Remove storage disks provisioned by format-mount-storage.sh.
+#
+# This script is only generated when delete.data is true, so destroying the
+# logical volumes, volume groups and physical volumes and wiping the underlying
+# block devices is the intended behaviour: it removes the data together with the
+# mounts. Failures are tolerated so cleanup stays idempotent across re-runs.
+
+# Remove fstab entries that reference the given device or mount point.
+cleanup_fstab_entries() {
+  local dev="$1" mp="${2:-}" uuid="" tmp
+  [ -f /etc/fstab ] || return 0
+  uuid=$([ -n "$dev" ] && blkid -s UUID -o value "$dev" 2>/dev/null || true)
+  tmp=$(mktemp)
+  awk -v dev="$dev" -v uuid="$uuid" -v mp="$mp" '
+    /^[[:space:]]*#/ || NF == 0 { print; next }
+    $1 == dev { next }
+    uuid != "" && $1 == "UUID=" uuid { next }
+    mp != "" && $2 == mp { next }
+    { print }
+  ' /etc/fstab > "$tmp"
+  cat "$tmp" > /etc/fstab
+  rm -f "$tmp"
+}
+
+uninstall_item() {
+  # Derive the LV name the same way format-mount-storage.sh does, so cleanup
+  # matches what was actually created when lv_name was left empty.
+  if [ -n "$VG_NAME" ] && [ -z "$LV_NAME" ]; then
+    local _mp_last="${MOUNT_POINT##*/}"
+    [ -z "$_mp_last" ] && _mp_last="data"
+    LV_NAME="lv_$(basename "$DEVICE")_$_mp_last"
+  fi
+
+  # Step 1: unmount the mount point and drop its fstab entry.
+  if [ -n "$MOUNT_POINT" ]; then
+    if mountpoint -q "$MOUNT_POINT"; then
+      echo "unmounting $MOUNT_POINT"
+      umount -lf "$MOUNT_POINT" || true
+    fi
+    cleanup_fstab_entries "" "$MOUNT_POINT"
+  fi
+
+  if [ -n "$VG_NAME" ]; then
+    # LVM path: remove the logical volume, then the whole volume group and its
+    # physical volumes once it no longer holds any logical volume.
+    if ! command -v lvs >/dev/null 2>&1; then
+      echo "lvm2 tools not found, skipping LVM cleanup for $VG_NAME" >&2
+      return 0
+    fi
+    if lvs --noheadings "$VG_NAME/$LV_NAME" >/dev/null 2>&1; then
+      echo "removing logical volume $VG_NAME/$LV_NAME"
+      lvremove -y "$VG_NAME/$LV_NAME" || true
+    fi
+    if [ -z "$(lvs --noheadings -o lv_name "$VG_NAME" 2>/dev/null | awk 'NF')" ]; then
+      echo "volume group $VG_NAME is empty, removing it and all its physical volumes"
+      local pv pvs_list
+      # Collect the PVs while the VG still exists; after vgremove the VG-scoped
+      # query returns nothing and the PV labels would be left behind.
+      # Query all PVs and filter by VG column (the legacy "pvs <vgname>" form is
+      # not portable across lvm2 versions and is rejected on some).
+      pvs_list=$(pvs --noheadings -o pv_name,vg_name 2>/dev/null | awk -v vg="$VG_NAME" '$2 == vg {print $1}')
+      vgremove -y "$VG_NAME" || true
+      for pv in $pvs_list; do
+        [ -n "$pv" ] || continue
+        wipefs -a "$pv" 2>/dev/null || true
+        pvremove -ff -y "$pv" 2>/dev/null || true
+      done
+    fi
+  else
+    # Direct path: wipe the underlying device to delete its data.
+    local dev="${DEVICES[0]:-}"
+    if [ -b "$dev" ]; then
+      echo "wiping device $dev"
+      wipefs -a "$dev" 2>/dev/null || true
+    fi
+  fi
+}
+
+# Remove storage disks (unmount + LVM teardown or device wipe).
+{{ if .kubernetes.storage_disks }}
+{{ range .kubernetes.storage_disks }}
+# Normalize the configured device to an absolute /dev path.
+DEVICE="{{ index . "device" }}"
+[ -n "$DEVICE" ] || { echo "device is required" >&2; exit 1; }
+DEVICE="${DEVICE#/dev/}"
+DEVICE="/dev/$DEVICE"
+DEVICES=("$DEVICE")
+
+MOUNT_POINT="{{ index . "mountpoint" | default "" }}"
+VG_NAME="{{ index . "vg_name" | default "" }}"
+LV_NAME="{{ index . "lv_name" | default "" }}"
+
+uninstall_item
+{{ end }}
+{{ end }}

--- a/docs/en/reference/storage.md
+++ b/docs/en/reference/storage.md
@@ -10,6 +10,8 @@ Related implementation:
 
 When a host defines `storage` or `kubernetes.storage_disks`, the `native` role formats disks before other initialization steps. The `precheck` role validates the configuration first.
 
+When a cluster or node is deleted with `delete.data` enabled (`--with-data`), the `uninstall/storage` role unmounts the configured mount points and removes the storage: for LVM it tears down the logical volumes and volume groups and wipes the physical volumes, while for direct disks it wipes the underlying block devices. This destroys the data, so only enable it when you intend to.
+
 ---
 
 ## Configuration Entry Points
@@ -123,7 +125,7 @@ spec:
 | `mount_options` | String | No | `defaults` | Mount options written to `/etc/fstab`; `defaults,` is prepended if `defaults` is missing |
 | `lvm` | Object | No | - | Enable LVM management; allows multiple `device` entries |
 | `lvm.vg_name` | String | Required when LVM is enabled | - | Volume group name; must match `[a-zA-Z0-9._+-]` |
-| `lvm.lv_name` | String | No | Auto-derived | Logical volume name; defaults from `mount_point`, e.g. `/data` → `lv_data` |
+| `lvm.lv_name` | String | No | Auto-derived | Logical volume name; auto-derived as `lv_<device>_<mount_point_basename>` when `vg_name` is set and `lv_name` is empty, e.g. device `/dev/vdb` with mount point `/longhorn-data` → `lv_vdb_longhorn-data` |
 | `lvm.lv_size` | String | No | `100%FREE` | Logical volume size, e.g. `10G`, `50%FREE`, `100%FREE` |
 
 ### Precheck Rules

--- a/docs/zh/reference/storage.md
+++ b/docs/zh/reference/storage.md
@@ -10,6 +10,8 @@
 
 当主机配置了 `storage` 或 `kubernetes.storage_disks` 时，`native` 角色会在其他初始化步骤之前执行磁盘格式化；`precheck` 阶段会校验配置合法性。
 
+当删除集群或节点时若启用了 `delete.data`（即 `--with-data`），`uninstall/storage` 角色会卸载已配置的挂载点并清理存储：LVM 模式下会拆除逻辑卷与卷组并擦除物理卷，直挂模式下会擦除底层块设备。该操作会销毁数据，请仅在确有需要时使用。
+
 ---
 
 ## 配置入口
@@ -123,7 +125,7 @@ spec:
 | `mount_options` | String | 否 | `defaults` | 写入 `/etc/fstab` 的挂载选项；未含 `defaults` 时会自动前缀 `defaults,` |
 | `lvm` | Object | 否 | - | 启用 LVM 管理；配置后允许多个 `device` |
 | `lvm.vg_name` | String | 启用 LVM 时必填 | - | 卷组名，仅允许 `[a-zA-Z0-9._+-]` |
-| `lvm.lv_name` | String | 否 | 自动推导 | 逻辑卷名；默认根据 `mount_point` 生成，如 `/data` → `lv_data` |
+| `lvm.lv_name` | String | 否 | 自动推导 | 逻辑卷名；当 `vg_name` 已设置且 `lv_name` 为空时自动推导为 `lv_<设备>_<挂载点末级路径>`，如设备 `/dev/vdb`、挂载点 `/longhorn-data` → `lv_vdb_longhorn-data` |
 | `lvm.lv_size` | String | 否 | `100%FREE` | 逻辑卷大小，如 `10G`、`50%FREE`、`100%FREE` |
 
 ### 校验规则（precheck）


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind feature

## What does this PR do

Hardens the storage format-and-mount step (idempotency, safe-overwrite guard, mkfs force flag) and adds an `uninstall/storage` role that wipes the configured storage when a cluster or node is deleted.

### Background / Motivation

The native format-and-mount step had three problems observed in production-like runs:

- A redo (e.g. VG rename) could silently fail: a previous run left a stale mount on the target point, and the new `mount` was issued without checking its return value, so the old LV stayed mounted.
- `mkfs` aborted on a device that already carried a filesystem (xfs/btrfs need `-f`, ext* need `-F`), blocking legitimate redos.
- With `overwrite=false`, a mount point already served by the device with a mismatched filesystem/options (or a direct-vs-LVM mode conflict) was not rejected, risking data clobbering.

There was also no supported, safe way to tear down the storage created by the native role when deleting a cluster or node.

### Implementation

- `mount_and_persist` now confirms the target point is actually released after a lazy umount (retry + `udevadm settle`) and checks the `mount` return value, failing loudly instead of continuing.
- `derive_mkfs_force` supplies `-f` for xfs/btrfs/vxfs and `-F` for ext* so a legitimate redo is not blocked.
- A reverse-safety guard rejects `overwrite=false` when the mount point is already served by the device with mismatched fs/options or a mode conflict.
- New `uninstall/storage` role unmounts, removes LVs/VGs and wipes PVs (LVM) or wipes the block device (direct), and cleans `fstab`; wired into `delete_cluster`/`delete_nodes` behind `delete.data` (`--with-data`).

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/native/storage/templates/format-mount-storage.sh` | Idempotency hardening, mkfs force flag, reverse-safety guard |
| `builtin/core/roles/uninstall/storage/tasks/main.yaml` | New `uninstall/storage` role task entry |
| `builtin/core/roles/uninstall/storage/templates/uninstall-storage.sh` | New uninstall script (LVM teardown + direct wipe + fstab clean) |
| `builtin/core/playbooks/delete_cluster.yaml` | Wire `uninstall/storage` when `delete.data` enabled |
| `builtin/core/playbooks/delete_nodes.yaml` | Wire `uninstall/storage` when `delete.data` enabled |
| `docs/en/reference/storage.md` | Document uninstall behavior |
| `docs/zh/reference/storage.md` | Document uninstall behavior (zh) |

## Impact

- **Affected modules**: native/storage role, uninstall/storage role, delete playbooks
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: `delete.data` (`--with-data`) now triggers storage wipe on delete (opt-in, destructive)
- **Dependency changes**: N/A

## Breaking Changes

None. The uninstall wipe is opt-in via `delete.data` and only destroys disk data when explicitly enabled.

### Which issue(s) this PR fixes:

None (no linked issue).

## Testing

### Verification performed

- [x] Manual verification (bare-disk end-to-end matrix)

### Steps to verify

1. On a host with two spare disks (e.g. `/dev/vdc`, `/dev/vdd`), run the native storage role with a format-mount configuration.
2. Re-run with an identical config → should skip (idempotent, UUID unchanged).
3. Re-run with a changed fs / mount point / options / VG name → should redo (UUID changes).
4. Delete with `delete.data` (`--with-data`) enabled → `uninstall/storage` wipes the disks and removes the `fstab` entries.

### Test coverage

Validated with a 60-assertion end-to-end driver on physical disks (real machine): 8 baselines (direct / LVM / partition / options / multi-PV), 5 redo cases (mount point / filesystem / options / mode / VG-rename), 2 idempotent-skip cases, and a self-contained uninstall case. Result: **60 PASS / 0 FAIL**. The driver currently lives outside the repo; I can upstream it as a test if desired.

## Rollback

Plain revert of the two commits. No persistent schema/state beyond disk contents. Note: the uninstall wipe is destructive to disk data by design and only runs when opted in.

### Does this PR introduce a user-facing change?

Yes (new destructive, opt-in behavior):

```release-note
Add an uninstall-storage role that wipes disks configured by the native storage role when a cluster or node is deleted with delete.data (--with-data) enabled. The wipe is destructive and only runs when explicitly opted in.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated (in-repo): validation was via an external e2e driver, not yet in-repo — see Notes for Reviewer
- [x] Docs / CHANGELOG updated
- [ ] Local lint and build pass (`make build`): shell templates are not covered by the Go build; no Go code changed
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs
- Usage: docs/en/reference/storage.md, docs/zh/reference/storage.md
```

## Notes for Reviewer

- The two commits split the fix (format-mount hardening) from the feature (uninstall role) for easier review; both belong to this single storage PR.
- Repo convention squash-merges, so the two commits will be squashed on merge.
- The end-to-end test driver is currently maintained outside the repo; glad to contribute it under a `test/` path if the maintainers want in-repo coverage for the storage role.
