### PR TITLE
fix(connector): free sudo's stdin for the password prompt over SSH

### DIFF
--- a/pkg/connector/ssh_connector.go
+++ b/pkg/connector/ssh_connector.go
@@ -298,6 +298,20 @@ func (c *sshConnector) FetchFile(_ context.Context, src string, dst io.Writer) e
 	return nil
 }
 
+// buildSudoCommand wraps cmd so it executes via sudo as the given user/shell.
+//
+// The script is passed to the shell as a "-c" argument built through a quoted
+// command substitution ("$(cat <<'EOF' ... EOF)") rather than piped to sudo's
+// own stdin via a heredoc. sudo reads the interactive password prompt from its
+// stdin when one is required (i.e. NOPASSWD is not configured); piping the
+// script itself into that same stdin means sudo consumes lines of the script
+// as bogus password attempts and the real password, written to the SSH
+// session's stdin by ExecuteCommand, never reaches it. Passing the script via
+// "-c" leaves stdin free for that password write.
+func buildSudoCommand(user, shell, cmd string) string {
+	return fmt.Sprintf("TERM=dumb; export LANG=C.UTF-8; SUDO_USER=%s; sudo -E %s -c \"$(cat << 'KUBEKEY_EOF'\n%s\nKUBEKEY_EOF\n)\"", user, shell, cmd)
+}
+
 // ExecuteCommand exec cmd with sudo
 func (c *sshConnector) ExecuteCommand(_ context.Context, cmd string) ([]byte, []byte, error) {
 	session, err := c.session()
@@ -306,7 +320,7 @@ func (c *sshConnector) ExecuteCommand(_ context.Context, cmd string) ([]byte, []
 	}
 	defer session.Close()
 
-	cmd = fmt.Sprintf("TERM=dumb; export LANG=C.UTF-8; SUDO_USER=%s; sudo -E %s << 'KUBEKEY_EOF'\n%s\nKUBEKEY_EOF", c.User, c.shell, cmd)
+	cmd = buildSudoCommand(c.User, c.shell, cmd)
 	klog.V(5).InfoS("exec ssh command", "cmd", cmd)
 
 	in, err := session.StdinPipe()

--- a/pkg/connector/ssh_connector_test.go
+++ b/pkg/connector/ssh_connector_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package connector
 
 import (
+	"bufio"
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -248,5 +252,142 @@ func TestSSHConnector_InitValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestExecuteCommand_SudoPasswordPromptDeliversPassword reproduces the bug
+// reported in https://github.com/kubesphere/kubekey/issues/2412 : when sudo
+// on the remote host requires a password (NOPASSWD is not configured), the
+// interactive password prompt must be read from sudo's own stdin, and the
+// password written by ExecuteCommand's read/write loop must reach it.
+//
+// Before the buildSudoCommand fix, the script was piped into sudo's stdin via
+// a heredoc ("sudo -E <shell> << 'EOF' ... EOF"), so sudo consumed lines of
+// the script itself as bogus password attempts and always failed, exactly
+// matching the "Sorry, try again" / "3 incorrect password attempts" output in
+// the issue -- regardless of whether the real password was correct.
+//
+// This test drives the exact command built by buildSudoCommand through a
+// local subprocess (no real SSH/sudo involved) using a fake "sudo" on PATH
+// that mimics the real prompt/read behavior, and reuses the same byte-by-byte
+// prompt-detection loop ExecuteCommand uses over the SSH session's stdio.
+func TestExecuteCommand_SudoPasswordPromptDeliversPassword(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	const (
+		user     = "testuser"
+		password = "s3cret"
+	)
+
+	binDir := t.TempDir()
+	fakeSudo := filepath.Join(binDir, "sudo")
+	fakeSudoScript := `#!/bin/bash
+shift # drop -E
+attempts=0
+while [ $attempts -lt 3 ]; do
+  printf '[sudo] password for ` + user + `: '
+  IFS= read -r pass
+  if [ "$pass" = "` + password + `" ]; then
+    exec "$@"
+  fi
+  echo ""
+  echo "Sorry, try again."
+  attempts=$((attempts+1))
+done
+echo "sudo: 3 incorrect password attempts" >&2
+exit 1
+`
+	if err := os.WriteFile(fakeSudo, []byte(fakeSudoScript), 0o755); err != nil { //nolint:gosec // test fixture, needs to be executable
+		t.Fatalf("write fake sudo: %v", err)
+	}
+
+	script := "echo IT_WORKED"
+	cmd := buildSudoCommand(user, "bash", script)
+
+	c := exec.Command("bash", "-c", cmd)
+	c.Env = append(os.Environ(), "PATH="+binDir+":"+os.Getenv("PATH"))
+
+	in, err := c.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	out, err := c.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := c.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Same byte-by-byte prompt-detection loop as sshConnector.ExecuteCommand.
+	var output []byte
+	line := ""
+	r := bufio.NewReader(out)
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			break
+		}
+		output = append(output, b)
+		if b == '\n' {
+			line = ""
+			continue
+		}
+		line += string(b)
+		if (strings.HasPrefix(line, "[sudo] password for ") || strings.HasPrefix(line, "Password")) && strings.HasSuffix(line, ": ") {
+			if _, err := in.Write([]byte(password + "\n")); err != nil {
+				break
+			}
+		}
+	}
+
+	waitErr := c.Wait()
+	outStr := string(output)
+
+	if waitErr != nil {
+		t.Fatalf("expected sudo to accept the password and run the script, got error: %v\noutput:\n%s", waitErr, outStr)
+	}
+	if !strings.Contains(outStr, "IT_WORKED") {
+		t.Fatalf("expected script output %q in output, got:\n%s", "IT_WORKED", outStr)
+	}
+	if strings.Contains(outStr, "incorrect password") {
+		t.Fatalf("sudo reported incorrect password attempts, the write to stdin did not reach it:\n%s", outStr)
+	}
+}
+
+// TestBuildSudoCommand_PreservesSpecialCharacters ensures the quoting used to
+// pass the script via "sudo ... -c \"$(cat <<'EOF' ... EOF)\"" round-trips
+// shell metacharacters (quotes, backticks, "$(...)") in the script literally,
+// without the outer command line re-interpreting or executing them.
+func TestBuildSudoCommand_PreservesSpecialCharacters(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	script := "echo \"hello \\\"world\\\"\"\n" +
+		"echo 'literal: $(id) and `whoami`'"
+
+	cmd := buildSudoCommand("root", "bash", script)
+	// Use the real "sudo" -> here none is needed since target user matches
+	// (bypass by aliasing sudo to a passthrough), so this test only exercises
+	// quoting, not the password prompt path.
+	binDir := t.TempDir()
+	passthroughSudo := filepath.Join(binDir, "sudo")
+	if err := os.WriteFile(passthroughSudo, []byte("#!/bin/bash\nshift\nexec \"$@\"\n"), 0o755); err != nil { //nolint:gosec // test fixture, needs to be executable
+		t.Fatalf("write passthrough sudo: %v", err)
+	}
+
+	c := exec.Command("bash", "-c", cmd)
+	c.Env = append(os.Environ(), "PATH="+binDir+":"+os.Getenv("PATH"))
+	output, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\noutput:\n%s", err, output)
+	}
+
+	want := "hello \"world\"\nliteral: $(id) and `whoami`\n"
+	if string(output) != want {
+		t.Fatalf("output mismatch:\ngot:  %q\nwant: %q", output, want)
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

## What does this PR do

Frees sudo's stdin so the interactively-written password can actually reach it when a KubeKey SSH host's sudo requires a password.

### Background / Motivation

`sshConnector.ExecuteCommand` ran the remote script as `sudo -E <shell> << 'EOF' ... EOF`, piping the script itself into sudo's own stdin via a heredoc. When the remote user's sudo is not configured `NOPASSWD` and sudo needs to prompt interactively (there is no controlling tty on a plain SSH exec), sudo falls back to reading the password from that same stdin. Because the heredoc already occupies it with the script content, sudo instead consumes lines of the script as bogus password attempts and always fails with `3 incorrect password attempts` — the real password, written by `ExecuteCommand`'s prompt-detection loop to the SSH session's stdin, never reaches it. This reproduces the `Sorry, try again` / `sudo: 3 incorrect password attempts` failure reported for SSH key-based auth with password-protected sudo in the linked issue, independent of whether the configured password is correct.

### Implementation

Pass the script to the shell as a `-c` argument, built through a quoted command substitution (`"$(cat << 'KUBEKEY_EOF' ... KUBEKEY_EOF)"`) instead of piping it directly into sudo's stdin. The heredoc delimiter stays single-quoted so the script is captured byte-for-byte by `cat` and is not re-expanded by the outer double quotes, preserving embedded quotes/backticks/`$()`/newlines literally. This leaves sudo's real stdin connected to the SSH session, so the interactively-written password now reaches it. The command construction was extracted into a small `buildSudoCommand` helper so it can be exercised without a live SSH session.

### Key Changes

| File | What changed |
|---|---|
| `pkg/connector/ssh_connector.go` | Extracted `buildSudoCommand`; script is now passed via `-c` + quoted command substitution instead of a heredoc piped into sudo's stdin |
| `pkg/connector/ssh_connector_test.go` | Added `TestExecuteCommand_SudoPasswordPromptDeliversPassword` (fake-sudo subprocess repro of the password-prompt path) and `TestBuildSudoCommand_PreservesSpecialCharacters` (quoting round-trip) |

## Impact

- **Affected modules**: `pkg/connector` (SSH connector command execution)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A
- **Dependency changes**: N/A

## Breaking Changes

None. The remote command's effective script content and behavior are unchanged when sudo does not need to prompt (the common `NOPASSWD` case); only the transport mechanism for delivering the script to the shell changed.

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Unit tests pass (`go test ./pkg/connector/...`)
- [ ] Integration / E2E tests pass (not run — no live SSH host with password-protected sudo was available in this environment)
- [ ] Manual verification

### Steps to verify

1. Run `go test ./pkg/connector/... -run TestExecuteCommand_SudoPasswordPromptDeliversPassword -v` — a fake `sudo` script on `PATH` mimics sudo's stdin-based interactive password prompt; `buildSudoCommand`'s output is driven through `bash -c` using the same byte-by-byte stdout-scan/stdin-write loop `ExecuteCommand` uses.
2. Confirm the test passes and the output contains no `incorrect password` text.
3. Expected result: the password written to the process's stdin is delivered to sudo's prompt and the wrapped command runs successfully — this was also confirmed to fail with the exact `Sorry, try again` x3 pattern from the issue when temporarily reverted to the old heredoc-into-stdin construction.

### Test coverage

Two new tests in `pkg/connector/ssh_connector_test.go`:
- `TestExecuteCommand_SudoPasswordPromptDeliversPassword`: failing-before/passing-after regression test for the exact defect reported in the issue, using a local subprocess (no real SSH/sudo/cluster).
- `TestBuildSudoCommand_PreservesSpecialCharacters`: verifies quotes/backticks/`$()`/newlines in the wrapped script are preserved literally and not re-interpreted or executed by the outer shell.

## Rollback

Plain revert of this commit; no data or config migration involved.

### Does this PR introduce a user-facing change?

```release-note
Fixed SSH connector command execution so the sudo password is correctly delivered when a host's sudo requires a password (not NOPASSWD) over SSH key-based authentication. Previously such hosts always failed with "sudo: 3 incorrect password attempts", even with a correct password configured.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [ ] All commits are GPG-signed (GitHub shows Verified)
- [x] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`go build ./...`, `golangci-lint run ./pkg/connector/...`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

This was validated with a local subprocess reproduction (a fake `sudo` script standing in for the real one, driven via `bash -c`, no real SSH server or live cluster involved) rather than an end-to-end reproduction against a real host with password-protected sudo. The reproduction targets the specific shell-command-construction defect (sudo's own stdin being starved by the heredoc) and is offered as sufficient evidence for that class of defect, not as a claim of full end-to-end validation. Please flag if a live-host reproduction is still wanted before merge.

Fixes #2412