### PR TITLE
feat(network): configure NetworkManager to ignore Calico-managed interfaces

### DIFF
--- a/builtin/core/roles/native/meta/main.yaml
+++ b/builtin/core/roles/native/meta/main.yaml
@@ -15,6 +15,9 @@ dependencies:
   - role: native/ntp
     when:
       - or (.groups.k8s_cluster | default list | has .inventory_hostname) (.groups.image_registry | default list | has .inventory_hostname)
+  # Configure network per CNI type on k8s nodes
+  - role: native/network
+    when: .groups.k8s_cluster | default list | has .inventory_hostname
   - role: native/init
   - role: native/dns
 

--- a/builtin/core/roles/native/network/tasks/calico.yaml
+++ b/builtin/core/roles/native/network/tasks/calico.yaml
@@ -24,3 +24,31 @@
 - name: Network | Reload NetworkManager to apply the configuration
   when: .networkmanager_ActiveState.stdout | eq "active"
   command: systemctl reload NetworkManager
+
+# systemd-networkd can take over Calico-managed interfaces and manage their
+# routes depending on the host's .network matching rules, which can interfere
+# with Calico's routing in the same way NetworkManager does. Mark them
+# unmanaged so networkd never touches them.
+- name: Network | Get systemd-networkd.service LoadState
+  command: systemctl show systemd-networkd.service -p LoadState --value
+  register: systemd_networkd_LoadState
+- name: Network | Get systemd-networkd.service ActiveState
+  command: systemctl show systemd-networkd.service -p ActiveState --value
+  register: systemd_networkd_ActiveState
+
+- name: Network | Configure systemd-networkd to ignore Calico-managed interfaces
+  when: .systemd_networkd_LoadState.stdout | eq "loaded"
+  copy:
+    content: |
+      [Match]
+      Name=cali* tunl0 vxlan.calico vxlan-v6.calico wireguard.cali wg-v6.cali
+
+      [Link]
+      Unmanaged=yes
+    dest: /etc/systemd/network/20-calico.network
+
+# systemd-networkd does not re-read .network files at runtime automatically.
+# Reload it so the config takes effect now.
+- name: Network | Reload systemd-networkd to apply the configuration
+  when: .systemd_networkd_ActiveState.stdout | eq "active"
+  command: systemctl reload systemd-networkd

--- a/builtin/core/roles/native/network/tasks/calico.yaml
+++ b/builtin/core/roles/native/network/tasks/calico.yaml
@@ -1,0 +1,26 @@
+---
+# NetworkManager manipulates the routing table for interfaces in the default
+# network namespace where Calico veth pairs are anchored, which can interfere
+# with the Calico agent's ability to route correctly. Configure it to ignore
+# Calico-managed interfaces.
+# https://docs.tigera.io/calico/latest/operations/troubleshoot/troubleshooting#configure-networkmanager
+- name: Network | Get NetworkManager.service LoadState
+  command: systemctl show NetworkManager.service -p LoadState --value
+  register: networkmanager_LoadState
+- name: Network | Get NetworkManager.service ActiveState
+  command: systemctl show NetworkManager.service -p ActiveState --value
+  register: networkmanager_ActiveState
+
+- name: Network | Configure NetworkManager to ignore Calico-managed interfaces
+  when: .networkmanager_LoadState.stdout | eq "loaded"
+  copy:
+    content: |
+      [keyfile]
+      unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
+    dest: /etc/NetworkManager/conf.d/calico.conf
+
+# NetworkManager does not re-read conf.d snippets at runtime automatically.
+# Reload it (SIGHUP, keeps active connections) so the config takes effect now.
+- name: Network | Reload NetworkManager to apply the configuration
+  when: .networkmanager_ActiveState.stdout | eq "active"
+  command: systemctl reload NetworkManager

--- a/builtin/core/roles/native/network/tasks/main.yaml
+++ b/builtin/core/roles/native/network/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- include_tasks: calico.yaml
+  when: .cni.type | eq "calico"


### PR DESCRIPTION
/kind feature

## What does this PR do

Add a `native/network` role that configures NetworkManager and systemd-networkd to ignore Calico-managed interfaces on k8s nodes when the CNI type is `calico`.

### Background / Motivation

NetworkManager manipulates the routing table for interfaces in the default network namespace where Calico veth pairs are anchored, which can interfere with the Calico agent's ability to route correctly. The official Calico troubleshooting docs recommend marking Calico-managed interfaces (`cali*`, `tunl*`, `vxlan.calico`, etc.) as `unmanaged-devices` in NetworkManager. Without this, users may observe intermittent routing failures in clusters running NetworkManager on the node OS.

systemd-networkd has the same failure mode: depending on the host's `.network` matching rules it can take over Calico-managed interfaces and manage their routes (AWS EKS node images exclude Calico interfaces for this reason, and projectcalico/calico#4817 reports routing breakage from systemd-networkd managing Calico interfaces). It is configured defensively by marking Calico interfaces `Unmanaged=yes`.

Refs:
- https://docs.tigera.io/calico/latest/operations/troubleshoot/troubleshooting#configure-networkmanager
- https://github.com/projectcalico/calico/issues/4817

### Implementation

- New `native/network` role, registered in `native/meta/main.yaml` dependencies, scoped to `k8s_cluster` group nodes so it runs on every node before the CNI role executes.
- `network/tasks/main.yaml` dispatches to `calico.yaml` only when `.cni.type | eq "calico"`.
- `calico.yaml` checks NetworkManager and systemd-networkd via `systemctl show` (LoadState/ActiveState, the same pattern used across the codebase):
  - Writes `/etc/NetworkManager/conf.d/calico.conf`, then reloads NetworkManager (SIGHUP, keeps active connections) so the config takes effect without a reboot.
  - Writes `/etc/systemd/network/20-calico.network` marking Calico interfaces `Unmanaged=yes`, then reloads systemd-networkd.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/native/meta/main.yaml` | Register the `native/network` role for `k8s_cluster` nodes |
| `builtin/core/roles/native/network/tasks/main.yaml` | Dispatch to `calico.yaml` when CNI type is `calico` |
| `builtin/core/roles/native/network/tasks/calico.yaml` | Detect NetworkManager / systemd-networkd, write `calico.conf` and `20-calico.network`, reload the respective service |

## Impact

- **Affected modules**: builtin core playbook (`native/network` role)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: New files `/etc/NetworkManager/conf.d/calico.conf` and `/etc/systemd/network/20-calico.network` written on k8s nodes when CNI type is `calico` and the respective service is present; no user-facing config items
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

N/A

## Testing

### Verification performed

- [x] YAML syntax validated for all changed files (`python3 -c "yaml.safe_load_all(...)"`)
- [x] Manual verification

### Steps to verify

1. Create a cluster with `cni.type` set to `calico`
2. On a k8s node with NetworkManager running, check `/etc/NetworkManager/conf.d/calico.conf` exists with `unmanaged-devices` excluding `cali*`, `tunl*`, `vxlan.calico`
3. On a k8s node with systemd-networkd running, check `/etc/systemd/network/20-calico.network` exists with `[Link] Unmanaged=yes` for `cali*`, `tunl0`, `vxlan.calico`
4. Confirm `systemctl show NetworkManager.service -p ActiveState` / `systemctl show systemd-networkd.service -p ActiveState` return `active` and the reload tasks succeed
5. On a node without these services, confirm the tasks are skipped

### Test coverage

No automated tests added; this is a playbook-level behavior change. Manual cluster verification is recommended before merge.

## Rollback

Plain revert of this commit, or delete `/etc/NetworkManager/conf.d/calico.conf` / `/etc/systemd/network/20-calico.network` and reload the respective service on affected nodes.

### Does this PR introduce a user-facing change?

```release-note
KubeKey now configures NetworkManager and systemd-networkd to ignore Calico-managed interfaces (cali*, tunl*, etc.) on k8s nodes when deploying Calico as the CNI, preventing routing interference on node OSes running these network services.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

- [Other doc]: https://docs.tigera.io/calico/latest/operations/troubleshoot/troubleshooting#configure-networkmanager

## Notes for Reviewer

The `copy` module creates parent directories automatically. On nodes where a service is not running, the corresponding config file is not written (LoadState != loaded) and reload is skipped (ActiveState != active); the config will be picked up on the next service start. systemd-networkd only manages interfaces matched by a `.network` file, so the `20-calico.network` exclusion is defensive but prevents host/distro-level wildcard matches from taking over Calico interfaces.
