### PR TITLE
fix(harbor): align offline package image namespace to docker.io/goharbor

### DIFF
--- a/config/harbor/v2.10.2/Makefile
+++ b/config/harbor/v2.10.2/Makefile
@@ -11,9 +11,13 @@ NPM_REGISTRY?=https://registry.npmmirror.com
 .PHONY: build
 build:
 	if [ ! -d '_source' ];then \
-  	  mkdir _source; \
+	  mkdir _source; \
    	  git clone -b $(VERSION) https://github.com/goharbor/harbor.git _source/; \
    	  cd _source/ && git apply --ignore-space-change ../build_$(VERSION).patch; \
-  	fi
+   	fi
+	# 离线包自包含：docker save 进 tar 的镜像命名空间是 SAVEIMAGENAMESPACE(=goharbor, 即 docker.io/goharbor)，
+	# 而镜像从 IMAGENAMESPACE(=hub.kubesphere.com.cn/harbor) 拉取后被重新打 tag 成 goharbor。
+	# prepare 容器镜像也必须对齐 SAVEIMAGENAMESPACE，否则离线部署时 prepare 会去拉 hub 而本地只有 docker.io/goharbor。
+	# 该对齐在 build_v2.10.2.patch 的 update_prepare_version 中完成（改用 $(SAVEIMAGENAMESPACE)），无需在此处再 sed。
 	cd _source && make package_offline SAVEIMAGENAMESPACE=$(SAVEIMAGENAMESPACE) VERSIONTAG=$(VERSION) PKGVERSIONTAG=$(VERSION) BASEIMAGENAMESPACE=$(BASEIMAGENAMESPACE) IMAGENAMESPACE=$(IMAGENAMESPACE) BASEIMAGETAG=$(BASEIMAGETAG) DOCKER_PLATFORM=$(DOCKER_PLATFORM) DOCKER_BUILD_IMAGES=$(DOCKER_BUILD_IMAGES) TRIVYFLAG=true NPM_REGISTRY=$(NPM_REGISTRY)
 	mv _source/harbor-offline-installer*.tgz . && rm -rf _source/

--- a/config/harbor/v2.10.2/build_v2.10.2.patch
+++ b/config/harbor/v2.10.2/build_v2.10.2.patch
@@ -76,7 +76,7 @@ index 609c4004f..356e03b84 100644
  update_prepare_version:
  	@echo "substitute the prepare version tag in prepare file..."
 -	@$(SEDCMDI) -e 's/goharbor\/prepare:.*[[:space:]]\+/goharbor\/prepare:$(VERSIONTAG) prepare /' $(MAKEPATH)/prepare ;
-+	@$(SEDCMDI) -e 's/goharbor\/prepare:.*[[:space:]]\+/$(subst /,\/,$(IMAGENAMESPACE))\/prepare:$(VERSIONTAG) prepare /' $(MAKEPATH)/prepare ;
++	@$(SEDCMDI) -e 's/goharbor\/prepare:.*[[:space:]]\+/$(subst /,\/,$(SAVEIMAGENAMESPACE))\/prepare:$(VERSIONTAG) prepare /' $(MAKEPATH)/prepare ;
  
  gen_tls:
  	@$(DOCKERCMD) run --rm -v /:/hostfs:z $(IMAGENAMESPACE)/prepare:$(VERSIONTAG) gencert -p /etc/harbor/tls/internal
@@ -435,7 +435,7 @@ index c0ef48262..528d321d9 100755
                      -v /:/hostfs \
                      --privileged \
 -                    goharbor/prepare:dev prepare $@
-+                    hub.kubesphere.com.cn/harbor/prepare:v2.10.2 prepare $@
++                    goharbor/prepare:v2.10.2 prepare $@
  
  echo "Clean up the input dir"
  # Clean up input dir


### PR DESCRIPTION
/kind bug

## What does this PR do

Align the harbor offline installer's `prepare` image namespace to `docker.io/goharbor` so offline deployment no longer fails pulling from the mirror.

### Background / Motivation

The harbor offline package's `prepare` script referenced `hub.kubesphere.com.cn/harbor/prepare`, but the images saved into the offline tar use `SAVEIMAGENAMESPACE` (= `goharbor`, i.e. `docker.io/goharbor`). Offline deployment then failed because the local registry only contains `docker.io/goharbor` images.

### Implementation

Root cause: harbor's top-level `Makefile` `update_prepare_version` rewrites `make/prepare`'s image to `$(IMAGENAMESPACE)` (= `hub...`), and `package_offline` depends on it before building the tgz. `build_v2.10.2.patch` also hardcoded `make/prepare` to hub.

Fix in `build_v2.10.2.patch`:
- `update_prepare_version` now uses `$(SAVEIMAGENAMESPACE)` so the prepare image matches the saved images.
- `make/prepare` is set directly to `goharbor/prepare:v2.10.2` (not hub, not `:dev`) because the macOS/BSD `sed` does not support the GNU `\+` extension used by `update_prepare_version` (that step is a no-op locally and must not leave the `:dev` tag behind); on Linux CI (GNU `sed`) the result is identical (idempotent).

`IMAGENAMESPACE=hub.kubesphere.com.cn/harbor` is still used to pull images from the mirror before re-tagging them to `goharbor`.

### Key Changes

| File | What changed |
|---|---|
| `config/harbor/v2.10.2/build_v2.10.2.patch` | `update_prepare_version` uses `$(SAVEIMAGENAMESPACE)`; `make/prepare` image set to `goharbor/prepare:v2.10.2` |
| `config/harbor/v2.10.2/Makefile` | Removed the misplaced post-`package_offline` sed band-aid (it operated on an already-`rm -rf`'d dir and would fail CI); replaced with a comment explaining the fix lives in the patch |

## Impact

- **Affected modules**: harbor offline package build (`config/harbor/v2.10.2`)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A (namespace variables unchanged)
- **Dependency changes**: N/A

## Breaking Changes

None

## Testing

### Verification performed

- [x] Manual verification (built the arm64 offline package locally)

### Steps to verify

1. `cd config/harbor/v2.10.2 && make build`
2. Inspect the package: `tar -xzOf harbor-offline-installer-v2.10.2-linux-arm64.tgz harbor/prepare | grep prepare:v2.10.2` → `goharbor/prepare:v2.10.2`
3. Confirm no `hub.kubesphere.com.cn` reference inside the package and that the embedded image tar contains only `goharbor/*:v2.10.2`

### Test coverage

Build/config change only; verified by reproducing the offline package and inspecting its contents. CI `build-harbor` job (`gen-repository-iso.yaml`) regenerates and publishes the artifact.

## Rollback

Plain revert of this commit.

### Does this PR introduce a user-facing change?

```release-note
Fix harbor arm64 offline installer referencing the wrong image registry: the prepare image now uses docker.io/goharbor (matching the images bundled in the offline tar) instead of hub.kubesphere.com.cn/harbor, so offline deployment no longer fails to pull the prepare image.
```

## Checklist

- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [ ] All commits are GPG-signed (local env has no usable GPG private key — DCO only, no Verified badge)
- [x] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

## Notes for Reviewer

I dropped the earlier approach of a sed in the kubekey `Makefile` `build` target: it ran after `package_offline` had already created the tgz and `rm -rf`'d the staging dir, so it was a no-op and would also fail CI (`find` on a removed path). The fix now lives entirely in `build_v2.10.2.patch` at the source of the namespace rewrite.
