### PR TITLE
fix: align PutData temp file path with connector working directory

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -142,7 +142,13 @@ func isLocalIP(ipAddr string) bool {
 
 func PutData(ctx context.Context, data []byte, dest string, mode fs.FileMode, conn Connector) error {
 	dest = filepath.ToSlash(dest)
-	tmpDest := path.Join("/tmp", ".kk."+rand.String(10))
+	// Use a relative temp name so that PutFile (which may prepend the
+	// connector's homedir to the destination) and the subsequent `mv` command
+	// (run with the connector's working directory as cwd) agree on where the
+	// temp file lives. An absolute "/tmp/..." prefix here is relocated by the
+	// kubernetes connector's PutFile but not by the mv command, causing the mv
+	// to fail with a missing source on kubekey v4.x.
+	tmpDest := ".kk." + rand.String(10)
 
 	if err := conn.PutFile(ctx, data, tmpDest, mode); err != nil {
 		return err


### PR DESCRIPTION
/kind bug
/kind regression

## What does this PR do

Fixes a regression where `template`/`copy` module operations fail on the kubernetes connector because the temporarily staged file cannot be found by the subsequent `mv`.

### Background / Motivation

On the kubernetes connector, `PutData` (`pkg/connector/connector.go`) stages data under an absolute temp name `/tmp/.kk.<rand>`, then runs `mkdir -p <dir> && mv <tmp> <dest>`. However, the kubernetes connector's `PutFile` prepends the connector homedir to the destination (`filepath.Join(c.homedir, dst)`), so the file is actually written to `<homedir>/tmp/.kk.<rand>`. The `mv` command (run with `c.homedir` as cwd) references the raw `/tmp/.kk.<rand>`, which does not exist, so `mv` fails with a missing source. This breaks every `template`/`copy` task that stages files locally before applying them (e.g. deploying rendered manifests), making `kk` unusable for such playbooks on v4.x.

### Implementation

Change `PutData`'s temp name from an absolute `/tmp/.kk.<rand>` to a relative `.kk.<rand>`. Now both `PutFile` (which may prepend the homedir) and the `mv` command (run with the connector's working directory as cwd) resolve the temp file to the same location, regardless of connector. The local connector is unaffected (it writes/executes relative to the process cwd).

### Key Changes

| File | What changed |
|---|---|
| `pkg/connector/connector.go` | `PutData`: use a relative temp name instead of `/tmp/.kk.<rand>` |

## Impact

- **Affected modules**: `pkg/connector`
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Manual verification: built `kk` with the fix and ran a playbook that renders + applies manifests via the `template` module on the kubernetes connector — previously failed with `failed to template file`, now succeeds (`total: 6, success: 6, failed: 0`).

### Steps to verify

1. Build `kk` from this branch.
2. Run a playbook that uses the `template` or `copy` module against a cluster via a kubeconfig connector (kubernetes connector).
3. Expected: the staged file is moved and applied successfully (no `failed to template/copy file`).

### Test coverage

This is a one-line behavioral fix in the staging path. Existing connector tests cover `PutData`/`PutFile`. No new unit test added, but covered by the manual verification above (happy to add a regression test if maintainers prefer).

## Rollback

Plain revert of this commit.

```release-note
Fix kubernetes connector failing to stage files for the `template`/`copy` modules (temp file path mismatch).
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [ ] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

## Notes for Reviewer

The regression was introduced by the kubernetes connector prepending `homedir` to `PutFile` destinations; this fix makes the temp name relative so both sides agree.
