### PR TITLE
fix: detect kubectl client version via structured -o yaml output

### DIFF
--- a/builtin/core/roles/kubernetes/pre-kubernetes/tasks/install_binaries.yaml
+++ b/builtin/core/roles/kubernetes/pre-kubernetes/tasks/install_binaries.yaml
@@ -32,18 +32,12 @@
 
 - name: Binary | Check if kubectl is installed
   ignore_errors: true
-  command: |
-    {{- if .kubernetes.kube_version | semverCompare ">=v1.28.0" -}}
-    kubectl version --client
-    {{- else -}}
-    kubectl version --client --short
-    {{- end -}}
+  command: kubectl version --client -o yaml
   register: kubectl_install_version
   register_type: yaml
 
 - name: Binary | Install kubectl if not present or version mismatch
-  when: |
-    or (.kubectl_install_version.error | empty | not) ((get .kubectl_install_version.stdout "Client Version") | ne  .kubernetes.kube_version)
+  when: or (.kubectl_install_version.error | empty | not) ((index .kubectl_install_version.stdout "clientVersion" "gitVersion") | ne .kubernetes.kube_version)
   copy:
     src: >-
       {{ .binary_dir }}/kube/{{ .kubernetes.kube_version }}/{{ .binary_type }}/kubectl


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup

### What this PR does / why we need it:

The kubectl client version probe in `pre-kubernetes` used `kubectl version --client`
(with a version-conditional `--short` flag for older clients) and then parsed the
human-readable `Client Version` key out of the registered YAML. That key/format is
not part of kubectl's stable API surface and can shift between releases, making the
detection brittle.

This switches to `kubectl version --client -o yaml` and reads the stable API field
`.clientVersion.gitVersion`, which is supported by every kubectl version KubeKey
deploys. It also drops the now-unneeded version branch and `semverCompare` conditional.

### Which issue(s) this PR fixes:

None

### Special notes for reviewers:

- `-o yaml` is supported across all kubectl versions KubeKey provisions (verified
  against v1.23.x and v1.34.x); it reliably yields `clientVersion.gitVersion`.
- `register_type: yaml` already parses stdout into `.stdout`, so
  `(index .stdout "clientVersion" "gitVersion")` is nil-safe and avoids depending on
  the human-readable output layout.

### Does this PR introduced a user-facing change?

None

```release-note
None
```
