### PR TITLE
feat(kubernetes): support kubelet extra_config in KubeletConfiguration

### DIFF
--- a/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
+++ b/builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml
@@ -65,6 +65,8 @@ kubernetes:
     container_log_max_size: 5Mi
     container_log_max_files: 3
 #    extra_args:
+#    extra_config:   # Extra fields merged into KubeletConfiguration (e.g. maxOpenFiles, eventRecordQPS)
+#      maxOpenFiles: 1000000
 
   # Specify a stable IP address or DNS name for the control plane endpoint.
   # For high availability, it is recommended to set control_plane_endpoint to a DNS name.

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3
@@ -232,3 +232,6 @@ featureGates:
 cgroupDriver: {{ .cri.cgroup_driver }}
 containerLogMaxSize: {{ .kubernetes.kubelet.container_log_max_size }}
 containerLogMaxFiles: {{ .kubernetes.kubelet.container_log_max_files }}
+{{- if .kubernetes.kubelet.extra_config | empty | not }}
+{{ .kubernetes.kubelet.extra_config | toYaml }}
+{{- end }}

--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4
@@ -263,3 +263,6 @@ featureGates:
 cgroupDriver: {{ .cri.cgroup_driver }}
 containerLogMaxSize: {{ .kubernetes.kubelet.container_log_max_size }}
 containerLogMaxFiles: {{ .kubernetes.kubelet.container_log_max_files }}
+{{- if .kubernetes.kubelet.extra_config | empty | not }}
+{{ .kubernetes.kubelet.extra_config | toYaml }}
+{{- end }}


### PR DESCRIPTION
### What type of PR is this?
/kind feature

## What does this PR do

支持在 KubeletConfiguration 中注入自定义字段：通过 `kubernetes.kubelet.extra_config` 合并到 kubeadm init 渲染生成的 KubeletConfiguration，已在 v1beta3 / v1beta4 两套模板生效。

### Background / Motivation

kubelet 需要额外调优（如 `maxOpenFiles`、自定义 eventRecordQPS 等）时，目前 KubeletConfiguration 里只有 KubeKey 硬编码的那组字段，无法扩展。倾向用结构化配置而非 `nodeRegistration.kubeletExtraArgs` 命令行参数（后者对部分 kubelet 配置项不支持或语义不同），故提供直接合并到 KubeletConfiguration 的地图。

### Implementation

在 `kubeadm-init.v1beta3` 与 `kubeadm-init.v1beta4` 的 KubeletConfiguration 末尾追加条件渲染块：

```yaml
{{- if .kubernetes.kubelet.extra_config | empty | not }}
{{ .kubernetes.kubelet.extra_config | toYaml }}
{{- end }}
```

与现有 `kubernetes.kube_proxy.config | toYaml` 的处理方式保持一致（直接 `toYaml`，无缩进，输出为顶层字段）。

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta3` | KubeletConfiguration 末尾合并 `kubernetes.kubelet.extra_config` |
| `builtin/core/roles/kubernetes/init-kubernetes/templates/kubeadm/kubeadm-init.v1beta4` | 同上，保持版本一致 |
| `builtin/core/roles/defaults/defaults/main/03-kubernetes.yaml` | kubelet 段新增 `extra_config` 注释示例 |

## Impact

- **Affected modules**: init-kubernetes kubeadm 模板渲染
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: 新增可选配置 `kubernetes.kubelet.extra_config`（map，合并进 KubeletConfiguration），无默认值
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:
Fixes #

## Testing

### Verification performed

- [x] Manual verification

### Steps to verify

1. 在 cluster config 中设置 `kubernetes.kubelet.extra_config: { maxOpenFiles: 1000000 }`
2. 执行 `kk create cluster`，检查生成的 `/etc/kubernetes/kubelet-config.yaml`（kubeadm-init 渲染产物）包含 `maxOpenFiles: 1000000`

### Test coverage

模板条件渲染改动，未新增单测；依赖既有 init-kubernetes 渲染链路验证。

## Rollback

直接 revert 本 PR 即可；未配置 `extra_config` 时渲染结果与改动前一致。

### Does this PR introduce a user-facing change?

```release-note
支持通过 `kubernetes.kubelet.extra_config` 向 KubeletConfiguration 注入自定义字段。
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

## Notes for Reviewer

`extra_config` 与模板内已硬编码字段（如 `maxPods`、`clusterDomain`、`cgroupDriver` 等）存在同名时会出现重复字段，kubelet 解析可能报错，使用时需自行避开；此处保持与 `kube_proxy.config` 一致的直接合并语义，未做去重。
