### PR TITLE
ci: split QingStor OSS sync into separate jobs

### DIFF
--- a/.github/workflows/gen-repository-iso.yaml
+++ b/.github/workflows/gen-repository-iso.yaml
@@ -113,9 +113,45 @@ jobs:
             ${{ matrix.name }}-arm64.iso
           overwrite: true
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: iso-${{ matrix.name }}
+          path: |
+            ${{ matrix.name }}.iso.sha256sum.txt
+            ${{ matrix.name }}-amd64.iso
+            ${{ matrix.name }}-arm64.iso
+          retention-days: 5
+
+  sync-iso-oss:
+    runs-on: ubuntu-latest
+    needs: build-iso
+    if: github.repository == 'kubesphere/kubekey' && (github.event_name == 'push' || github.event.inputs.upload_iso == 'true')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: almalinux-9.0-rpms
+          - name: centos-8-rpms
+          - name: debian-10-debs
+          - name: debian-11-debs
+          - name: kylin-v10SP3-2403-rpms
+          - name: kylin-v10SP3-rpms
+          - name: kylin-v10SP2-rpms
+          - name: kylin-v10SP1-rpms
+          - name: ubuntu-18.04-debs
+          - name: ubuntu-20.04-debs
+          - name: ubuntu-22.04-debs
+          - name: ubuntu-24.04-debs
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: iso-${{ matrix.name }}
+          path: .
+
       - name: Synchronize artifacts to OSS
         run: |
-          
           rm -rf qsctl_v2.4.3_linux_amd64.tar.gz
           wget https://attack-on-titan.gd2.qingstor.com/qsctl/v2.4.3/qsctl_v2.4.3_linux_amd64.tar.gz
           tar -zxvf qsctl_v2.4.3_linux_amd64.tar.gz
@@ -123,13 +159,12 @@ jobs:
           mv qsctl_v2.4.3_linux_amd64 /usr/local/bin/qsctl
           echo "access_key_id: ${{secrets.KS_QSCTL_ACCESS_KEY_ID}}" > qsctl-config.yaml
           echo "secret_access_key: ${{ secrets.KS_QSCTL_SECRET_ACCESS_KEY }}" >> qsctl-config.yaml
-          
+
           qsctl -c qsctl-config.yaml cp ${{ matrix.name }}.iso.sha256sum.txt qs://kubekey/github.com/kubesphere/kubekey/releases/download/iso-latest/${{ matrix.name }}.iso.sha256sum.txt
           qsctl -c qsctl-config.yaml cp ${{ matrix.name }}-amd64.iso qs://kubekey/github.com/kubesphere/kubekey/releases/download/iso-latest/${{ matrix.name }}-amd64.iso
           qsctl -c qsctl-config.yaml cp ${{ matrix.name }}-arm64.iso qs://kubekey/github.com/kubesphere/kubekey/releases/download/iso-latest/${{ matrix.name }}-arm64.iso
 
           rm -rf qsctl-config.yaml
-
 
   build-harbor:
     runs-on: ubuntu-latest
@@ -160,6 +195,24 @@ jobs:
           name: iso-latest
           files: config/harbor/*/*harbor-offline-installer*.tgz
           overwrite: true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: harbor
+          path: config/harbor
+          retention-days: 5
+
+  sync-harbor-oss:
+    runs-on: ubuntu-latest
+    needs: build-harbor
+    if: github.repository == 'kubesphere/kubekey' && (github.event_name == 'push' || github.event.inputs.upload_harbor == 'true')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: harbor
+          path: .
 
       - name: Synchronize harbor packages to OSS
         shell: bash

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -60,10 +60,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_GH_TOKEN }}
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 5
+
+  sync-oss:
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    if: github.repository == 'kubesphere/kubekey'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: .
+
       - name: Synchronize artifacts to OSS
         run: |
+          VERSION=${GITHUB_REF#refs/tags/}
           # Check if the current Git reference is a valid semantic version tag (e.g., v1.2.3)
-          if [[ ! ${GITHUB_REF#refs/*/} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "Skipping artifact synchronization: not a release tag."
               return 0
           fi
@@ -76,6 +95,6 @@ jobs:
           echo "secret_access_key: ${{ secrets.KS_QSCTL_SECRET_ACCESS_KEY }}" >> qsctl-config.yaml
 
           mkdir -p dist-output && mv dist/*.tar.gz dist-output/
-          qsctl -c qsctl-config.yaml cp -r dist-output/ qs://kubekey/github.com/kubesphere/kubekey/releases/download/${{ steps.prepare.outputs.version }}/
+          qsctl -c qsctl-config.yaml cp -r dist-output/ qs://kubekey/github.com/kubesphere/kubekey/releases/download/${VERSION}/
 
           rm -rf qsctl-config.yaml dist-output/


### PR DESCRIPTION
## Summary

Extract the QingCloud object storage (QingStor/qsctl) synchronization out of the build jobs into dedicated jobs, so a sync failure only requires re-running the sync step instead of the whole build pipeline.

- **releaser.yaml**: add a `sync-oss` job (`needs: goreleaser`) that receives the `dist` artifacts via GitHub artifact upload/download.
- **gen-repository-iso.yaml**: add a `sync-iso-oss` job (matrix, one-to-one with `build-iso`) and a `sync-harbor-oss` job (`needs: build-harbor`); ISO/harbor artifacts are passed between jobs via artifacts.

## Motivation

Previously the QingStor sync was the last step of the build jobs. When the sync failed due to QingStor network throttling/flake, the entire workflow had to be re-run (checkout, compilation, GoReleaser, GitHub Release upload, etc.). After this change, a sync failure only requires re-running the corresponding `sync-oss` / `sync-iso-oss` / `sync-harbor-oss` job.

## Notes

- The `if` guards of the sync jobs match the original build jobs, and they `needs` the corresponding build jobs, so behavior is unchanged.
- `sync-iso-oss` keeps the matrix, so a single ISO sync failure only requires re-running that matrix variant.
- Both workflow files pass YAML syntax validation.

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy/codebuddy-code)