### PR TITLE
fix(cmd): correct the short description of kk create config

### DIFF
--- a/cmd/kk/app/builtin/create.go
+++ b/cmd/kk/app/builtin/create.go
@@ -67,7 +67,7 @@ func newCreateConfigCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Create a Kubernetes or KubeSphere cluster",
+		Short: "Create a cluster configuration file",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return o.Run()
 		},


### PR DESCRIPTION
/kind bug

## What does this PR do

Fix the incorrect `Short` help description of the `kk create config` command.

### Background / Motivation

`kk create config` only generates a default cluster configuration file
(`config-<version>.yaml`) or prints it to stdout. However, its `Short` help
text was copied from `create cluster` and wrongly read "Create a Kubernetes or
KubeSphere cluster", which misleads users into thinking the command creates a
cluster.

### Implementation

Correct the `Short` string of the config subcommand to describe what it
actually does.

### Key Changes

| File | What changed |
|---|---|
| `cmd/kk/app/builtin/create.go` | Fix the `Short` description of the `create config` command |

## Impact

- **Affected modules**: kubekey CLI (`builtin` commands)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [ ] Unit tests pass (`make test`)
- [ ] Integration / E2E tests pass
- [x] Manual verification

### Steps to verify

1. Build the CLI: `go build -tags builtin ./cmd/kk/app/builtin/`
2. Run `kk create config --help`
3. Expected: description reads "Create a cluster configuration file"

### Test coverage

No tests added. This is a help-text fix with no functional change; the
`builtin` package compiles cleanly under `-tags builtin`.

## Rollback

Plain revert of the single-line change.

### Does this PR introduce a user-facing change?

```release-note
Correct the help description of the `kk create config` command.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

## Notes for Reviewer

Single-line help text correction; the previous text was a copy-paste from
`create cluster`.
