### PR TITLE
docs(installation): align kubernetes & kubesphere install guides (zh/en)

### DIFF
--- a/docs/en/installation/offline.md
+++ b/docs/en/installation/offline.md
@@ -1,41 +1,80 @@
 # Offline Installation of Kubernetes and KubeSphere
 
-This section describes how to deploy Kubernetes and KubeSphere using offline packages in an environment without Internet access.
+This section describes how to deploy Kubernetes and KubeSphere using offline packages in an environment that cannot access the Internet.
 
-> **Prerequisite**: The installation process depends on the `tar` utility for compression and decompression. Please ensure it is pre-installed in your system environment. If `charts` is configured in `config.yaml`, make sure Helm is pre-installed on the packaging node.
+The installation process uses the open-source tool KubeKey v4.x. For more information about KubeKey, visit the [GitHub KubeKey repository](https://github.com/kubesphere/kubekey).
 
----
+> **Note**: KubeSphere Community Edition users need to build the offline package themselves while connected to the Internet; users of other KubeSphere editions can contact KubeSphere delivery service experts to obtain the latest offline package, and can skip the "Build Offline Package" section.
 
-## Preparation
+> **Note**: The installation process depends on the `tar` utility for compression and decompression of software packages. Make sure it is pre-installed in your system environment. If `charts` is configured in `config.yaml`, make sure Helm is pre-installed on the packaging node.
 
-Prepare Linux hosts according to the following minimum configuration requirements.
+## Overview
 
-| Role | Host Count | Minimum Requirements (per node) | Network |
-|------|-----------|--------------------------------|---------|
-| Packaging node | 1 | CPU: 1 core, Memory: 1 GB, Disk: 150 GB | |
-| Deployment node (runs Web Installer) | 1 | CPU: 1 core, Memory: 1 GB, Disk: 150 GB | Network connected to Kubernetes nodes |
-| Private image registry node | 1 | CPU: 8 cores, Memory: 16 GB, Disk: 100 GB | Network connected to Kubernetes nodes |
-| Kubernetes node | ≥ 1 | CPU: 2 cores, Memory: 4 GB, Disk: 40 GB | Inter-node network connected |
+Compared with online installation, offline installation requires you to first package the required components and images as an offline package on a machine that can access the Internet, and then transfer it to the target environment for installation. The overall flow is as follows:
 
-> **Notes**
->
-> - A single host can simultaneously assume multiple roles, e.g. both a deployment node and a private image registry node, or both a deployment node and a Kubernetes node.
-> - **The private image registry node and Kubernetes nodes cannot be the same host.**
+1. **Build the offline package** (on a networked machine): Download components and images and package them as `artifact.tgz`.
+2. **Transfer the offline package**: Copy `artifact.tgz` to the target environment (for example, via a storage medium or an intranet transfer).
+3. **Install the cluster** (in the target environment): Extract the offline package, push images to the private image registry (if installing the private image registry separately, i.e., Option 1, image pushing is completed automatically by the installation flow when KubeKey installs the image registry together with the cluster), and then install Kubernetes and KubeSphere.
 
-**Role descriptions:**
+## Role Descriptions
 
-- **Packaging node**: Prepare at least 1 Linux server as the packaging node. This node will download required software packages and images from the Internet, so it must be able to access: `github.com`, `docker.io`, `quay.io`.
-- **Deployment node** (runs Web Installer services): During installation, `kk` commands need to be executed on this node to run the installation service. This node must maintain network connectivity with the private image registry nodes and Kubernetes nodes.
-- **Private image registry node**: If no private image registry has been deployed, prepare at least 1 Linux server. This node must maintain network connectivity with all Kubernetes nodes.
-- **Kubernetes nodes**: Prepare at least 1 Linux server as a cluster node (no need to pre-install Kubernetes).
+Offline installation involves the following four roles:
 
----
+| Role | Responsibility | Minimum Configuration (per node) | Network Requirements |
+|---|---|---|---|
+| Packaging node | Downloads required software packages and images from the Internet and builds the offline package | CPU: 1 core, Memory: 1 GB, Disk: 150 GB | Must have Internet access |
+| Deployment node (runs the Web Installer service) | Executes `kk` commands on this node during installation to run the installation service | CPU: 1 core, Memory: 1 GB, Disk: 150 GB | Network connected to Kubernetes nodes |
+| Private image registry node | Stores the container images required by the cluster | CPU: 8 cores, Memory: 16 GB, Disk: 100 GB | Network connected to Kubernetes nodes |
+| Kubernetes node | Runs cluster workloads (no need to pre-install Kubernetes) | CPU: 2 cores, Memory: 4 GB, Disk: 40 GB | Inter-node network connected |
+
+> **Note**:
+> - A single host can simultaneously assume multiple roles, for example both a deployment node and a private image registry node, or both a deployment node and a Kubernetes node.
+> - The private image registry node and the Kubernetes node cannot be the same host, because the Kubernetes installation process restarts the container runtime on that node, which may interrupt the image registry service.
+
+## Prerequisites
+
+> **Note**: The following are the prerequisites that Kubernetes nodes must satisfy.
+
+- You need to prepare at least 1 Linux server as a cluster node. In production environments, to ensure high availability, it is recommended to prepare at least 5 Linux servers, 3 of which act as control plane nodes and another 2 as worker nodes. If you install KubeSphere on multiple Linux servers, make sure all servers belong to the same subnet.
+- The operating system and version of the cluster nodes must be Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, Debian 10, Debian 11, CentOS 8, AlmaLinux 9.0, or Kylin v10. The operating systems of multiple servers can be different. For support of other operating systems and versions, consult the official solution experts or delivery service experts of QingCloud.
+- In production environments, to ensure the cluster has sufficient compute and storage resources, it is recommended that each cluster node be configured with at least 8 CPU cores, 16 GB of memory, and 200 GB of disk space. In addition, it is recommended to mount at least another 200 GB of disk space under `/var/lib/docker` (for Docker) or `/var/lib/containerd` (for containerd) on each cluster node to store container runtime data.
+- In production environments, it is recommended to configure high availability for the KubeSphere cluster in advance to avoid service interruption when a single control plane node fails. For more information, see [Configure High Availability](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/).
+
+  > **Note**: If you plan multiple control plane nodes, be sure to configure high availability for the cluster in advance.
+
+- By default, KubeSphere uses the local disk space of cluster nodes as persistent storage. In production environments, it is recommended to configure an external storage system as persistent storage in advance. For more information, see [Configure External Persistent Storage](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/).
+- Make sure the DNS server addresses configured in the `/etc/resolv.conf` file are available on all cluster nodes. Otherwise, the KubeSphere cluster may experience domain name resolution issues.
+- Make sure the `sudo`, `tar`, `curl`, and `openssl` commands are available on all cluster nodes.
+- Make sure the clocks of all cluster nodes are synchronized.
+
+## Configure Firewall Rules
+
+KubeSphere requires specific ports and protocols for communication between services. If firewall is enabled in your infrastructure environment, you need to allow the required ports and protocols in the firewall settings. If firewall is not enabled in your infrastructure environment, you can skip this step.
+
+The following table lists the ports and protocols that need to be allowed in the firewall.
+
+| Service | Protocol | Action | Start Port | End Port | Remarks |
+|---|---|---|---|---|---|
+| ssh | TCP | allow | 22 | N/A | — |
+| etcd | TCP | allow | 2379 | 2380 | — |
+| apiserver | TCP | allow | 6443 | N/A | — |
+| calico | TCP | allow | 9099 | 9100 | — |
+| bgp | TCP | allow | 179 | N/A | — |
+| nodeport | TCP | allow | 30000 | 32767 | — |
+| master | TCP | allow | 10250 | 10258 | — |
+| worker | TCP | allow | 10250 | N/A | — |
+| dns | TCP | allow | 53 | N/A | — |
+| dns | UDP | allow | 53 | N/A | — |
+| local-registry | TCP | allow | 5000 | N/A | Required in offline environments |
+| local-apt | TCP | allow | 5080 | N/A | Required in offline environments |
+| rpcbind | TCP | allow | 111 | N/A | Required when using NFS as persistent storage |
+| ipip | IPENCAP / IPIP | allow | N/A | N/A | Required when using Calico |
 
 ## Build Offline Package
 
 ### Create Configuration File
 
-> You can generate it via the https://get-images.kubesphere.io page.
+**Tip**: You can visually select the required components and automatically generate `config.yaml` on the [https://get-images.kubesphere.io](https://get-images.kubesphere.io) page, or create it manually by referring to the following example.
 
 Log in to the packaging node and create a `config.yaml` file on the packaging node:
 
@@ -53,18 +92,8 @@ spec:
       registry: hub.kubesphere.com.cn
     kubernetes:
       kube_version:
-        - v1.23.17
-        - v1.24.17
-        - v1.25.16
-        - v1.26.15
-        - v1.27.16
-        - v1.28.15
-        - v1.29.15
-        - v1.30.14
-        - v1.31.12
-        - v1.32.11
-        - v1.33.7
         - v1.34.3
+        # Other versions from v1.23~v1.34 can also be listed
     cni:
       type:
         - calico
@@ -72,9 +101,8 @@ spec:
         - flannel
         - kubeovn
         - hybridnet
-      multi_cni:
-        - multus
-        - spiderpool
+      # multi_cni:          # Optional, multi-CNI management component, e.g. multus
+      #   - multus
     cri:
       container_manager:
         - containerd
@@ -89,76 +117,71 @@ spec:
         - harbor
         - docker-registry
     iso:
-      - "almalinux-9.0-rpms"
-      - "kylin-v10SP3-rpms"
       - "ubuntu-22.04-debs"
       - "centos-8-rpms"
-      - "kylin-v10SP2-rpms"
-      - "ubuntu-24.04-debs"
-      - "debian-10-debs"
-      - "kylin-v10SP1-rpms"
-      - "debian-11-debs"
-      - "ubuntu-18.04-debs"
-      - "kylin-v10SP3-2403-rpms"
-      - "ubuntu-20.04-debs"
+      # Add or remove as needed
 ```
 
 **Field descriptions:**
 
 | Field | Description |
-|-------|-------------|
+|---|---|
 | `apiVersion` | API version of the configuration file. Fixed value: `kubekey.kubesphere.io/v1` |
 | `kind` | Resource type. Fixed value: `Config` |
-| `spec.zone` | Download zone for packages. `cn` means using domestic mirrors |
+| `spec.zone` | Region for downloading software packages. `cn` means using domestic sources |
 | `spec.download.arch` | CPU architectures to download. Supports `amd64` and `arm64` |
-| `spec.download.images.policy` | Image download policy. `warn` means only warning if the image does not exist |
+| `spec.download.images.policy` | Image download policy. `warn` means only recording a warning if the image is missing some CPU architectures or operating systems; `strict` means the pulled image must contain all selected CPU architectures and operating systems, otherwise an error is raised |
 | `spec.download.images.registry` | Image registry address |
 | `spec.download.kubernetes.kube_version` | List of Kubernetes versions to include |
 | `spec.download.cni.type` | CNI plugin types to include |
 | `spec.download.cni.multi_cni` | Multi-CNI management components to include |
 | `spec.download.cri.container_manager` | Container runtime types. Supports `containerd` and `docker` |
-| `spec.download.storage_class` | Storage classes to include. Supports `local` and `nfs` |
+| `spec.download.storage_class` | Storage classes to include. Supports `local`, `nfs` |
 | `spec.download.image_registry.type` | Image registry types. Supports `harbor` and `docker-registry` |
-| `spec.download.iso` | List of operating systems for building ISO dependency packages |
+| `spec.download.iso` | List of operating systems for building ISO dependency packages, used to install system dependencies |
 
-### Get kk and Web Installer
+### Get KubeKey and Web Installer
 
-If your access to GitHub/GoogleAPIs is restricted, set the following environment variable:
+If your access to GitHub or Google APIs is restricted, set the following environment variable:
 
-```shell
+```bash
 export KKZONE=cn
 ```
 
 Execute the following command to download KubeKey and Web Installer:
 
-```shell
+```bash
 curl -sfL https://get-kk.kubesphere.io | sh -
 ```
 
 After execution, the following files will be generated in the current directory:
 
 | Original File | Extracted File |
-|--------|-----------|
-| `kubekey-v4.x.x-linux-amd64.tar.gz` | kk: KubeKey binary |
-| `web-installer.tgz` | dist: Web UI resources<br>host-check.yaml, kubernetes, kubesphere: Task template files<br>schema: Configuration files<br>README.md: Installation documentation |
-| `package.sh` | Offline package build script |
+|---|---|
+| `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`: KubeKey binary |
+| `web-installer.tgz` | `dist`: Web page resources; `host-check.yaml`, `kubernetes`, `kubesphere`: Task template files; `schema`: Configuration form definitions; `README.md`: Installation documentation |
+| `package.sh` | Build script for the offline package (automatically generated by the download command; internally calls `kk artifact export` to complete download and packaging) |
 
-### Build Offline Package
+### Build the Offline Package
 
 Execute the build script:
 
-```shell
+```bash
 ./package.sh config.yaml
 ```
 
-When `Offline package artifact.tgz has been created successfully.` is printed, the build is successful. The offline package is `artifact.tgz`.
+When the following information is printed, the build has succeeded:
 
-Offline package contents:
+```text
+Offline package artifact.tgz has been created successfully.
+```
+
+The offline package is `artifact.tgz` and contains the following:
 
 ```text
 artifact/
-├── artifact/kubekey-artifact.tgz    # Complete offline resource package
-└── artifact/tools/                  # Tool packages for different architectures
+├── kubekey-artifact.tgz    # Complete offline resource package
+└── tools/                  # Tool packages for different architectures
     ├── amd64/
     │   ├── kubekey-v4.x.x-linux-amd64.tar.gz
     │   ├── nerdctl-2.2.1-linux-amd64.tar.gz
@@ -169,126 +192,75 @@ artifact/
         └── oras_1.3.0_linux_arm64.tar.gz
 ```
 
----
+After transferring `artifact.tgz` to the target environment, the following steps are all executed in the target environment.
 
-## Install Cluster Using Offline Package
+## Install the Cluster Using the Offline Package
 
-Before installing the cluster, you need to specify a private image registry address. There are two options:
+Before installing the cluster, you need to specify a private image registry address. There are two ways:
 
-- **Option 1**: Install a private image registry separately. Please refer to [Image Registry Installation](../image-registry/README.md).
-- **Option 2**: Install the image registry together with the cluster. You need to add the corresponding configuration in `inventory.yaml` and `config.yaml` (see the command line installation steps below).
+- **Option 1**: Install the private image registry separately. Refer to [Image Registry Installation](https://github.com/kubesphere/kubekey/blob/main/docs/zh/image-registry/README.md).
+- **Option 2**: Install the image registry together with the cluster. See the installation steps below for details.
+
+### Choose an Installation Method
+
+Both of the following methods can complete the installation of Kubernetes and KubeSphere. **The installation results are identical. You only need to choose one entry point; there is no need to run both**:
+
+- **Method 1: Command Line Installation**: Suitable for scenarios where you are familiar with command line operations and need fine-grained cluster parameter configuration.
+- **Method 2: Web Installer Installation**: Suitable for scenarios where you want to complete node addition, parameter configuration, and installation validation through a graphical interface.
+
+> **Note**: Choose either one of the two methods; do not run them repeatedly. Both methods support the two private image registry deployment ways described above (install separately, or install together with the cluster).
 
 ### Extract the Offline Package
 
-```shell
+```bash
 tar -zxvf artifact.tgz
 ```
 
-### Method 1: Web Installer
-
-> **Tip**: The Web Installer does not currently support installing a private image registry. Please install it separately beforehand by referring to [Image Registry Installation](../image-registry/README.md).
+### Method 1: Command Line Installation
 
 #### 1. Enter the Offline Package Directory and Extract Tools
 
-KubeKey tools are located in the `tools/{arch}/` directory. Extract the corresponding tool based on your machine's architecture:
+KubeKey tools are located in the `tools/{arch}/` directory. Extract the corresponding tool based on the architecture of the installation machine.
 
-```shell
-# Check machine architecture
+Check the machine architecture:
+
+```bash
 uname -m
 ```
 
-Extract KubeKey to the offline package directory
+Enter the offline package directory:
 
-```shell
+```bash
 cd artifact/
-tar -zxvf tools/{arch}/kubekey-v4.x.x-linux-{arch}.tar.gz .
 ```
 
-#### 2. Push Images to the Private Image Registry
+Extract KubeKey to the offline package directory:
 
-Execute the following command to push images from the offline package to the deployed private image registry:
-
-```shell
-kk artifact images --push -c config.yaml -a kubekey-artifact.tgz
+```bash
+tar -zxvf tools/$(uname -m)/kubekey-v4.x.x-linux-$(uname -m).tar.gz -C .
 ```
 
-> **Note**: Before executing, make sure the private image registry address is correctly configured in `config.yaml`.
+#### 2. Push Images to the Private Image Registry (Option 1 only: install the private image registry separately)
 
-Example `config.yaml`:
+> **Note**: Only when using **Option 1 (install the private image registry separately)** do you need to manually execute this step to push the images in the offline package to the deployed private image registry. If you use **Option 2 (install the image registry together with the cluster)**, KubeKey automatically deploys the image registry and pushes the images when executing `kk create cluster`. **Skip this step in that case.**
 
-```yaml
-apiVersion: kubekey.kubesphere.io/v1
-kind: Config
-spec:
-  image_registry:
-    auth:
-      registry: dockerhub.kubekey.local
-      username: admin
-      password: Harbor12345
-      skip_tls_verify: false
-      plain_http: false
+Execute the following command to push the images in the offline package to the deployed private image registry:
+
+```bash
+./kk artifact images --push -c config.yaml -a kubekey-artifact.tgz
 ```
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `spec.image_registry.auth.registry` | String | Yes | Private image registry address |
-| `spec.image_registry.auth.username` | String | Yes | Username for the private image registry |
-| `spec.image_registry.auth.password` | String | Yes | Password for the private image registry |
-| `spec.image_registry.auth.skip_tls_verify` | Boolean | No | Whether to skip TLS certificate verification. Default is `false` |
-| `spec.image_registry.auth.plain_http` | Boolean | No | Whether to use plain HTTP. Default is `false` |
-
-#### 3. Start the Web Installer
-
-```shell
-kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
-```
-
-If the following information is displayed, the Web Installer has started successfully:
-
-```
-Web server started successfully on port 8080
-```
-
-Do not close the command terminal. Open KubeKey's UI page in the browser via `http://<bootstrap-node-ip>:8080`.
-
-### Method 2: Command Line Installation
-
-> **Tip**: The command line supports installing the [Image Registry](../image-registry/README.md) separately. It also supports synchronous installation during cluster creation (just modify `inventory.yaml` and `config.yaml`).
-
-#### 1. Enter the Offline Package Directory
-
-KubeKey tools are located in the `tools/{arch}/` directory. Extract the corresponding tool based on your machine's architecture:
-
-```shell
-# Check machine architecture
-uname -m
-```
-
-Extract KubeKey to the offline package directory
-
-```shell
-tar -zxvf tools/{arch}/kubekey-v4.x.x-linux-{arch}.tar.gz .
-```
-
-#### 2. Push Images to the Private Image Registry
-
-Execute the following command to push images from the offline package to the deployed private image registry:
-
-```shell
-kk artifact images --push -c config.yaml -a kubekey-artifact.tgz
-```
-
-> **Note**: Before executing, make sure the private image registry address is correctly configured in `config.yaml`.
+> **Note**: Before execution, make sure the private image registry address is correctly configured in the `config.yaml` used for pushing (that is, the `spec.image_registry.auth` field). This `config.yaml` is the same file used for packaging in the "Build Offline Package" section above.
 
 #### 3. Create Node Configuration File
 
 Execute the following command to create the node configuration file `inventory.yaml`:
 
-```shell
+```bash
 ./kk create inventory -o .
 ```
 
-`inventory.yaml` mainly defines the connection information of each node in the cluster. After execution, the node configuration file will be generated. Example:
+After execution, the node configuration file `inventory.yaml` will be generated. `inventory.yaml` is mainly used to set the connection information of each node in the cluster, for example:
 
 ```yaml
 apiVersion: kubekey.kubesphere.io/v1
@@ -296,136 +268,283 @@ kind: Inventory
 metadata:
   name: default
 spec:
-  hosts:
-    # localhost:
-    #   connector:
-    #     password: 123456
-    # node1:
-    #   connector:
-    #     type: ssh
-    #     host: node1
-    #     port: 22
-    #     user: root
-    #     password: 123456
-    #   internal_ipv4: 1.1.1.1
+  hosts: {}
   groups:
-    # All Kubernetes nodes
     k8s_cluster:
       groups:
         - kube_control_plane
         - kube_worker
-    # Control plane nodes
     kube_control_plane:
       hosts:
         - localhost
-    # Worker nodes
     kube_worker:
       hosts:
         - localhost
-    # etcd nodes (when etcd_deployment_type is external)
     etcd:
       hosts:
         - localhost
-#    image_registry:
-#      hosts:
-#        - localhost
-    # NFS nodes for registry storage and Kubernetes NFS storage
-#    nfs:
-#      hosts:
-#        - localhost
 ```
 
-**Configure node connection parameters in `spec:hosts`:**
+Node connection parameters in `spec.hosts`:
 
 | Parameter | Description |
-|-----------|-------------|
+|---|---|
 | `<key>` | Node name |
-| `<key>:connector` | Node connection info |
-| `<key>:connector:type` | Connection type. Supports `local` (local connection) and `ssh` (remote connection). Automatically identifies local or ssh based on the node name or IP |
-| `<key>:connector:host` | Address when using ssh to connect to the node |
-| `<key>:connector:port` | Port when using ssh to connect to the node. Default: `22` |
-| `<key>:connector:user` | Username when using ssh to connect to the node. Default: `root` |
-| `<key>:connector:password` | Password for the connection. For local connections this is the sudo password; for ssh connections this is the ssh password |
-| `<key>:connector:private_key` | Path to the ssh private key file. Either password or key must be provided |
-| `<key>:connector:private_key_content` | Content of the ssh private key. Can be used instead of a key file path |
-| `<key>:internal_ipv4` | IPv4 address used for cluster-internal communication |
-| `<key>:internal_ipv6` | IPv6 address used for cluster-internal communication |
+| `<key>.connector.type` | Node connection type. Supports `local` (local connection) and `ssh` (remote connection). KubeKey automatically identifies the connection type based on the node name or IP |
+| `<key>.connector.host` | Address when using SSH to connect to the node |
+| `<key>.connector.port` | Port when using SSH to connect to the node. Default: `22` |
+| `<key>.connector.user` | Username when using SSH to connect to the node. Default: `root` |
+| `<key>.connector.password` | Password for connecting to the node. For `local` connections this is the sudo password; for `ssh` connections this is the SSH password |
+| `<key>.connector.private_key` | Path to the SSH private key file. Either password or key must be provided |
+| `<key>.connector.private_key_content` | Content of the SSH private key. The key content can be used instead of the key file path |
+| `<key>.internal_ipv4` | IPv4 address used for cluster-internal communication |
+| `<key>.internal_ipv6` | IPv6 address used for cluster-internal communication |
 
-**Configure node role information in `spec:groups`:**
+Node role parameters in `spec.groups`:
 
 | Parameter | Description |
-|-----------|-------------|
-| `k8s_cluster` | Kubernetes cluster organization. Contains `kube_control_plane` and `kube_worker`, no additional configuration needed |
-| `kube_control_plane` | Control plane nodes in the Kubernetes cluster. Configure node names defined in `spec:hosts` under `kube_control_plane:hosts` |
-| `kube_worker` | Worker nodes in the Kubernetes cluster. Configure node names defined in `spec:hosts` under `kube_worker:hosts` |
-| `etcd` | etcd nodes in the Kubernetes cluster. Configure node names defined in `spec:hosts` under `etcd:hosts` |
+|---|---|
+| `k8s_cluster` | Kubernetes cluster node group. Contains `kube_control_plane` and `kube_worker`, no additional configuration needed |
+| `kube_control_plane` | Control plane nodes in the Kubernetes cluster. Configure node names defined in `spec.hosts` under `kube_control_plane.hosts` |
+| `kube_worker` | Worker nodes in the Kubernetes cluster. Configure node names defined in `spec.hosts` under `kube_worker.hosts` |
+| `etcd` | etcd nodes in the Kubernetes cluster. Configure node names defined in `spec.hosts` under `etcd.hosts` |
 | `image_registry` | Nodes used to create a private image registry. Usually required for offline installation |
 
->
-> If you choose to install the image registry together with the cluster, you need to add the `image_registry` node and group in `inventory.yaml`. Example:
->
-> ```yaml
-> spec:
->   hosts:
->     harbor1:
->       connector:
->         type: ssh
->         host: 172.16.0.1
->         port: 22
->         user: root
->         password: 123456
->       internal_ipv4: 172.16.0.1
->   groups:
->     image_registry:
->       hosts:
->         - harbor1
-> ```
+If you choose to install the image registry together with the cluster, you need to add the `image_registry` node and group in `inventory.yaml`. Example:
 
-#### 3. Create Installation Configuration File
-
-Execute the following command to create the installation configuration file `config.yaml`:
-
-```shell
-./kk create config --with-kubernetes v1.32.13 -o .
+```yaml
+spec:
+  hosts:
+    harbor1:
+      connector:
+        type: ssh
+        host: 172.16.0.1
+        port: 22
+        user: root
+        password: 123456
+      internal_ipv4: 172.16.0.1
+  groups:
+    image_registry:
+      hosts:
+        - harbor1
 ```
 
-Replace `v1.32.13` with the actual version you need. KubeKey supports Kubernetes `v1.23~v1.34` by default.
+#### 4. Create Installation Configuration File
 
-After execution, the installation configuration file `config-v1.32.13.yaml` will be generated.
+> **Note**: The configuration file generated in this step is used for **installing the cluster**, and is not the same file as the `config.yaml` used for **packaging** in the "Build Offline Package" section above.
 
->
-> If you choose to install the image registry together with the cluster, you need to add the image registry configuration in `config.yaml`:
->
-> ```yaml
-> spec:
->   image_registry:
->     # Image registry type. Supports harbor, docker-registry. Leave empty to skip installation.
->     type: "harbor"
->     auth:
->       # Address of the private image registry
->       registry: "dockerhub.kubekey.local"
-> ```
+Execute the following command to create the installation configuration file. The following example uses `v1.34.3`, which is already included in the offline resource list of the `config.yaml` example above:
 
-#### 4. Configure Cluster Parameters
+```bash
+./kk create config --with-kubernetes v1.34.3 -o .
+```
 
-Configure Kubernetes cluster information in `config-v1.32.13.yaml`:
+Replace `v1.34.3` with the actual Kubernetes version you need. Make sure the replaced version is included in the `spec.download.kubernetes.kube_version` list used when building the offline package.
 
-| Parameter | Description |
-|-----------|-------------|
-| `zone` | Download zone for files and images. Not needed for network access during offline installation, but effective when building the offline package |
-| `kubernetes` | Kubernetes-related configuration |
-| `etcd` | etcd-related configuration |
-| `image_registry` | Private image registry-related configuration |
-| `cri` | Container runtime-related configuration |
-| `cni` | Network plugin-related configuration |
-| `storage_class` | Storage plugin-related configuration |
-| `dns` | DNS-related configuration |
-| `image_manifests` | Additional images to be downloaded |
+After execution, the installation configuration file `config-v1.34.3.yaml` will be generated.
 
-> **Note**: For complete configuration reference, please refer to [Configuration Reference](../reference/config.md).
+If you choose to install the image registry together with the cluster, you need to add the image registry configuration in `config-v1.34.3.yaml`:
+
+```yaml
+apiVersion: kubekey.kubesphere.io/v1
+kind: Config
+spec:
+  download:
+    arch:
+      - amd64
+      - arm64
+    images:
+      policy: warn
+  image_registry:
+    auth:
+      registry: dockerhub.kubekey.local  # Replace with your actual private image registry address
+      username: admin
+      password: Harbor12345
+      skip_tls_verify: false
+      plain_http: false
+```
 
 #### 5. Install the Cluster
 
-```shell
-kk create cluster -a kubekey-artifact.tgz -i inventory.yaml -c config.yaml
+```bash
+./kk create cluster -a kubekey-artifact.tgz -i inventory.yaml -c config-v1.34.3.yaml
 ```
+
+#### 6. Install KubeSphere
+
+KubeKey v4.x decouples the installation of Kubernetes and KubeSphere. After Kubernetes is installed, you need to manually execute the following Helm commands to install KubeSphere.
+
+> **Note**: The `ks-core` Helm Chart package is included in `kubekey-artifact.tgz`. After extracting `kubekey-artifact.tgz`, it is located in the `charts/` directory.
+
+```bash
+# Extract the offline resource package to obtain the ks-core chart
+tar -zxvf kubekey-artifact.tgz
+```
+
+```bash
+helm upgrade --install \
+  -n kubesphere-system \
+  --create-namespace \
+  ks-core \
+  ./charts/ks-core-1.2.5.tgz \
+  --debug \
+  --wait \
+  --reset-values \
+  --set auditing.enable=true \
+  --set ha.enabled=true \
+  --set redisHA.enabled=true \
+  --set global.imageRegistry=dockerhub.kubekey.local \
+  --set extension.imageRegistry=dockerhub.kubekey.local
+```
+
+> **Note**:
+> - Replace the registry address above with your actual private image registry address.
+> - `auditing.enable`, `ha.enabled`, and `redisHA.enabled` are recommended configuration items for production environments and can be adjusted based on actual needs.
+> - Helm version must be >= 3.17.0.
+
+### Method 2: Web Installer Installation
+
+#### 1. Enter the Offline Package Directory and Extract Tools
+
+KubeKey tools are located in the `tools/{arch}/` directory. Extract the corresponding tool based on the architecture of the installation machine.
+
+Check the machine architecture:
+
+```bash
+uname -m
+```
+
+Enter the offline package directory:
+
+```bash
+cd artifact/
+```
+
+Extract KubeKey to the offline package directory:
+
+```bash
+tar -zxvf tools/$(uname -m)/kubekey-v4.x.x-linux-$(uname -m).tar.gz -C .
+```
+
+Extract `kubekey-artifact.tgz` to the working directory. This file contains all the resources required for installation: binaries, Helm chart packages, image files, and so on.
+
+```bash
+mkdir kubekey
+tar -zxvf kubekey-artifact.tgz -C kubekey
+```
+
+#### 2. Start Web Installer
+
+Extract the Web Installer package
+
+```shell
+tar -zxvf web-installer.tgz
+```
+
+Execute the following command to start the Web Installer page:
+
+```shell
+./kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
+```
+
+If the following information is displayed, the Web Installer has started successfully:
+
+```text
+Web server started successfully on port 8080
+```
+
+Do not close the command terminal.
+
+#### 3. Deploy Kubernetes and KubeSphere via Web Installer
+
+In the browser, visit `http://<Deployment Node IP Address>:8080` and click **Start Installation** to enter the deployment flow.
+
+##### 3.1 Add Cluster Nodes
+
+On the **Basic Information** page, add cluster nodes. Each node needs to be assigned a role, and the following three roles are supported:
+
+- **Master**: Control plane node, responsible for cluster scheduling and management. etcd is automatically installed on Master nodes.
+- **Worker**: Worker node, running actual business containers.
+- **Image**: Image registry node, used to automatically deploy a private image registry. This role is usually required for offline installation.
+
+The Web Installer supports the following three ways to add nodes:
+
+- **Manual addition**: Suitable for adding a single node. You need to fill in host name, IP address, SSH address, SSH authentication, and other information.
+- **File upload**: Suitable for batch adding nodes. Fill in the node information according to the template and upload the file.
+- **Node scan**: Suitable for automatically discovering nodes. You can scan nodes by IP CIDR and select the nodes to add based on the scan results.
+
+> **Note**: If you only add one node, the node role must be `Master & Worker`.
+
+##### 3.2 Modify Configuration Parameters
+
+Configure the parameters required for deploying Kubernetes and KubeSphere.
+
+Both the Kubernetes and KubeSphere Core tabs support **Form mode** and **YAML mode**. You can fill in the configuration information in the form (all parameters need to be configured), or directly edit the YAML file. For more configuration information, refer to the [Configuration Example](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md).
+
+> **Note**: If you choose to install the image registry, you need to add the following parameters in **YAML mode** to skip the online download:
+>
+> ```yaml
+> download:
+>   fetch: false
+> ```
+
+**Install Image Registry**
+
+If you need to deploy a private image registry together with the cluster, add an Image role node when adding nodes, and set the image registry type to `harbor` or `docker-registry` in the Kubernetes configuration parameters:
+
+- **Single-node image registry**: Add 1 Image role node and set the image registry type in the Kubernetes configuration parameters.
+- **Highly available image registry**: Add multiple Image role nodes (recommended ≥ 3), set the image registry type in the Kubernetes configuration parameters, and configure the highly available virtual IP of the image registry as the access entry.
+
+After configuration, click **Next**.
+
+##### 3.3 Installation Preview
+
+On the **Installation Preview** page, confirm that the version and other information are correct, then click **Next: Execute Installation** to start the installation. You can also go back to the previous step to modify the configuration parameters.
+
+##### 3.4 Installation
+
+Wait patiently for the installation to complete. After the installation is complete, the system will automatically enter the installation validation step.
+
+If an exception occurs during the installation, click **View Logs** to view the log details, and quit or initialize and reinstall.
+
+> **Note**: If you need to reinstall, modify configuration parameters, or clear the configuration on the Web Installer page, click the **Initialize** button on the left. It resets all tasks on the Kubernetes nodes and returns to the Basic Information page. The initialization operation is irreversible, so proceed with caution.
+
+##### 3.5 Installation Validation
+
+1. On the **Installation Validation** page, click **Start Detection**, and the system will automatically run the corresponding detection scripts to verify system availability.
+2. If the system detection passes, click **Complete** to view the KubeSphere access address, administrator username, and default password.
+3. Enter the access address in the web browser, log in to the KubeSphere Web console, and start using KubeSphere.
+
+> **Note**: Depending on your network environment, you may need to configure traffic forwarding rules and allow port `30880` in the firewall.
+
+## Access the KubeSphere Web Console
+
+After the installation is complete, visit the KubeSphere console address displayed in the installation result in your browser.
+
+Use the administrator username and default password displayed in the installation result to log in to the KubeSphere Web console. It is recommended that you change the default password immediately after the first login.
+
+## FAQ
+
+**Q: The version selected when packaging differs from the version used during installation?**
+A: The Kubernetes version used for installation must be included in the `spec.download.kubernetes.kube_version` list when building the offline package; otherwise, the images of that version are not included in the offline package.
+
+**Q: Can the Web Installer install a private image registry?**
+A: Yes. Add an Image role node when adding nodes, and set the image registry type (`harbor` or `docker-registry`) in the Kubernetes configuration parameters. To deploy a highly available image registry, add multiple Image role nodes and configure the highly available virtual IP of the image registry as the access entry.
+
+**Q: Image pushing fails?**
+A: Make sure the registry address, username, and password in `config.yaml` are correct, and that port `5000` is reachable over the network.
+
+**Q: Why does pushing images pull the hub.kubesphere.com.cn images online?**
+A: Before pushing images to the private image registry, KubeKey first checks the integrity of the local image files online (verifying whether the image manifests match the images in the registry). If no online check is needed, you can set `spec.download.fetch` to `false` in `config.yaml` to skip the online check and completely complete the image push offline.
+
+**Q: How do I add a single machine?**
+A: The node role must be `Master & Worker`.
+
+**Q: How do I re-run the installation?**
+A: On the Web Installer, click the **Initialize** button (this operation is irreversible); for the command line method, clean up the nodes and then re-run `kk create cluster`.
+
+**Q: How do I keep the CA certificate for adding nodes later?**
+A: If you use the KubeKey default certificate, keep the `<working directory>/kubekey/pki/root.crt` file after the installation (the default working directory is `/root/kubekey`). This certificate may be needed when adding nodes later.
+
+**Q: How do I install in an environment with Internet access?**
+A: Refer to [Online Installation of Kubernetes and KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/01-online-install-kubernetes-and-kubesphere/).

--- a/docs/en/installation/offline.md
+++ b/docs/en/installation/offline.md
@@ -1,55 +1,47 @@
-# Offline Installation of Kubernetes and KubeSphere
+# Offline Installation of Kubernetes
 
-This section describes how to deploy Kubernetes and KubeSphere using offline packages in an environment that cannot access the Internet.
+This section describes how to deploy Kubernetes using offline packages in an environment that cannot access the Internet.
 
 The installation process uses the open-source tool KubeKey v4.x. For more information about KubeKey, visit the [GitHub KubeKey repository](https://github.com/kubesphere/kubekey).
-
-> **Note**: KubeSphere Community Edition users need to build the offline package themselves while connected to the Internet; users of other KubeSphere editions can contact KubeSphere delivery service experts to obtain the latest offline package, and can skip the "Build Offline Package" section.
 
 > **Note**: The installation process depends on the `tar` utility for compression and decompression of software packages. Make sure it is pre-installed in your system environment. If `charts` is configured in `config.yaml`, make sure Helm is pre-installed on the packaging node.
 
 ## Overview
 
-Compared with online installation, offline installation requires you to first package the required components and images as an offline package on a machine that can access the Internet, and then transfer it to the target environment for installation. The overall flow is as follows:
+Offline installation requires you to first package the required components and images as an offline package on a machine that can access the Internet, and then transfer it to the target environment for installation. The overall flow is as follows:
 
 1. **Build the offline package** (on a networked machine): Download components and images and package them as `artifact.tgz`.
 2. **Transfer the offline package**: Copy `artifact.tgz` to the target environment (for example, via a storage medium or an intranet transfer).
-3. **Install the cluster** (in the target environment): Extract the offline package, push images to the private image registry (if installing the private image registry separately, i.e., Option 1, image pushing is completed automatically by the installation flow when KubeKey installs the image registry together with the cluster), and then install Kubernetes and KubeSphere.
+3. **Install the cluster** (in the target environment): Extract the offline package, push images to the private image registry (if installing the private image registry separately, i.e., Option 1, image pushing is completed automatically by the installation flow when KubeKey installs the image registry together with the cluster), and then install Kubernetes.
 
 ## Role Descriptions
 
-Offline installation involves the following four roles:
+Offline installation involves the following three roles:
 
 | Role | Responsibility | Minimum Configuration (per node) | Network Requirements |
 |---|---|---|---|
 | Packaging node | Downloads required software packages and images from the Internet and builds the offline package | CPU: 1 core, Memory: 1 GB, Disk: 150 GB | Must have Internet access |
-| Deployment node (runs the Web Installer service) | Executes `kk` commands on this node during installation to run the installation service | CPU: 1 core, Memory: 1 GB, Disk: 150 GB | Network connected to Kubernetes nodes |
 | Private image registry node | Stores the container images required by the cluster | CPU: 8 cores, Memory: 16 GB, Disk: 100 GB | Network connected to Kubernetes nodes |
 | Kubernetes node | Runs cluster workloads (no need to pre-install Kubernetes) | CPU: 2 cores, Memory: 4 GB, Disk: 40 GB | Inter-node network connected |
 
 > **Note**:
-> - A single host can simultaneously assume multiple roles, for example both a deployment node and a private image registry node, or both a deployment node and a Kubernetes node.
-> - The private image registry node and the Kubernetes node cannot be the same host, because the Kubernetes installation process restarts the container runtime on that node, which may interrupt the image registry service.
+> - A single host can simultaneously assume multiple roles, for example both a packaging node and a private image registry node, or both a packaging node and a Kubernetes node.
+> - If the packaging node does not assume a cluster role, you need to prepare another host as a Kubernetes node.
 
 ## Prerequisites
 
 > **Note**: The following are the prerequisites that Kubernetes nodes must satisfy.
 
-- You need to prepare at least 1 Linux server as a cluster node. In production environments, to ensure high availability, it is recommended to prepare at least 5 Linux servers, 3 of which act as control plane nodes and another 2 as worker nodes. If you install KubeSphere on multiple Linux servers, make sure all servers belong to the same subnet.
+- You need to prepare at least 1 Linux server as a cluster node. In production environments, to ensure high availability, it is recommended to prepare at least 5 Linux servers, 3 of which act as control plane nodes and another 2 as worker nodes. If you install Kubernetes on multiple Linux servers, make sure all servers belong to the same subnet.
 - The operating system and version of the cluster nodes must be Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, Debian 10, Debian 11, CentOS 8, AlmaLinux 9.0, or Kylin v10. The operating systems of multiple servers can be different. For support of other operating systems and versions, consult the official solution experts or delivery service experts of QingCloud.
 - In production environments, to ensure the cluster has sufficient compute and storage resources, it is recommended that each cluster node be configured with at least 8 CPU cores, 16 GB of memory, and 200 GB of disk space. In addition, it is recommended to mount at least another 200 GB of disk space under `/var/lib/docker` (for Docker) or `/var/lib/containerd` (for containerd) on each cluster node to store container runtime data.
-- In production environments, it is recommended to configure high availability for the KubeSphere cluster in advance to avoid service interruption when a single control plane node fails. For more information, see [Configure High Availability](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/).
-
-  > **Note**: If you plan multiple control plane nodes, be sure to configure high availability for the cluster in advance.
-
-- By default, KubeSphere uses the local disk space of cluster nodes as persistent storage. In production environments, it is recommended to configure an external storage system as persistent storage in advance. For more information, see [Configure External Persistent Storage](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/).
-- Make sure the DNS server addresses configured in the `/etc/resolv.conf` file are available on all cluster nodes. Otherwise, the KubeSphere cluster may experience domain name resolution issues.
+- Make sure the DNS server addresses configured in the `/etc/resolv.conf` file are available on all cluster nodes. Otherwise, the cluster may experience domain name resolution issues.
 - Make sure the `sudo`, `tar`, `curl`, and `openssl` commands are available on all cluster nodes.
 - Make sure the clocks of all cluster nodes are synchronized.
 
 ## Configure Firewall Rules
 
-KubeSphere requires specific ports and protocols for communication between services. If firewall is enabled in your infrastructure environment, you need to allow the required ports and protocols in the firewall settings. If firewall is not enabled in your infrastructure environment, you can skip this step.
+Kubernetes requires specific ports and protocols for communication between services. If firewall is enabled in your infrastructure environment, you need to allow the required ports and protocols in the firewall settings. If firewall is not enabled in your infrastructure environment, you can skip this step.
 
 The following table lists the ports and protocols that need to be allowed in the firewall.
 
@@ -140,7 +132,7 @@ spec:
 | `spec.download.image_registry.type` | Image registry types. Supports `harbor` and `docker-registry` |
 | `spec.download.iso` | List of operating systems for building ISO dependency packages, used to install system dependencies |
 
-### Get KubeKey and Web Installer
+### Get KubeKey
 
 If your access to GitHub or Google APIs is restricted, set the following environment variable:
 
@@ -148,7 +140,7 @@ If your access to GitHub or Google APIs is restricted, set the following environ
 export KKZONE=cn
 ```
 
-Execute the following command to download KubeKey and Web Installer:
+Execute the following command to download KubeKey:
 
 ```bash
 curl -sfL https://get-kk.kubesphere.io | sh -
@@ -159,7 +151,6 @@ After execution, the following files will be generated in the current directory:
 | Original File | Extracted File |
 |---|---|
 | `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`: KubeKey binary |
-| `web-installer.tgz` | `dist`: Web page resources; `host-check.yaml`, `kubernetes`, `kubesphere`: Task template files; `schema`: Configuration form definitions; `README.md`: Installation documentation |
 | `package.sh` | Build script for the offline package (automatically generated by the download command; internally calls `kk artifact export` to complete download and packaging) |
 
 ### Build the Offline Package
@@ -201,22 +192,13 @@ Before installing the cluster, you need to specify a private image registry addr
 - **Option 1**: Install the private image registry separately. Refer to [Image Registry Installation](https://github.com/kubesphere/kubekey/blob/main/docs/zh/image-registry/README.md).
 - **Option 2**: Install the image registry together with the cluster. See the installation steps below for details.
 
-### Choose an Installation Method
-
-Both of the following methods can complete the installation of Kubernetes and KubeSphere. **The installation results are identical. You only need to choose one entry point; there is no need to run both**:
-
-- **Method 1: Command Line Installation**: Suitable for scenarios where you are familiar with command line operations and need fine-grained cluster parameter configuration.
-- **Method 2: Web Installer Installation**: Suitable for scenarios where you want to complete node addition, parameter configuration, and installation validation through a graphical interface.
-
-> **Note**: Choose either one of the two methods; do not run them repeatedly. Both methods support the two private image registry deployment ways described above (install separately, or install together with the cluster).
-
 ### Extract the Offline Package
 
 ```bash
 tar -zxvf artifact.tgz
 ```
 
-### Method 1: Command Line Installation
+### Install the Cluster
 
 #### 1. Enter the Offline Package Directory and Extract Tools
 
@@ -250,7 +232,7 @@ Execute the following command to push the images in the offline package to the d
 ./kk artifact images --push -c config.yaml -a kubekey-artifact.tgz
 ```
 
-> **Note**: Before execution, make sure the private image registry address is correctly configured in the `config.yaml` used for pushing (that is, the `spec.image_registry.auth` field). This `config.yaml` is the same file used for packaging in the "Build Offline Package" section above.
+> **Note**: Before execution, make sure the private image registry address is correctly configured in the `config.yaml` used for pushing (that is, the `spec.image_registry.auth` field). This `config.yaml` is the same file used for packaging in the "Build the Offline Package" section above.
 
 #### 3. Create Node Configuration File
 
@@ -331,7 +313,7 @@ spec:
 
 #### 4. Create Installation Configuration File
 
-> **Note**: The configuration file generated in this step is used for **installing the cluster**, and is not the same file as the `config.yaml` used for **packaging** in the "Build Offline Package" section above.
+> **Note**: The configuration file generated in this step is used for **installing the cluster**, and is not the same file as the `config.yaml` used for **packaging** in the "Build the Offline Package" section above.
 
 Execute the following command to create the installation configuration file. The following example uses `v1.34.3`, which is already included in the offline resource list of the `config.yaml` example above:
 
@@ -370,166 +352,16 @@ spec:
 ./kk create cluster -a kubekey-artifact.tgz -i inventory.yaml -c config-v1.34.3.yaml
 ```
 
-#### 6. Install KubeSphere
-
-KubeKey v4.x decouples the installation of Kubernetes and KubeSphere. After Kubernetes is installed, you need to manually execute the following Helm commands to install KubeSphere.
-
-> **Note**: The `ks-core` Helm Chart package is included in `kubekey-artifact.tgz`. After extracting `kubekey-artifact.tgz`, it is located in the `charts/` directory.
-
-```bash
-# Extract the offline resource package to obtain the ks-core chart
-tar -zxvf kubekey-artifact.tgz
-```
-
-```bash
-helm upgrade --install \
-  -n kubesphere-system \
-  --create-namespace \
-  ks-core \
-  ./charts/ks-core-1.2.5.tgz \
-  --debug \
-  --wait \
-  --reset-values \
-  --set auditing.enable=true \
-  --set ha.enabled=true \
-  --set redisHA.enabled=true \
-  --set global.imageRegistry=dockerhub.kubekey.local \
-  --set extension.imageRegistry=dockerhub.kubekey.local
-```
-
-> **Note**:
-> - Replace the registry address above with your actual private image registry address.
-> - `auditing.enable`, `ha.enabled`, and `redisHA.enabled` are recommended configuration items for production environments and can be adjusted based on actual needs.
-> - Helm version must be >= 3.17.0.
-
-### Method 2: Web Installer Installation
-
-#### 1. Enter the Offline Package Directory and Extract Tools
-
-KubeKey tools are located in the `tools/{arch}/` directory. Extract the corresponding tool based on the architecture of the installation machine.
-
-Check the machine architecture:
-
-```bash
-uname -m
-```
-
-Enter the offline package directory:
-
-```bash
-cd artifact/
-```
-
-Extract KubeKey to the offline package directory:
-
-```bash
-tar -zxvf tools/$(uname -m)/kubekey-v4.x.x-linux-$(uname -m).tar.gz -C .
-```
-
-Extract `kubekey-artifact.tgz` to the working directory. This file contains all the resources required for installation: binaries, Helm chart packages, image files, and so on.
-
-```bash
-mkdir kubekey
-tar -zxvf kubekey-artifact.tgz -C kubekey
-```
-
-#### 2. Start Web Installer
-
-Extract the Web Installer package
+After the installation is complete, you can check the cluster node status with `kubectl get nodes`:
 
 ```shell
-tar -zxvf web-installer.tgz
+kubectl get nodes
 ```
-
-Execute the following command to start the Web Installer page:
-
-```shell
-./kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
-```
-
-If the following information is displayed, the Web Installer has started successfully:
-
-```text
-Web server started successfully on port 8080
-```
-
-Do not close the command terminal.
-
-#### 3. Deploy Kubernetes and KubeSphere via Web Installer
-
-In the browser, visit `http://<Deployment Node IP Address>:8080` and click **Start Installation** to enter the deployment flow.
-
-##### 3.1 Add Cluster Nodes
-
-On the **Basic Information** page, add cluster nodes. Each node needs to be assigned a role, and the following three roles are supported:
-
-- **Master**: Control plane node, responsible for cluster scheduling and management. etcd is automatically installed on Master nodes.
-- **Worker**: Worker node, running actual business containers.
-- **Image**: Image registry node, used to automatically deploy a private image registry. This role is usually required for offline installation.
-
-The Web Installer supports the following three ways to add nodes:
-
-- **Manual addition**: Suitable for adding a single node. You need to fill in host name, IP address, SSH address, SSH authentication, and other information.
-- **File upload**: Suitable for batch adding nodes. Fill in the node information according to the template and upload the file.
-- **Node scan**: Suitable for automatically discovering nodes. You can scan nodes by IP CIDR and select the nodes to add based on the scan results.
-
-> **Note**: If you only add one node, the node role must be `Master & Worker`.
-
-##### 3.2 Modify Configuration Parameters
-
-Configure the parameters required for deploying Kubernetes and KubeSphere.
-
-Both the Kubernetes and KubeSphere Core tabs support **Form mode** and **YAML mode**. You can fill in the configuration information in the form (all parameters need to be configured), or directly edit the YAML file. For more configuration information, refer to the [Configuration Example](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md).
-
-> **Note**: If you choose to install the image registry, you need to add the following parameters in **YAML mode** to skip the online download:
->
-> ```yaml
-> download:
->   fetch: false
-> ```
-
-**Install Image Registry**
-
-If you need to deploy a private image registry together with the cluster, add an Image role node when adding nodes, and set the image registry type to `harbor` or `docker-registry` in the Kubernetes configuration parameters:
-
-- **Single-node image registry**: Add 1 Image role node and set the image registry type in the Kubernetes configuration parameters.
-- **Highly available image registry**: Add multiple Image role nodes (recommended ≥ 3), set the image registry type in the Kubernetes configuration parameters, and configure the highly available virtual IP of the image registry as the access entry.
-
-After configuration, click **Next**.
-
-##### 3.3 Installation Preview
-
-On the **Installation Preview** page, confirm that the version and other information are correct, then click **Next: Execute Installation** to start the installation. You can also go back to the previous step to modify the configuration parameters.
-
-##### 3.4 Installation
-
-Wait patiently for the installation to complete. After the installation is complete, the system will automatically enter the installation validation step.
-
-If an exception occurs during the installation, click **View Logs** to view the log details, and quit or initialize and reinstall.
-
-> **Note**: If you need to reinstall, modify configuration parameters, or clear the configuration on the Web Installer page, click the **Initialize** button on the left. It resets all tasks on the Kubernetes nodes and returns to the Basic Information page. The initialization operation is irreversible, so proceed with caution.
-
-##### 3.5 Installation Validation
-
-1. On the **Installation Validation** page, click **Start Detection**, and the system will automatically run the corresponding detection scripts to verify system availability.
-2. If the system detection passes, click **Complete** to view the KubeSphere access address, administrator username, and default password.
-3. Enter the access address in the web browser, log in to the KubeSphere Web console, and start using KubeSphere.
-
-> **Note**: Depending on your network environment, you may need to configure traffic forwarding rules and allow port `30880` in the firewall.
-
-## Access the KubeSphere Web Console
-
-After the installation is complete, visit the KubeSphere console address displayed in the installation result in your browser.
-
-Use the administrator username and default password displayed in the installation result to log in to the KubeSphere Web console. It is recommended that you change the default password immediately after the first login.
 
 ## FAQ
 
 **Q: The version selected when packaging differs from the version used during installation?**
 A: The Kubernetes version used for installation must be included in the `spec.download.kubernetes.kube_version` list when building the offline package; otherwise, the images of that version are not included in the offline package.
-
-**Q: Can the Web Installer install a private image registry?**
-A: Yes. Add an Image role node when adding nodes, and set the image registry type (`harbor` or `docker-registry`) in the Kubernetes configuration parameters. To deploy a highly available image registry, add multiple Image role nodes and configure the highly available virtual IP of the image registry as the access entry.
 
 **Q: Image pushing fails?**
 A: Make sure the registry address, username, and password in `config.yaml` are correct, and that port `5000` is reachable over the network.
@@ -541,10 +373,10 @@ A: Before pushing images to the private image registry, KubeKey first checks the
 A: The node role must be `Master & Worker`.
 
 **Q: How do I re-run the installation?**
-A: On the Web Installer, click the **Initialize** button (this operation is irreversible); for the command line method, clean up the nodes and then re-run `kk create cluster`.
+A: For the command line method, clean up the nodes and then re-run `kk create cluster`.
 
 **Q: How do I keep the CA certificate for adding nodes later?**
 A: If you use the KubeKey default certificate, keep the `<working directory>/kubekey/pki/root.crt` file after the installation (the default working directory is `/root/kubekey`). This certificate may be needed when adding nodes later.
 
 **Q: How do I install in an environment with Internet access?**
-A: Refer to [Online Installation of Kubernetes and KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/01-online-install-kubernetes-and-kubesphere/).
+A: Refer to [Online Installation of Kubernetes](./online/).

--- a/docs/en/installation/online.md
+++ b/docs/en/installation/online.md
@@ -1,6 +1,6 @@
-# Online Installation of Kubernetes and KubeSphere
+# Online Installation of Kubernetes
 
-This section describes how to install Kubernetes and KubeSphere in an environment with Internet access.
+This section describes how to install Kubernetes in an environment with Internet access.
 
 The installation process uses the open-source tool KubeKey v4.x. For more information about KubeKey, visit the [GitHub KubeKey repository](https://github.com/kubesphere/kubekey).
 
@@ -11,24 +11,16 @@ Before proceeding, it is recommended to understand the following basic concepts:
 - **Control plane node (Master)**: Responsible for cluster scheduling and management, and typically does not run business workloads.
 - **Worker node**: A workload node that runs actual business containers.
 - **etcd**: A distributed key-value store that holds all critical state data of the cluster.
-- **Container runtime**: The underlying software responsible for creating and running containers. KubeKey supports automatically installing two container runtimes: Docker and containerd. If you need to use CRI-O or iSula, install it manually in advance; however, their compatibility with KubeSphere has not been fully verified.
+- **Container runtime**: The underlying software responsible for creating and running containers. KubeKey supports automatically installing two container runtimes: Docker and containerd.
 - **CNI (Container Network Interface)**: Provides network connectivity for Pods in the cluster. Common plugins include Calico, Cilium, Flannel, and so on.
 
 ## Prerequisites
 
-- At least 1 Linux server is required as a cluster node. In production environments, to ensure high availability, it is recommended to prepare at least 5 Linux servers, 3 of which act as control plane nodes and another 2 as worker nodes. If you install KubeSphere on multiple Linux servers, make sure all servers belong to the same subnet.
+- At least 1 Linux server is required as a cluster node. In production environments, to ensure high availability, it is recommended to prepare at least 5 Linux servers, 3 of which act as control plane nodes and another 2 as worker nodes. If you install Kubernetes on multiple Linux servers, make sure all servers belong to the same subnet.
 - The operating system and version of the cluster nodes must be Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, Debian 10, Debian 11, CentOS 8, AlmaLinux 9.0, or Kylin v10. The operating systems of multiple servers can be different. For support of other operating systems and versions, consult the official solution experts or delivery service experts of QingCloud.
 - In production environments, to ensure the cluster has sufficient compute and storage resources, it is recommended that each cluster node be configured with at least 8 CPU cores, 16 GB of memory, and 200 GB of disk space. In addition, it is recommended to mount at least another 200 GB of disk space under `/var/lib/docker` (for Docker) or `/var/lib/containerd` (for containerd) on each cluster node to store container runtime data.
-- In production environments, it is recommended to configure high availability for the KubeSphere cluster in advance to avoid service interruption when a single control plane node fails. For more information, see [Configure High Availability](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/).
-
-  > **Note**: If you plan multiple control plane nodes, be sure to configure high availability for the cluster in advance.
-
-- By default, KubeSphere uses the local disk space of cluster nodes as persistent storage. In production environments, it is recommended to configure an external storage system as persistent storage in advance. For more information, see [Configure External Persistent Storage](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/).
 - If the cluster nodes do not have a container runtime installed, the installation tool KubeKey will automatically install a container runtime on each cluster node during the installation process. KubeKey installs containerd by default; you can also specify Docker as the container runtime in the configuration file.
-
-  > **Note**: If you need to use CRI-O or iSula, install it manually in advance; however, their compatibility with KubeSphere has not been fully verified and unknown issues may exist.
-
-- Make sure the DNS server addresses configured in the `/etc/resolv.conf` file are available on all cluster nodes. Otherwise, the KubeSphere cluster may experience domain name resolution issues.
+- Make sure the DNS server addresses configured in the `/etc/resolv.conf` file are available on all cluster nodes. Otherwise, the cluster may experience domain name resolution issues.
 - Make sure the `sudo`, `tar`, `curl`, and `openssl` commands are available on all cluster nodes.
 - Make sure the clocks of all cluster nodes are synchronized.
 
@@ -36,7 +28,7 @@ Before proceeding, it is recommended to understand the following basic concepts:
 
 ## Configure Firewall Rules
 
-KubeSphere requires specific ports and protocols for communication between services. If firewall is enabled in your infrastructure environment, you need to allow the required ports and protocols in the firewall settings. If firewall is not enabled in your infrastructure environment, you can skip this step.
+Kubernetes requires specific ports and protocols for communication between services. If firewall is enabled in your infrastructure environment, you need to allow the required ports and protocols in the firewall settings. If firewall is not enabled in your infrastructure environment, you can skip this step.
 
 The following table lists the ports and protocols that need to be allowed in the firewall.
 
@@ -57,18 +49,11 @@ The following table lists the ports and protocols that need to be allowed in the
 
 If you need to temporarily disable the firewall in a test environment, you can run `systemctl stop firewalld`; in production environments, please allow the required ports precisely according to the table above.
 
-## Choose an Installation Method
+## Install Kubernetes
 
-Both of the following methods can complete the installation of Kubernetes and KubeSphere. **The installation results are identical. You only need to choose one entry point; there is no need to run both**:
+Only the command line installation method is currently supported.
 
-- **Method 1: Command Line Installation**: Suitable for scenarios where you are familiar with command line operations and need fine-grained cluster parameter configuration.
-- **Method 2: Web Installer Installation**: Suitable for scenarios where you want to complete node addition, parameter configuration, and installation validation through a graphical interface.
-
-> **Note**: Choose either one of the two methods; do not run them repeatedly.
-
-### Method 1: Command Line Installation
-
-#### 1. Download KubeKey
+### 1. Download KubeKey
 
 If your access to GitHub / Google APIs is restricted, set the following environment variable:
 
@@ -86,7 +71,7 @@ curl -sfL https://get-kk.kubesphere.io | SKIP_WEB_INSTALLER=true SKIP_PACKAGE=tr
 
 After execution, the `kk` binary will be generated in the current directory.
 
-#### 2. Create Node Configuration File
+### 2. Create Node Configuration File
 
 Execute the following command to create the node configuration file `inventory.yaml`:
 
@@ -167,7 +152,7 @@ spec:
 | `etcd` | etcd nodes in the Kubernetes cluster. Configure node names defined in `spec.hosts` under `etcd.hosts` |
 | `image_registry` | Nodes used to create a private image registry. Not required for online installation |
 
-#### 3. Create Installation Configuration File
+### 3. Create Installation Configuration File
 
 Execute the following command to create the installation configuration file `config.yaml`:
 
@@ -175,11 +160,11 @@ Execute the following command to create the installation configuration file `con
 ./kk create config --with-kubernetes <Kubernetes version> -o .
 ```
 
-Replace `<Kubernetes version>` with the actual version you need, for example `v1.34.3`. KubeSphere supports Kubernetes `v1.23` ~ `v1.34` by default.
+Replace `<Kubernetes version>` with the actual version you need, for example `v1.34.3`. Kubernetes `v1.23` ~ `v1.34` is supported by default.
 
 After execution, the installation configuration file `config-<Kubernetes version>.yaml` will be generated.
 
-#### 4. Configure Cluster Parameters
+### 4. Configure Cluster Parameters
 
 Configure the Kubernetes cluster information in `config-<Kubernetes version>.yaml`. The commonly used parameters are as follows:
 
@@ -197,7 +182,7 @@ Configure the Kubernetes cluster information in `config-<Kubernetes version>.yam
 
 > **Note**: For the complete field descriptions of each parameter, refer to the [Configuration Reference](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md).
 
-#### 5. Install Kubernetes
+### 5. Install Kubernetes
 
 Execute the following command to install Kubernetes:
 
@@ -211,185 +196,22 @@ If you have renamed the installation configuration file to `config.yaml`, you ca
 ./kk create cluster -i inventory.yaml -c config.yaml
 ```
 
-#### 6. Install KubeSphere
-
-KubeKey v4.x decouples the installation of Kubernetes and KubeSphere. After Kubernetes is installed, you need to manually execute the following Helm commands to install KubeSphere.
-
-> **Note**: The Web Installer installation method completes the KubeSphere installation automatically, so this step is not required.
-
-Execute the following command to install KubeSphere:
+After the installation is complete, you can check the cluster node status with `kubectl get nodes`:
 
 ```shell
-chart=oci://hub.kubesphere.com.cn/kse/ks-core
-version=1.2.5
-helm upgrade --install -n kubesphere-system --create-namespace ks-core $chart \
-  --debug --wait --version $version --reset-values --take-ownership \
-  --set global.imageRegistry=hub.kubesphere.com.cn,extension.imageRegistry=hub.kubesphere.com.cn
+kubectl get nodes
 ```
-
-> **Note**:
-> - `--take-ownership` is used to take over resources with the same name that already exist in the cluster in order to avoid installation conflicts. This parameter requires Helm >= 3.17.0.
-
-If the following information is displayed, KubeSphere has been installed successfully:
-
-```text
-NOTES:
-Thank you for choosing KubeSphere Helm Chart.
-
-Please be patient and wait for several seconds for the KubeSphere deployment to complete.
-
-1. Wait for Deployment Completion
-
-    Confirm that all KubeSphere components are running by executing the following command:
-
-    kubectl get pods -n kubesphere-system
-
-2. Access the KubeSphere Console
-
-    Once the deployment is complete, you can access the KubeSphere console using the following URL:
-
-    http://<Node IP Address>:30880
-
-3. Login to KubeSphere Console
-
-    Use the following credentials to log in:
-
-    Account: admin
-    Password: P@88w0rd
-
-NOTE: It is highly recommended to change the default password immediately after the first login.
-```
-
-### Method 2: Web Installer Installation
-
-#### 1. Download KubeKey and Web Installer
-
-If your access to GitHub / Google APIs is restricted, set the following environment variable:
-
-```shell
-export KKZONE=cn
-```
-
-Execute the following command to download the latest version of KubeKey (including Web Installer):
-
-```shell
-curl -sfL https://get-kk.kubesphere.io | SKIP_PACKAGE=true sh -
-```
-
-> **Note**: `SKIP_PACKAGE=true` skips the download of the offline packaging script (`package.sh`), which is not needed for the online installation scenario.
-
-After execution, the following files will be generated in the current directory:
-
-| Original File | Extracted File |
-|---|---|
-| `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`: KubeKey binary |
-| `web-installer.tgz` | `dist`: Web page resources; `host-check.yaml`, `kubernetes`, `kubesphere`: Task template files; `schema`: Configuration form definitions; `README.md`: Installation documentation |
-
-#### 2. Start Web Installer
-
-Extract the Web Installer package
-
-```shell
-tar -zxvf web-installer.tgz
-```
-
-Execute the following command to start the Web Installer page:
-
-```shell
-./kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
-```
-
-If the following message is displayed, the Web Installer has started successfully:
-
-```text
-Web server started successfully on port 8080
-```
-
-Do not close the command terminal.
-
-#### 3. Deploy Kubernetes and KubeSphere via Web Installer
-
-In the browser, visit `http://<Bootstrap Node IP Address>:8080` to open the KubeKey Web Installer page.
-
-Click **Start Installation** on the page to enter the installation flow.
-
-##### 3.1. Add Cluster Nodes
-
-On the **Basic Information** page, add cluster nodes. Each node needs to be assigned a role, and the following three roles are supported:
-
-- **Master**: Control plane node, responsible for cluster scheduling and management. etcd is automatically installed on Master nodes.
-- **Worker**: Worker node, running actual business containers.
-- **Image**: Image registry node, used to automatically deploy a private image registry. This role is usually not required for online installation.
-
-The Web Installer supports the following three ways to add nodes:
-
-- **Manual addition**: Suitable for adding a single node. You need to fill in host name, IP address, SSH address, SSH authentication, and other information.
-- **File upload**: Suitable for batch adding nodes. Fill in the node information according to the template and upload the file.
-- **Node scan**: Suitable for automatically discovering nodes. You can scan nodes by IP CIDR and select the nodes to add based on the scan results.
-
-> **Note**: If you only add one node, the node role must be `Master & Worker`.
-
-##### 3.2. Modify Configuration Parameters
-
-On the installation configuration page, fill in the parameters required for deploying Kubernetes and KubeSphere.
-
-Both the Kubernetes and KubeSphere Core tabs support **Form mode** and **YAML mode**. You can fill in the configuration information in the form, or directly edit the YAML file. For more configuration parameters, refer to the [Configuration Example](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md).
-
-> **Note**: If your access to GitHub / Google APIs is restricted, switch to YAML mode and add the `zone: cn` parameter so that KubeKey downloads binaries from domestic addresses. At the same time, it is recommended to set the image registry address to `hub.kubesphere.com.cn`. After switching to domestic sources, only a limited number of Kubernetes versions are supported. For the specific supported versions, refer to the Kubernetes tab on the [get-images.kubesphere.io](https://get-images.kubesphere.io) page.
-
-**Install Image Registry (Optional)**
-
-If you need to deploy a private image registry together with the cluster, add an Image role node when adding nodes, and set the image registry type to `harbor` or `docker-registry` in the Kubernetes configuration parameters:
-
-- **Single-node image registry**: Add 1 Image role node and set the image registry type in the Kubernetes configuration parameters.
-- **Highly available image registry**: Add multiple Image role nodes (recommended ≥ 3), set the image registry type in the Kubernetes configuration parameters, and configure the highly available virtual IP of the image registry as the access entry.
-
-After configuration, click **Next**.
-
-##### 3.3. Preview Installation Configuration
-
-On the **Installation Preview** page, confirm that the version, nodes, network, storage, and other information are correct, then click **Next: Execute Installation** to start the installation.
-
-If you need to modify the configuration, you can go back to the previous step to re-edit the configuration parameters.
-
-##### 3.4. Execute Installation
-
-Wait for the installation to complete. After the installation is complete, the system will automatically enter the installation validation flow.
-
-If an exception occurs during the installation, you can click **View Logs** to view the log details and troubleshoot the problem based on the log information. If necessary, you can force-quit the current installation flow or initialize and reinstall.
-
-> **Note**: If you need to reinstall, modify configuration parameters, or clear the configuration on the Web Installer page, click the **Initialize** button on the left. The initialization operation resets all tasks on the Kubernetes nodes and returns to the Basic Information page. This operation is irreversible, so proceed with caution.
-
-##### 3.5. Installation Validation
-
-1. On the **Installation Validation** page, click **Start Detection**, and the system will automatically run detection scripts to verify system availability.
-2. If the system detection passes, click **Complete** to view the KubeSphere access address, administrator username, and default password.
-3. Enter the access address in the browser, log in to the KubeSphere Web console, and start using KubeSphere.
-
-> **Note**: Depending on your network environment, you may need to configure traffic forwarding rules and allow port `30880` in the firewall.
-
-## Access the KubeSphere Web Console
-
-After the installation is complete, visit the KubeSphere console address displayed in the installation result in your browser.
-
-Use the administrator username and default password displayed in the installation result to log in to the KubeSphere Web console. It is recommended that you change the default password immediately after the first login.
 
 ## FAQ
 
 **Q: Download times out or is slow when accessing GitHub?**
 A: First run `export KKZONE=cn` to use domestic sources before downloading. After switching to domestic sources, only a limited number of Kubernetes versions are supported. Set the Kubernetes version to one of the versions listed in the **Kubernetes tab** on the [get-images.kubesphere.io](https://get-images.kubesphere.io) page (specified via `./kk create config --with-kubernetes <version> -o .`).
 
-**Q: The console cannot be accessed after single-node deployment?**
-A: For single-node deployment, the node role must be `Master & Worker`; at the same time, make sure port `30880` is allowed in the firewall.
-
 **Q: How do I re-run the installation?**
-A: On the Web Installer, click the **Initialize** button (this operation is irreversible); for the command line method, clean up the nodes with `kk delete cluster --all --with-data` and then re-run `kk create cluster`.
+A: First clean up the nodes with `kk delete cluster --all --with-data`, then re-run `kk create cluster`.
 
 **Q: How do I keep the CA certificate for adding nodes later?**
 A: If you use the KubeKey default certificate, keep the `<working directory>/kubekey/pki/root.crt` file after the installation (the default working directory is `/root/kubekey`). This certificate may be needed when adding nodes later.
 
 **Q: What extra recommendations are there for production environments?**
 A: It is recommended to prepare at least 5 nodes, configure high availability in advance, and configure external persistent storage to avoid using node-local disk space as persistent storage.
-
-**Q: How do I install in an environment without Internet access?**
-A: Refer to [Offline Installation of Kubernetes and KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/02-offline-install-kubernetes-and-kubesphere/).

--- a/docs/en/installation/online.md
+++ b/docs/en/installation/online.md
@@ -1,22 +1,76 @@
 # Online Installation of Kubernetes and KubeSphere
 
-This section describes how to install Kubernetes and KubeSphere in an Internet-accessible environment.
+This section describes how to install Kubernetes and KubeSphere in an environment with Internet access.
 
-The installation process uses KubeKey. For more information about KubeKey, visit the [GitHub KubeKey repository](https://github.com/kubesphere/kubekey).
+The installation process uses the open-source tool KubeKey v4.x. For more information about KubeKey, visit the [GitHub KubeKey repository](https://github.com/kubesphere/kubekey).
+
+## Core Concepts
+
+Before proceeding, it is recommended to understand the following basic concepts:
+
+- **Control plane node (Master)**: Responsible for cluster scheduling and management, and typically does not run business workloads.
+- **Worker node**: A workload node that runs actual business containers.
+- **etcd**: A distributed key-value store that holds all critical state data of the cluster.
+- **Container runtime**: The underlying software responsible for creating and running containers. KubeKey supports automatically installing two container runtimes: Docker and containerd. If you need to use CRI-O or iSula, install it manually in advance; however, their compatibility with KubeSphere has not been fully verified.
+- **CNI (Container Network Interface)**: Provides network connectivity for Pods in the cluster. Common plugins include Calico, Cilium, Flannel, and so on.
 
 ## Prerequisites
 
-The installation process depends on the `tar` utility for compression and decompression. Please ensure it is pre-installed in your system environment.
+- At least 1 Linux server is required as a cluster node. In production environments, to ensure high availability, it is recommended to prepare at least 5 Linux servers, 3 of which act as control plane nodes and another 2 as worker nodes. If you install KubeSphere on multiple Linux servers, make sure all servers belong to the same subnet.
+- The operating system and version of the cluster nodes must be Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, Debian 10, Debian 11, CentOS 8, AlmaLinux 9.0, or Kylin v10. The operating systems of multiple servers can be different. For support of other operating systems and versions, consult the official solution experts or delivery service experts of QingCloud.
+- In production environments, to ensure the cluster has sufficient compute and storage resources, it is recommended that each cluster node be configured with at least 8 CPU cores, 16 GB of memory, and 200 GB of disk space. In addition, it is recommended to mount at least another 200 GB of disk space under `/var/lib/docker` (for Docker) or `/var/lib/containerd` (for containerd) on each cluster node to store container runtime data.
+- In production environments, it is recommended to configure high availability for the KubeSphere cluster in advance to avoid service interruption when a single control plane node fails. For more information, see [Configure High Availability](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/).
 
-## Install Kubernetes and KubeSphere
+  > **Note**: If you plan multiple control plane nodes, be sure to configure high availability for the cluster in advance.
 
-Two installation methods are supported: **command line** and **Web UI**.
+- By default, KubeSphere uses the local disk space of cluster nodes as persistent storage. In production environments, it is recommended to configure an external storage system as persistent storage in advance. For more information, see [Configure External Persistent Storage](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/).
+- If the cluster nodes do not have a container runtime installed, the installation tool KubeKey will automatically install a container runtime on each cluster node during the installation process. KubeKey installs containerd by default; you can also specify Docker as the container runtime in the configuration file.
 
-### Command Line Installation
+  > **Note**: If you need to use CRI-O or iSula, install it manually in advance; however, their compatibility with KubeSphere has not been fully verified and unknown issues may exist.
+
+- Make sure the DNS server addresses configured in the `/etc/resolv.conf` file are available on all cluster nodes. Otherwise, the KubeSphere cluster may experience domain name resolution issues.
+- Make sure the `sudo`, `tar`, `curl`, and `openssl` commands are available on all cluster nodes.
+- Make sure the clocks of all cluster nodes are synchronized.
+
+> **Note**: KubeKey depends on the `tar` utility for compression and decompression of software packages. Make sure it is installed.
+
+## Configure Firewall Rules
+
+KubeSphere requires specific ports and protocols for communication between services. If firewall is enabled in your infrastructure environment, you need to allow the required ports and protocols in the firewall settings. If firewall is not enabled in your infrastructure environment, you can skip this step.
+
+The following table lists the ports and protocols that need to be allowed in the firewall.
+
+| Service | Protocol | Action | Start Port | End Port | Remarks |
+|---|---|---|---|---|---|
+| ssh | TCP | allow | 22 | N/A | — |
+| etcd | TCP | allow | 2379 | 2380 | — |
+| apiserver | TCP | allow | 6443 | N/A | — |
+| calico | TCP | allow | 9099 | 9100 | — |
+| bgp | TCP | allow | 179 | N/A | — |
+| nodeport | TCP | allow | 30000 | 32767 | — |
+| master | TCP | allow | 10250 | 10258 | — |
+| worker | TCP | allow | 10250 | N/A | — |
+| dns | TCP | allow | 53 | N/A | — |
+| dns | UDP | allow | 53 | N/A | — |
+| rpcbind | TCP | allow | 111 | N/A | Required when using NFS as persistent storage |
+| ipip | IPENCAP / IPIP | allow | N/A | N/A | Required when using Calico |
+
+If you need to temporarily disable the firewall in a test environment, you can run `systemctl stop firewalld`; in production environments, please allow the required ports precisely according to the table above.
+
+## Choose an Installation Method
+
+Both of the following methods can complete the installation of Kubernetes and KubeSphere. **The installation results are identical. You only need to choose one entry point; there is no need to run both**:
+
+- **Method 1: Command Line Installation**: Suitable for scenarios where you are familiar with command line operations and need fine-grained cluster parameter configuration.
+- **Method 2: Web Installer Installation**: Suitable for scenarios where you want to complete node addition, parameter configuration, and installation validation through a graphical interface.
+
+> **Note**: Choose either one of the two methods; do not run them repeatedly.
+
+### Method 1: Command Line Installation
 
 #### 1. Download KubeKey
 
-If your access to GitHub/GoogleAPIs is restricted, set the following environment variable:
+If your access to GitHub / Google APIs is restricted, set the following environment variable:
 
 ```shell
 export KKZONE=cn
@@ -28,11 +82,9 @@ Execute the following command to download the latest version of KubeKey:
 curl -sfL https://get-kk.kubesphere.io | SKIP_WEB_INSTALLER=true SKIP_PACKAGE=true sh -
 ```
 
-After execution, the following files will be generated in the current directory:
+> **Note**: `SKIP_WEB_INSTALLER=true` skips the download of Web Installer resources, and `SKIP_PACKAGE=true` skips the download of the offline packaging script. Command line installation only requires the `kk` binary.
 
-| Original File | Extracted File |
-|---------------|----------------|
-| kubekey-v4.x.x-linux-amd64.tar.gz | kk: KubeKey binary |
+After execution, the `kk` binary will be generated in the current directory.
 
 #### 2. Create Node Configuration File
 
@@ -42,7 +94,7 @@ Execute the following command to create the node configuration file `inventory.y
 ./kk create inventory -o .
 ```
 
-`inventory.yaml` mainly defines the connection information of each node in the cluster. After execution, the node configuration file will be generated. Example:
+`inventory.yaml` mainly sets the connection information of each node in the cluster. After execution, the node configuration file will be generated, for example:
 
 ```yaml
 apiVersion: kubekey.kubesphere.io/v1
@@ -50,7 +102,7 @@ kind: Inventory
 metadata:
   name: default
 spec:
-  hosts:
+  hosts: # you can set all nodes here. or set nodes on special groups.
     # localhost:
     #   connector:
     #     password: 123456
@@ -63,56 +115,56 @@ spec:
     #     password: 123456
     #   internal_ipv4: 1.1.1.1
   groups:
-    # All Kubernetes nodes
+    # all kubernetes nodes.
     k8s_cluster:
       groups:
         - kube_control_plane
         - kube_worker
-    # Control plane nodes
+    # control_plane nodes
     kube_control_plane:
       hosts:
         - localhost
-    # Worker nodes
+    # worker nodes
     kube_worker:
       hosts:
         - localhost
-    # etcd nodes (when etcd_deployment_type is external)
+    # etcd nodes when etcd_deployment_type is external
     etcd:
       hosts:
         - localhost
 #    image_registry:
 #      hosts:
 #        - localhost
-    # NFS nodes for registry storage and Kubernetes NFS storage
+    # nfs nodes for registry storage. and kubernetes nfs storage
 #    nfs:
 #      hosts:
 #        - localhost
+
 ```
 
-**Configure node connection parameters in `spec:hosts`:**
+`spec.hosts` is used to configure the connection parameters of each node. Each node uses the node name as the key, for example `localhost` or `node1`.
 
 | Parameter | Description |
-|-----------|-------------|
+|---|---|
 | `<key>` | Node name |
-| `<key>:connector` | Node connection info |
-| `<key>:connector:type` | Connection type. Supports `local` (local connection) and `ssh` (remote connection). Automatically identifies local or ssh based on the node name or IP |
-| `<key>:connector:host` | Address when using ssh to connect to the node |
-| `<key>:connector:port` | Port when using ssh to connect to the node. Default: `22` |
-| `<key>:connector:user` | Username when using ssh to connect to the node. Default: `root` |
-| `<key>:connector:password` | Password for the connection. For local connections this is the sudo password; for ssh connections this is the ssh password |
-| `<key>:connector:private_key` | Path to the ssh private key file. Either password or key must be provided |
-| `<key>:connector:private_key_content` | Content of the ssh private key. Can be used instead of a key file path |
-| `<key>:internal_ipv4` | IPv4 address used for cluster-internal communication |
-| `<key>:internal_ipv6` | IPv6 address used for cluster-internal communication |
+| `<key>.connector.type` | Node connection type. Supports `local` (local connection) and `ssh` (remote connection). It is identified automatically based on the node name or IP |
+| `<key>.connector.host` | Address when using SSH to connect to the node |
+| `<key>.connector.port` | Port when using SSH to connect to the node. Default: `22` |
+| `<key>.connector.user` | Username when using SSH to connect to the node. Default: `root` |
+| `<key>.connector.password` | Password for connecting to the node. For `local` connections this is the sudo password; for `ssh` connections this is the SSH password |
+| `<key>.connector.private_key` | Path to the SSH private key file. Either password or key must be provided |
+| `<key>.connector.private_key_content` | Content of the SSH private key. The key content can be used instead of the key file path |
+| `<key>.internal_ipv4` | IPv4 address used for cluster-internal communication |
+| `<key>.internal_ipv6` | IPv6 address used for cluster-internal communication |
 
-**Configure node role information in `spec:groups`:**
+`spec.groups` is used to configure the role information of nodes.
 
 | Parameter | Description |
-|-----------|-------------|
+|---|---|
 | `k8s_cluster` | Kubernetes cluster organization. Contains `kube_control_plane` and `kube_worker`, no additional configuration needed |
-| `kube_control_plane` | Control plane nodes in the Kubernetes cluster. Configure node names defined in `spec:hosts` under `kube_control_plane:hosts` |
-| `kube_worker` | Worker nodes in the Kubernetes cluster. Configure node names defined in `spec:hosts` under `kube_worker:hosts` |
-| `etcd` | etcd nodes in the Kubernetes cluster. Configure node names defined in `spec:hosts` under `etcd:hosts` |
+| `kube_control_plane` | Control plane nodes in the Kubernetes cluster. Configure node names defined in `spec.hosts` under `kube_control_plane.hosts` |
+| `kube_worker` | Worker nodes in the Kubernetes cluster. Configure node names defined in `spec.hosts` under `kube_worker.hosts` |
+| `etcd` | etcd nodes in the Kubernetes cluster. Configure node names defined in `spec.hosts` under `etcd.hosts` |
 | `image_registry` | Nodes used to create a private image registry. Not required for online installation |
 
 #### 3. Create Installation Configuration File
@@ -123,31 +175,37 @@ Execute the following command to create the installation configuration file `con
 ./kk create config --with-kubernetes <Kubernetes version> -o .
 ```
 
-Replace `<Kubernetes version>` with the actual version you need, e.g. `v1.27.4`. KubeSphere supports Kubernetes `v1.23~v1.34` by default.
+Replace `<Kubernetes version>` with the actual version you need, for example `v1.34.3`. KubeSphere supports Kubernetes `v1.23` ~ `v1.34` by default.
 
 After execution, the installation configuration file `config-<Kubernetes version>.yaml` will be generated.
 
 #### 4. Configure Cluster Parameters
 
-Configure Kubernetes cluster information in `config-<Kubernetes version>.yaml`:
+Configure the Kubernetes cluster information in `config-<Kubernetes version>.yaml`. The commonly used parameters are as follows:
 
 | Parameter | Description |
-|-----------|-------------|
-| `zone` | Download zone for files and images. If your access to GitHub/GoogleAPIs is restricted, set this to `cn` |
-| `kubernetes` | Kubernetes-related configuration |
-| `etcd` | etcd-related configuration |
-| `image_registry` | Private image registry-related configuration |
-| `cri` | Container runtime-related configuration |
-| `cni` | Network plugin-related configuration |
-| `storage_class` | Storage plugin-related configuration |
-| `dns` | DNS-related configuration |
-| `image_manifests` | Additional images to be downloaded |
+|---|---|
+| `zone` | Download zone for files and images. If your access to GitHub / Google APIs is restricted, set this value to `cn` |
+| `kubernetes` | Kubernetes cluster configuration, including version, control plane endpoint, network CIDR, and so on |
+| `etcd` | etcd cluster configuration, including installation method (built-in or external), data directory, and so on |
+| `image_registry` | Private image registry configuration. Default values are usually used for online installation |
+| `cri` | Container runtime configuration. Can be set to `docker` or `containerd` |
+| `cni` | Network plugin configuration. Can be set to `calico`, `cilium`, `flannel`, and so on |
+| `storage_class` | Storage plugin configuration. Supports `local`, `nfs`, and so on |
+| `dns` | Domain name resolution configuration |
+| `image_manifests` | List of additional images to be downloaded |
 
-> **Note**: For complete configuration reference, please refer to [Configuration Reference](../reference/config.md).
+> **Note**: For the complete field descriptions of each parameter, refer to the [Configuration Reference](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md).
 
 #### 5. Install Kubernetes
 
 Execute the following command to install Kubernetes:
+
+```shell
+./kk create cluster -i inventory.yaml -c config-<Kubernetes version>.yaml
+```
+
+If you have renamed the installation configuration file to `config.yaml`, you can use the following command:
 
 ```shell
 ./kk create cluster -i inventory.yaml -c config.yaml
@@ -155,21 +213,26 @@ Execute the following command to install Kubernetes:
 
 #### 6. Install KubeSphere
 
+KubeKey v4.x decouples the installation of Kubernetes and KubeSphere. After Kubernetes is installed, you need to manually execute the following Helm commands to install KubeSphere.
+
+> **Note**: The Web Installer installation method completes the KubeSphere installation automatically, so this step is not required.
+
 Execute the following command to install KubeSphere:
 
 ```shell
 chart=oci://hub.kubesphere.com.cn/kse/ks-core
-version=1.2.4
+version=1.2.5
 helm upgrade --install -n kubesphere-system --create-namespace ks-core $chart \
   --debug --wait --version $version --reset-values --take-ownership \
   --set global.imageRegistry=hub.kubesphere.com.cn,extension.imageRegistry=hub.kubesphere.com.cn
 ```
 
-> **Note**: Helm version must be >= 3.17.0
+> **Note**:
+> - `--take-ownership` is used to take over resources with the same name that already exist in the cluster in order to avoid installation conflicts. This parameter requires Helm >= 3.17.0.
 
 If the following information is displayed, KubeSphere has been installed successfully:
 
-```
+```text
 NOTES:
 Thank you for choosing KubeSphere Helm Chart.
 
@@ -185,7 +248,7 @@ Please be patient and wait for several seconds for the KubeSphere deployment to 
 
     Once the deployment is complete, you can access the KubeSphere console using the following URL:
 
-    http://192.168.6.10:30880
+    http://<Node IP Address>:30880
 
 3. Login to KubeSphere Console
 
@@ -197,11 +260,11 @@ Please be patient and wait for several seconds for the KubeSphere deployment to 
 NOTE: It is highly recommended to change the default password immediately after the first login.
 ```
 
-### Web UI Installation
+### Method 2: Web Installer Installation
 
-#### 1. Download KubeKey (with Web Installer)
+#### 1. Download KubeKey and Web Installer
 
-If your access to GitHub/GoogleAPIs is restricted, set the following environment variable:
+If your access to GitHub / Google APIs is restricted, set the following environment variable:
 
 ```shell
 export KKZONE=cn
@@ -213,16 +276,24 @@ Execute the following command to download the latest version of KubeKey (includi
 curl -sfL https://get-kk.kubesphere.io | SKIP_PACKAGE=true sh -
 ```
 
+> **Note**: `SKIP_PACKAGE=true` skips the download of the offline packaging script (`package.sh`), which is not needed for the online installation scenario.
+
 After execution, the following files will be generated in the current directory:
 
 | Original File | Extracted File |
-|---------------|----------------|
-| kubekey-v4.x.x-linux-amd64.tar.gz | kk: KubeKey binary |
-| web-installer.tgz | dist: Web UI resources<br>host-check.yaml, kubernetes, kubesphere: Task template files<br>schema: Configuration files<br>README.md: Installation documentation |
+|---|---|
+| `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`: KubeKey binary |
+| `web-installer.tgz` | `dist`: Web page resources; `host-check.yaml`, `kubernetes`, `kubesphere`: Task template files; `schema`: Configuration form definitions; `README.md`: Installation documentation |
 
 #### 2. Start Web Installer
 
-Execute the following command to start the Web Installer:
+Extract the Web Installer package
+
+```shell
+tar -zxvf web-installer.tgz
+```
+
+Execute the following command to start the Web Installer page:
 
 ```shell
 ./kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
@@ -230,8 +301,95 @@ Execute the following command to start the Web Installer:
 
 If the following message is displayed, the Web Installer has started successfully:
 
-```
+```text
 Web server started successfully on port 8080
 ```
 
-Do not close the terminal. Open KubeKey's UI page in the browser via `http://<bootstrap-node-ip>:8080`.
+Do not close the command terminal.
+
+#### 3. Deploy Kubernetes and KubeSphere via Web Installer
+
+In the browser, visit `http://<Bootstrap Node IP Address>:8080` to open the KubeKey Web Installer page.
+
+Click **Start Installation** on the page to enter the installation flow.
+
+##### 3.1. Add Cluster Nodes
+
+On the **Basic Information** page, add cluster nodes. Each node needs to be assigned a role, and the following three roles are supported:
+
+- **Master**: Control plane node, responsible for cluster scheduling and management. etcd is automatically installed on Master nodes.
+- **Worker**: Worker node, running actual business containers.
+- **Image**: Image registry node, used to automatically deploy a private image registry. This role is usually not required for online installation.
+
+The Web Installer supports the following three ways to add nodes:
+
+- **Manual addition**: Suitable for adding a single node. You need to fill in host name, IP address, SSH address, SSH authentication, and other information.
+- **File upload**: Suitable for batch adding nodes. Fill in the node information according to the template and upload the file.
+- **Node scan**: Suitable for automatically discovering nodes. You can scan nodes by IP CIDR and select the nodes to add based on the scan results.
+
+> **Note**: If you only add one node, the node role must be `Master & Worker`.
+
+##### 3.2. Modify Configuration Parameters
+
+On the installation configuration page, fill in the parameters required for deploying Kubernetes and KubeSphere.
+
+Both the Kubernetes and KubeSphere Core tabs support **Form mode** and **YAML mode**. You can fill in the configuration information in the form, or directly edit the YAML file. For more configuration parameters, refer to the [Configuration Example](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md).
+
+> **Note**: If your access to GitHub / Google APIs is restricted, switch to YAML mode and add the `zone: cn` parameter so that KubeKey downloads binaries from domestic addresses. At the same time, it is recommended to set the image registry address to `hub.kubesphere.com.cn`. After switching to domestic sources, only a limited number of Kubernetes versions are supported. For the specific supported versions, refer to the Kubernetes tab on the [get-images.kubesphere.io](https://get-images.kubesphere.io) page.
+
+**Install Image Registry (Optional)**
+
+If you need to deploy a private image registry together with the cluster, add an Image role node when adding nodes, and set the image registry type to `harbor` or `docker-registry` in the Kubernetes configuration parameters:
+
+- **Single-node image registry**: Add 1 Image role node and set the image registry type in the Kubernetes configuration parameters.
+- **Highly available image registry**: Add multiple Image role nodes (recommended ≥ 3), set the image registry type in the Kubernetes configuration parameters, and configure the highly available virtual IP of the image registry as the access entry.
+
+After configuration, click **Next**.
+
+##### 3.3. Preview Installation Configuration
+
+On the **Installation Preview** page, confirm that the version, nodes, network, storage, and other information are correct, then click **Next: Execute Installation** to start the installation.
+
+If you need to modify the configuration, you can go back to the previous step to re-edit the configuration parameters.
+
+##### 3.4. Execute Installation
+
+Wait for the installation to complete. After the installation is complete, the system will automatically enter the installation validation flow.
+
+If an exception occurs during the installation, you can click **View Logs** to view the log details and troubleshoot the problem based on the log information. If necessary, you can force-quit the current installation flow or initialize and reinstall.
+
+> **Note**: If you need to reinstall, modify configuration parameters, or clear the configuration on the Web Installer page, click the **Initialize** button on the left. The initialization operation resets all tasks on the Kubernetes nodes and returns to the Basic Information page. This operation is irreversible, so proceed with caution.
+
+##### 3.5. Installation Validation
+
+1. On the **Installation Validation** page, click **Start Detection**, and the system will automatically run detection scripts to verify system availability.
+2. If the system detection passes, click **Complete** to view the KubeSphere access address, administrator username, and default password.
+3. Enter the access address in the browser, log in to the KubeSphere Web console, and start using KubeSphere.
+
+> **Note**: Depending on your network environment, you may need to configure traffic forwarding rules and allow port `30880` in the firewall.
+
+## Access the KubeSphere Web Console
+
+After the installation is complete, visit the KubeSphere console address displayed in the installation result in your browser.
+
+Use the administrator username and default password displayed in the installation result to log in to the KubeSphere Web console. It is recommended that you change the default password immediately after the first login.
+
+## FAQ
+
+**Q: Download times out or is slow when accessing GitHub?**
+A: First run `export KKZONE=cn` to use domestic sources before downloading. After switching to domestic sources, only a limited number of Kubernetes versions are supported. Set the Kubernetes version to one of the versions listed in the **Kubernetes tab** on the [get-images.kubesphere.io](https://get-images.kubesphere.io) page (specified via `./kk create config --with-kubernetes <version> -o .`).
+
+**Q: The console cannot be accessed after single-node deployment?**
+A: For single-node deployment, the node role must be `Master & Worker`; at the same time, make sure port `30880` is allowed in the firewall.
+
+**Q: How do I re-run the installation?**
+A: On the Web Installer, click the **Initialize** button (this operation is irreversible); for the command line method, clean up the nodes with `kk delete cluster --all --with-data` and then re-run `kk create cluster`.
+
+**Q: How do I keep the CA certificate for adding nodes later?**
+A: If you use the KubeKey default certificate, keep the `<working directory>/kubekey/pki/root.crt` file after the installation (the default working directory is `/root/kubekey`). This certificate may be needed when adding nodes later.
+
+**Q: What extra recommendations are there for production environments?**
+A: It is recommended to prepare at least 5 nodes, configure high availability in advance, and configure external persistent storage to avoid using node-local disk space as persistent storage.
+
+**Q: How do I install in an environment without Internet access?**
+A: Refer to [Offline Installation of Kubernetes and KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/02-offline-install-kubernetes-and-kubesphere/).

--- a/docs/zh/installation/offline.md
+++ b/docs/zh/installation/offline.md
@@ -1,55 +1,47 @@
-# 离线安装 Kubernetes 和 KubeSphere
+# 离线安装 Kubernetes
 
-本节介绍如何在不能访问 Internet 的环境下使用离线安装包部署 Kubernetes 和 KubeSphere。
+本节介绍如何在不能访问 Internet 的环境下使用离线安装包部署 Kubernetes。
 
 安装过程中将使用开源工具 KubeKey 的 v4.x 版本。有关 KubeKey 的更多信息，请访问 [GitHub KubeKey 仓库](https://github.com/kubesphere/kubekey)。
-
-> **注意**：KubeSphere 社区版用户需要在联网状态下自行构建离线安装包；KubeSphere 其他版本的用户可联系 KubeSphere 交付服务专家获取最新的离线安装包，即可跳过「构建离线安装包」一节。
 
 > **说明**：安装过程依赖 `tar` 工具完成软件包的压缩和解压，请提前确认系统环境已预装该命令。若 `config.yaml` 中配置了 charts 参数，请确保打包节点已提前安装 `Helm`。
 
 ## 概述
 
-与在线安装相比，离线安装需要先在可访问 Internet 的机器上将所需的组件与镜像打包为离线安装包，再将其传输至目标环境进行安装。整体流程如下：
+离线安装需要先在可访问 Internet 的机器上将所需的组件与镜像打包为离线安装包，再将其传输至目标环境进行安装。整体流程如下：
 
 1. **构建离线安装包**（在联网机器上）：下载组件与镜像，并打包为 `artifact.tgz`。
 2. **传输离线包**：将 `artifact.tgz` 拷贝至目标环境（例如通过存储介质或内网传输）。
-3. **安装集群**（在目标环境）：解压离线包，将镜像推送至私有镜像仓库（若单独安装私有镜像仓库，即方式一；若由 KubeKey 在创建集群时同步安装，镜像推送由安装流程自动完成），然后安装 Kubernetes 与 KubeSphere。
+3. **安装集群**（在目标环境）：解压离线包，将镜像推送至私有镜像仓库（若单独安装私有镜像仓库，即方式一；若由 KubeKey 在创建集群时同步安装，镜像推送由安装流程自动完成），然后安装 Kubernetes。
 
 ## 角色说明
 
-离线安装涉及以下四类角色：
+离线安装涉及以下三类角色：
 
 | 角色 | 职责 | 最低配置（每节点） | 网络要求 |
 |---|---|---|---|
 | 打包节点 | 从 Internet 下载所需软件包与镜像，构建离线安装包 | CPU：1 核，内存：1 GB，硬盘：150 GB | 需能访问互联网 |
-| 部署节点（运行 Web Installer 服务） | 安装过程中在该节点执行 `kk` 命令以运行安装服务 | CPU：1 核，内存：1 GB，硬盘：150 GB | 与 Kubernetes 节点网络互通 |
 | 私有镜像仓库节点 | 存放集群所需的容器镜像 | CPU：8 核，内存：16 GB，硬盘：100 GB | 与 Kubernetes 节点网络互通 |
 | Kubernetes 节点 | 运行集群工作负载（无需提前安装 Kubernetes） | CPU：2 核，内存：4 GB，硬盘：40 GB | 节点间网络互通 |
 
 > **说明**：
-> - 同一台主机可同时承担多个角色，例如同时作为部署节点与私有镜像仓库节点，或同时作为部署节点与 Kubernetes 节点。
-> - 私有镜像仓库节点与 Kubernetes 节点不能是同一台主机，因为安装过程中 Kubernetes 组件会重启容器运行时，可能导致镜像仓库服务中断。
+> - 同一台主机可同时承担多个角色，例如同时作为打包节点与私有镜像仓库节点，或同时作为打包节点与 Kubernetes 节点。
+> - 若打包节点不承担集群角色，需另准备一台主机作为 Kubernetes 节点。
 
 ## 前提条件
 
 > **说明**：以下为 Kubernetes 节点需满足的前提条件。
 
-- 您需要准备至少 1 台 Linux 服务器作为集群节点。在生产环境中，为确保集群具备高可用性，建议准备至少 5 台 Linux 服务器，其中 3 台作为控制平面节点，另外 2 台作为工作节点。如果您在多台 Linux 服务器上安装 KubeSphere，请确保所有服务器属于同一子网。
+- 您需要准备至少 1 台 Linux 服务器作为集群节点。在生产环境中，为确保集群具备高可用性，建议准备至少 5 台 Linux 服务器，其中 3 台作为控制平面节点，另外 2 台作为工作节点。如果您在多台 Linux 服务器上安装 Kubernetes，请确保所有服务器属于同一子网。
 - 集群节点的操作系统和版本须为 Ubuntu 18.04、Ubuntu 20.04、Ubuntu 22.04、Ubuntu 24.04、Debian 10、Debian 11、CentOS 8、AlmaLinux 9.0 或 Kylin v10。多台服务器的操作系统可以不同。关于其它操作系统和版本支持，请咨询青云科技官方解决方案专家或交付服务专家。
 - 在生产环境中，为确保集群具有足够的计算和存储资源，建议每台集群节点配置至少 8 个 CPU 核心、16 GB 内存和 200 GB 磁盘空间。除此之外，建议在每台集群节点的 `/var/lib/docker`（对于 Docker）或 `/var/lib/containerd`（对于 containerd）目录额外挂载至少 200 GB 磁盘空间，用于存储容器运行时数据。
-- 在生产环境中，建议提前为 KubeSphere 集群配置高可用性，以避免单个控制平面节点出现故障时集群服务中断。有关更多信息，请参阅[配置高可用性](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/)。
-
-  > **说明**：如果您规划了多个控制平面节点，请务必提前为集群配置高可用性。
-
-- 默认情况下，KubeSphere 使用集群节点的本地磁盘空间作为持久化存储。在生产环境中，建议提前配置外部存储系统作为持久化存储。有关更多信息，请参阅[配置外部持久化存储](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/)。
-- 请确保所有集群节点上 `/etc/resolv.conf` 文件中配置的 DNS 服务器地址可用。否则，KubeSphere 集群可能会出现域名解析问题。
+- 请确保所有集群节点上 `/etc/resolv.conf` 文件中配置的 DNS 服务器地址可用。否则，集群可能会出现域名解析问题。
 - 请确保在所有集群节点上都可以使用 `sudo`、`tar`、`curl` 和 `openssl` 命令。
 - 请确保所有集群节点时间同步。
 
 ## 配置防火墙规则
 
-KubeSphere 需要特定端口和协议用于服务之间的通信。如果您的基础设施环境已启用防火墙，您需要在防火墙设置中放行所需的端口和协议。如果您的基础设施环境未启用防火墙，您可以跳过此步骤。
+Kubernetes 需要特定端口和协议用于服务之间的通信。如果您的基础设施环境已启用防火墙，您需要在防火墙设置中放行所需的端口和协议。如果您的基础设施环境未启用防火墙，您可以跳过此步骤。
 
 下表列出需要在防火墙中放行的端口和协议。
 
@@ -140,7 +132,7 @@ spec:
 | `spec.download.image_registry.type` | 镜像仓库类型，支持 `harbor` 和 `docker-registry` |
 | `spec.download.iso` | 制作 ISO 依赖包的操作系统列表，用于安装系统依赖 |
 
-### 获取 KubeKey 与 Web Installer
+### 获取 KubeKey
 
 如果访问 GitHub 或 Google APIs 受限，请设置如下环境变量：
 
@@ -148,7 +140,7 @@ spec:
 export KKZONE=cn
 ```
 
-执行以下命令下载 KubeKey 和 Web Installer：
+执行以下命令下载 KubeKey：
 
 ```bash
 curl -sfL https://get-kk.kubesphere.io | sh -
@@ -159,7 +151,6 @@ curl -sfL https://get-kk.kubesphere.io | sh -
 | 原文件 | 解压后文件 |
 |---|---|
 | `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`：KubeKey 二进制文件 |
-| `web-installer.tgz` | `dist`：Web 页面资源；`host-check.yaml`、`kubernetes`、`kubesphere`：任务模板文件；`schema`：配置表单定义；`README.md`：安装说明文档 |
 | `package.sh` | 离线安装包的构建脚本（由下载命令自动生成，内部调用 `kk artifact export` 完成下载与打包） |
 
 ### 制作离线安装包
@@ -199,16 +190,7 @@ artifact/
 安装集群前，需要指定私有镜像仓库地址。有以下两种方式：
 
 - **方式一**：单独安装私有镜像仓库，请参考[镜像仓库安装](https://github.com/kubesphere/kubekey/blob/main/docs/zh/image-registry/README.md)。
-- **方式二**：在创建集群时同时安装镜像仓库。详情请参考下文安装步骤。
-
-### 选择安装方式
-
-以下两种方法均可完成 Kubernetes 和 KubeSphere 的安装，**安装结果一致，您只需选择其中一种操作入口即可，无需同时执行**：
-
-- **方法 1：命令行安装**：适用于熟悉命令行操作、需要精细化配置集群参数的场景。
-- **方法 2：Web Installer 安装**：适用于希望通过图形化界面完成节点添加、参数配置和安装校验的场景。
-
-> **说明**：两种方法任选其一，请勿重复执行。两种方法均支持上文所述的两种私有镜像仓库部署方式（单独安装、或在创建集群时同步安装）。
+- **方式二**：在创建集群时同时安装镜像仓库。详情请参考下述安装步骤。
 
 ### 解压离线包
 
@@ -216,7 +198,7 @@ artifact/
 tar -zxvf artifact.tgz
 ```
 
-### 方法 1：命令行安装
+### 安装集群
 
 #### 1. 进入离线包目录并解压工具
 
@@ -370,167 +352,16 @@ spec:
 ./kk create cluster -a kubekey-artifact.tgz -i inventory.yaml -c config-v1.34.3.yaml
 ```
 
-#### 6. 安装 KubeSphere
-
-KubeKey v4.x 将 Kubernetes 和 KubeSphere 解耦安装，安装完 Kubernetes 后需手动执行以下 Helm 命令安装 KubeSphere。
-
-> **说明**：`ks-core` Helm Chart 包包含在 `kubekey-artifact.tgz` 中，解压 `kubekey-artifact.tgz` 后位于 `charts/` 目录下。
-
-```bash
-# 解压离线资源包以获取 ks-core chart
-tar -zxvf kubekey-artifact.tgz
-```
-
-```bash
-helm upgrade --install \
-  -n kubesphere-system \
-  --create-namespace \
-  ks-core \
-  ./charts/ks-core-1.2.5.tgz \
-  --debug \
-  --wait \
-  --reset-values \
-  --set auditing.enable=true \
-  --set ha.enabled=true \
-  --set redisHA.enabled=true \
-  --set global.imageRegistry=dockerhub.kubekey.local \
-  --set extension.imageRegistry=dockerhub.kubekey.local
-```
-
-> **说明**：
-> - 请将上文仓库地址替换为您实际的私有镜像仓库地址。
-> - `auditing.enable`、`ha.enabled`、`redisHA.enabled` 为生产环境推荐启用的配置项，可根据实际需求调整。
-> - Helm 版本需要 >= 3.17.0。
-
-### 方法 2：Web Installer 安装
-
-#### 1. 进入离线包目录并解压工具
-
-KubeKey 工具位于 `tools/{arch}/` 目录下，请根据安装机器的架构解压对应工具。
-
-查看机器架构：
-
-```bash
-uname -m
-```
-
-进入离线包目录：
-
-```bash
-cd artifact/
-```
-
-解压 KubeKey 到离线包目录：
-
-```bash
-tar -zxvf tools/$(uname -m)/kubekey-v4.x.x-linux-$(uname -m).tar.gz -C .
-```
-
-解压 `kubekey-artifact.tgz` 到工作目录。该文件包含安装时所需的所有资源：二进制文件、Helm Chart 包、镜像文件等。
-
-```bash
-mkdir kubekey
-tar -zxvf kubekey-artifact.tgz -C kubekey
-```
-
-#### 2. 启动 Web Installer
-
-解压 Web Installer 安装包
+安装完成后，可通过 `kubectl get nodes` 查看集群节点状态：
 
 ```shell
-tar -zxvf web-installer.tgz
+kubectl get nodes
 ```
-
-执行以下命令启动 Web Installer 页面：
-
-```shell
-./kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
-```
-
-如果显示如下信息，表示 Web Installer 启动成功：
-
-```text
-Web server started successfully on port 8080
-```
-
-请勿关闭命令终端。
-
-#### 3. 通过 Web Installer 部署 Kubernetes 和 KubeSphere
-
-在浏览器中访问 `http://<部署节点 IP 地址>:8080`，点击 **开始安装**，进入部署流程。
-
-##### 3.1 添加集群节点
-
-在 **基本信息** 页面，添加集群节点。每个节点需要指定角色，支持以下三种：
-
-- **Master**：控制平面节点，负责集群调度与管理。Master 节点上会自动安装 etcd。
-- **Worker**：工作节点，运行实际业务容器。
-- **Image**：镜像仓库节点，用于自动部署私有镜像仓库。离线安装时通常需要配置此角色。
-
-Web Installer 支持以下三种节点添加方式：
-
-- **手动添加**：适用于添加单个节点。您需要填写主机名、IP 地址、SSH 地址、SSH 认证等信息。
-- **文件上传**：适用于批量添加节点。请根据模板填写节点信息后上传文件。
-- **节点扫描**：适用于自动发现节点。您可以通过 IP CIDR 扫描节点，并根据扫描结果选择需要添加的节点。
-
-> **注意**：如果只添加一个节点，节点角色必须为 `Master & Worker`。
-
-
-##### 3.2 修改配置参数
-
-配置部署 Kubernetes 和 KubeSphere 所需的参数。
-
-Kubernetes 和 KubeSphere Core 标签页均支持 **表单模式** 和 **YAML 模式**。您可以在表单中填写配置信息（所有参数均需配置），也可以直接编辑 YAML 文件。如需了解更多配置信息，请参阅[配置示例](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md)。
-
-> **说明**：如果选择安装镜像仓库，需通过 **YAML 模式** 添加以下参数，跳过在线下载：
->
-> ```yaml
-> download:
->   fetch: false
-> ```
-
-**安装镜像仓库**
-
-如果需要在安装集群时同时部署私有镜像仓库，请在添加节点时添加 Image 角色的节点，并在 Kubernetes 配置参数中将镜像仓库类型设置为 `harbor` 或 `docker-registry`：
-
-- **单节点镜像仓库**：添加 1 个 Image 角色节点，在 Kubernetes 配置参数中设置镜像仓库类型。
-- **高可用镜像仓库**：添加多个 Image 角色节点（建议 ≥ 3 个），在 Kubernetes 配置参数中设置镜像仓库类型，并配置镜像仓库高可用虚拟 IP 作为访问入口。
-
-配置完成后，点击 **下一步**。
-
-##### 3.3 安装预览
-
-在 **安装预览** 页面，确认版本等信息无误后，点击 **下一步：执行安装** 开始安装。也可以返回上一步修改配置参数。
-
-##### 3.4 安装
-
-耐心等待安装完成。安装完成后，系统会自动进入安装校验步骤。
-
-若安装过程中出现异常，点击 **查看日志** 查看日志详情，退出或初始化后重新安装。
-
-> **说明**：若需要在 Web Installer 页面重新安装、修改配置参数或清除配置，点击左侧的 **初始化** 按钮，将重置 Kubernetes 节点上的所有任务并回到基本信息页面。初始化操作不可逆，请谨慎执行。
-
-##### 3.5 安装校验
-
-1. 在 **安装校验** 页面，点击 **开始检测**，系统将自动运行对应的检测脚本验证系统可用性。
-2. 若通过系统检测，点击 **完成**，可查看 KubeSphere 的访问地址、管理员用户名和默认密码。
-3. 在网页浏览器上输入访问地址，登录 KubeSphere Web 控制台，即可开始使用 KubeSphere。
-
-> **说明**：取决于您的网络环境，您可能需要配置流量转发规则并在防火墙中放行 `30880` 端口。
-
-## 访问 KubeSphere Web 控制台
-
-安装完成后，在浏览器中访问安装结果中显示的 KubeSphere 控制台地址。
-
-使用安装结果中显示的管理员用户名和默认密码登录 KubeSphere Web 控制台。首次登录后，建议立即修改默认密码。
 
 ## 常见问题
 
 **Q：打包时选择的版本与安装时使用的版本不一致？**
 A：安装使用的 Kubernetes 版本必须包含在构建离线包时 `spec.download.kubernetes.kube_version` 列表中，否则离线包中不包含该版本的镜像。
-
-**Q：Web Installer 能否安装私有镜像仓库？**
-A：支持。在添加节点时添加 Image 角色的节点，并在 Kubernetes 配置参数中设置镜像仓库类型（`harbor` 或 `docker-registry`）。部署高可用镜像仓库时，需添加多个 Image 角色节点并配置镜像仓库高可用虚拟 IP 作为访问入口。
 
 **Q：镜像推送失败？**
 A：请确认 `config.yaml` 中仓库地址、用户名和密码正确，且网络可访问 `5000` 端口。
@@ -542,10 +373,10 @@ A：在推送镜像到私有镜像仓库之前，KubeKey 会先在线检查本�
 A：节点角色必须为 `Master & Worker`。
 
 **Q：如何重新执行安装？**
-A：Web Installer 中点击 **初始化** 按钮（该操作不可逆）；命令行方式请在清理节点后重新执行 `kk create cluster`。
+A：命令行方式请在清理节点后重新执行 `kk create cluster`。
 
 **Q：如何保留 CA 证书用于后续添加节点？**
 A：如果使用 KubeKey 默认证书，请在安装完成后保留 `<工作目录>/kubekey/pki/root.crt` 文件（默认工作目录为 `/root/kubekey`）。后续添加节点时可能需要该证书。
 
 **Q：如何在有网络环境中安装？**
-A：请参考[在线安装 Kubernetes 和 KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/01-online-install-kubernetes-and-kubesphere/)。
+A：请参考[在线安装 Kubernetes](./online/)。

--- a/docs/zh/installation/offline.md
+++ b/docs/zh/installation/offline.md
@@ -1,43 +1,80 @@
 # 离线安装 Kubernetes 和 KubeSphere
 
-本节介绍如何在无法访问 Internet 的环境下，使用离线安装包部署 Kubernetes 和 KubeSphere。
+本节介绍如何在不能访问 Internet 的环境下使用离线安装包部署 Kubernetes 和 KubeSphere。
 
-> **前置依赖**：
-> 安装过程依赖 `tar` 工具完成软件包的压缩和解压，请提前确认系统环境已预装该命令。
-> 若 `config.yaml` 中配置了 `charts` 参数，请确保打包节点已提前安装 Helm。
+安装过程中将使用开源工具 KubeKey 的 v4.x 版本。有关 KubeKey 的更多信息，请访问 [GitHub KubeKey 仓库](https://github.com/kubesphere/kubekey)。
 
----
+> **注意**：KubeSphere 社区版用户需要在联网状态下自行构建离线安装包；KubeSphere 其他版本的用户可联系 KubeSphere 交付服务专家获取最新的离线安装包，即可跳过「构建离线安装包」一节。
 
-## 准备工作
+> **说明**：安装过程依赖 `tar` 工具完成软件包的压缩和解压，请提前确认系统环境已预装该命令。若 `config.yaml` 中配置了 charts 参数，请确保打包节点已提前安装 `Helm`。
 
-参考如下最低配置要求，准备 Linux 主机。
+## 概述
 
-| 角色 | 主机数量 | 最低要求（每个节点） | 网络要求 |
-|------|---------|---------------------|---------|
-| 打包节点 | 1 | CPU：1 核，内存：1 GB，硬盘：150 GB |  |
-| 部署节点（运行 Web Installer 服务） | 1 | CPU：1 核，内存：1 GB，硬盘：150 GB | 与 Kubernetes 节点网络互通 |
-| 私有镜像仓库节点 | 1 | CPU：8 核，内存：16 GB，硬盘：100 GB | 与 Kubernetes 节点网络互通 |
-| Kubernetes 节点 | ≥ 1 | CPU：2 核，内存：4 GB，硬盘：40 GB | 节点间网络互通 |
+与在线安装相比，离线安装需要先在可访问 Internet 的机器上将所需的组件与镜像打包为离线安装包，再将其传输至目标环境进行安装。整体流程如下：
 
-> **注意事项**
->
-> - 同一台主机可同时承担多个角色，例如：同时作为部署节点和私有镜像仓库节点，或者同时作为部署节点和 Kubernetes 节点。
-> - **私有镜像仓库节点与 Kubernetes 节点不能是同一台主机。**
+1. **构建离线安装包**（在联网机器上）：下载组件与镜像，并打包为 `artifact.tgz`。
+2. **传输离线包**：将 `artifact.tgz` 拷贝至目标环境（例如通过存储介质或内网传输）。
+3. **安装集群**（在目标环境）：解压离线包，将镜像推送至私有镜像仓库（若单独安装私有镜像仓库，即方式一；若由 KubeKey 在创建集群时同步安装，镜像推送由安装流程自动完成），然后安装 Kubernetes 与 KubeSphere。
 
-**各角色说明：**
+## 角色说明
 
-- **打包节点**：需要准备至少 1 台 Linux 服务器作为打包节点。该节点将从互联网下载所需软件包与镜像，需确保能够访问互联网。
-- **部署节点**（运行 Web Installer 服务）：安装过程中需要在该节点上执行 kk 命令以运行安装服务。该节点需与私有镜像仓库节点、Kubernetes 节点保持网络互通。
-- **私有镜像仓库节点**：如果尚未部署任何私有镜像仓库，需准备至少 1 台 Linux 服务器。该节点需与 Kubernetes 各节点保持网络互通。
-- **Kubernetes 节点**：需要准备至少 1 台 Linux 服务器作为集群节点（无需提前安装 Kubernetes）。
+离线安装涉及以下四类角色：
 
----
+| 角色 | 职责 | 最低配置（每节点） | 网络要求 |
+|---|---|---|---|
+| 打包节点 | 从 Internet 下载所需软件包与镜像，构建离线安装包 | CPU：1 核，内存：1 GB，硬盘：150 GB | 需能访问互联网 |
+| 部署节点（运行 Web Installer 服务） | 安装过程中在该节点执行 `kk` 命令以运行安装服务 | CPU：1 核，内存：1 GB，硬盘：150 GB | 与 Kubernetes 节点网络互通 |
+| 私有镜像仓库节点 | 存放集群所需的容器镜像 | CPU：8 核，内存：16 GB，硬盘：100 GB | 与 Kubernetes 节点网络互通 |
+| Kubernetes 节点 | 运行集群工作负载（无需提前安装 Kubernetes） | CPU：2 核，内存：4 GB，硬盘：40 GB | 节点间网络互通 |
+
+> **说明**：
+> - 同一台主机可同时承担多个角色，例如同时作为部署节点与私有镜像仓库节点，或同时作为部署节点与 Kubernetes 节点。
+> - 私有镜像仓库节点与 Kubernetes 节点不能是同一台主机，因为安装过程中 Kubernetes 组件会重启容器运行时，可能导致镜像仓库服务中断。
+
+## 前提条件
+
+> **说明**：以下为 Kubernetes 节点需满足的前提条件。
+
+- 您需要准备至少 1 台 Linux 服务器作为集群节点。在生产环境中，为确保集群具备高可用性，建议准备至少 5 台 Linux 服务器，其中 3 台作为控制平面节点，另外 2 台作为工作节点。如果您在多台 Linux 服务器上安装 KubeSphere，请确保所有服务器属于同一子网。
+- 集群节点的操作系统和版本须为 Ubuntu 18.04、Ubuntu 20.04、Ubuntu 22.04、Ubuntu 24.04、Debian 10、Debian 11、CentOS 8、AlmaLinux 9.0 或 Kylin v10。多台服务器的操作系统可以不同。关于其它操作系统和版本支持，请咨询青云科技官方解决方案专家或交付服务专家。
+- 在生产环境中，为确保集群具有足够的计算和存储资源，建议每台集群节点配置至少 8 个 CPU 核心、16 GB 内存和 200 GB 磁盘空间。除此之外，建议在每台集群节点的 `/var/lib/docker`（对于 Docker）或 `/var/lib/containerd`（对于 containerd）目录额外挂载至少 200 GB 磁盘空间，用于存储容器运行时数据。
+- 在生产环境中，建议提前为 KubeSphere 集群配置高可用性，以避免单个控制平面节点出现故障时集群服务中断。有关更多信息，请参阅[配置高可用性](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/)。
+
+  > **说明**：如果您规划了多个控制平面节点，请务必提前为集群配置高可用性。
+
+- 默认情况下，KubeSphere 使用集群节点的本地磁盘空间作为持久化存储。在生产环境中，建议提前配置外部存储系统作为持久化存储。有关更多信息，请参阅[配置外部持久化存储](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/)。
+- 请确保所有集群节点上 `/etc/resolv.conf` 文件中配置的 DNS 服务器地址可用。否则，KubeSphere 集群可能会出现域名解析问题。
+- 请确保在所有集群节点上都可以使用 `sudo`、`tar`、`curl` 和 `openssl` 命令。
+- 请确保所有集群节点时间同步。
+
+## 配置防火墙规则
+
+KubeSphere 需要特定端口和协议用于服务之间的通信。如果您的基础设施环境已启用防火墙，您需要在防火墙设置中放行所需的端口和协议。如果您的基础设施环境未启用防火墙，您可以跳过此步骤。
+
+下表列出需要在防火墙中放行的端口和协议。
+
+| 服务 | 协议 | 行为 | 起始端口 | 结束端口 | 备注 |
+|---|---|---|---|---|---|
+| ssh | TCP | allow | 22 | N/A | — |
+| etcd | TCP | allow | 2379 | 2380 | — |
+| apiserver | TCP | allow | 6443 | N/A | — |
+| calico | TCP | allow | 9099 | 9100 | — |
+| bgp | TCP | allow | 179 | N/A | — |
+| nodeport | TCP | allow | 30000 | 32767 | — |
+| master | TCP | allow | 10250 | 10258 | — |
+| worker | TCP | allow | 10250 | N/A | — |
+| dns | TCP | allow | 53 | N/A | — |
+| dns | UDP | allow | 53 | N/A | — |
+| local-registry | TCP | allow | 5000 | N/A | 离线环境需要 |
+| local-apt | TCP | allow | 5080 | N/A | 离线环境需要 |
+| rpcbind | TCP | allow | 111 | N/A | 使用 NFS 作为持久化存储时需要 |
+| ipip | IPENCAP / IPIP | allow | N/A | N/A | 使用 Calico 时需要 |
 
 ## 构建离线安装包
 
 ### 创建配置文件
 
-> 可通过 https://get-images.kubesphere.io 页面生成
+**提示**：可通过 [https://get-images.kubesphere.io](https://get-images.kubesphere.io) 页面可视化选择所需的组件并自动生成 `config.yaml`，也可参照以下示例手动创建。
 
 登录打包节点，在打包节点上创建 `config.yaml` 文件：
 
@@ -55,18 +92,8 @@ spec:
       registry: hub.kubesphere.com.cn
     kubernetes:
       kube_version:
-        - v1.23.17
-        - v1.24.17
-        - v1.25.16
-        - v1.26.15
-        - v1.27.16
-        - v1.28.15
-        - v1.29.15
-        - v1.30.14
-        - v1.31.12
-        - v1.32.11
-        - v1.33.7
         - v1.34.3
+        # 也可列出 v1.23~v1.34 中的其他版本
     cni:
       type:
         - calico
@@ -74,9 +101,8 @@ spec:
         - flannel
         - kubeovn
         - hybridnet
-      multi_cni:
-        - multus
-        - spiderpool
+      # multi_cni:          # 可选，多 CNI 管理组件，如 multus
+      #   - multus
     cri:
       container_manager:
         - containerd
@@ -91,29 +117,20 @@ spec:
         - harbor
         - docker-registry
     iso:
-      - "almalinux-9.0-rpms"
-      - "kylin-v10SP3-rpms"
       - "ubuntu-22.04-debs"
       - "centos-8-rpms"
-      - "kylin-v10SP2-rpms"
-      - "ubuntu-24.04-debs"
-      - "debian-10-debs"
-      - "kylin-v10SP1-rpms"
-      - "debian-11-debs"
-      - "ubuntu-18.04-debs"
-      - "kylin-v10SP3-2403-rpms"
-      - "ubuntu-20.04-debs"
+      # 按需增删
 ```
 
 **字段说明：**
 
 | 字段 | 说明 |
-|------|------|
+|---|---|
 | `apiVersion` | 配置文件的 API 版本，固定值为 `kubekey.kubesphere.io/v1` |
 | `kind` | 资源类型，固定值为 `Config` |
 | `spec.zone` | 软件包下载的区域，`cn` 表示使用国内源 |
 | `spec.download.arch` | 指定需要下载的 CPU 架构，支持 `amd64` 和 `arm64` |
-| `spec.download.images.policy` | 镜像下载策略，`warn` 表示镜像不存在时仅警告 |
+| `spec.download.images.policy` | 镜像下载策略，`warn` 表示如果镜像缺少某些 CPU 架构或操作系统，仅记录警告；`strict` 表示拉取的镜像必须包含所有选定的 CPU 架构和操作系统，否则报错 |
 | `spec.download.images.registry` | 镜像仓库地址 |
 | `spec.download.kubernetes.kube_version` | 需要包含的 Kubernetes 版本列表 |
 | `spec.download.cni.type` | 需要包含的 CNI 插件类型 |
@@ -123,45 +140,48 @@ spec:
 | `spec.download.image_registry.type` | 镜像仓库类型，支持 `harbor` 和 `docker-registry` |
 | `spec.download.iso` | 制作 ISO 依赖包的操作系统列表，用于安装系统依赖 |
 
-### 获取 kk 与 Web Installer
+### 获取 KubeKey 与 Web Installer
 
-如果您访问 GitHub/GoogleAPIs 受限，请设置如下环境变量：
+如果访问 GitHub 或 Google APIs 受限，请设置如下环境变量：
 
-```shell
+```bash
 export KKZONE=cn
 ```
 
 执行以下命令下载 KubeKey 和 Web Installer：
 
-```shell
+```bash
 curl -sfL https://get-kk.kubesphere.io | sh -
 ```
 
 执行完成后，会在当前目录生成以下文件：
 
 | 原文件 | 解压后文件 |
-|--------|-----------|
-| `kubekey-v4.x.x-linux-amd64.tar.gz` | kk：KubeKey 二进制文件 |
-| `web-installer.tgz` | dist：Web 页面资源<br>host-check.yaml、kubernetes、kubesphere：任务模板文件<br>schema：配置文件<br>README.md：安装说明文档 |
-| `package.sh` | 离线安装包的构建脚本 |
+|---|---|
+| `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`：KubeKey 二进制文件 |
+| `web-installer.tgz` | `dist`：Web 页面资源；`host-check.yaml`、`kubernetes`、`kubesphere`：任务模板文件；`schema`：配置表单定义；`README.md`：安装说明文档 |
+| `package.sh` | 离线安装包的构建脚本（由下载命令自动生成，内部调用 `kk artifact export` 完成下载与打包） |
 
 ### 制作离线安装包
 
 执行构建脚本：
 
-```shell
+```bash
 ./package.sh config.yaml
 ```
 
-当输出 `Offline package artifact.tgz has been created successfully.` 时表示制作成功。离线包为 `artifact.tgz`。
+当输出以下信息时，表示制作成功：
 
+```text
+Offline package artifact.tgz has been created successfully.
+```
 
-离线包包含以下内容：
+离线包为 `artifact.tgz`，包含以下内容：
 
 ```text
 artifact/
-├── artifact/kubekey-artifact.tgz    # 完整的离线资源包
-└── artifact/tools/                  # 不同架构的工具包
+├── kubekey-artifact.tgz    # 完整的离线资源包
+└── tools/                  # 不同架构的工具包
     ├── amd64/
     │   ├── kubekey-v4.x.x-linux-amd64.tar.gz
     │   ├── nerdctl-2.2.1-linux-amd64.tar.gz
@@ -172,126 +192,75 @@ artifact/
         └── oras_1.3.0_linux_arm64.tar.gz
 ```
 
----
+将 `artifact.tgz` 传输至目标环境后，后续步骤均在目标环境中执行。
 
 ## 使用离线包安装集群
 
-安装集群前，需指定私有镜像仓库地址。有以下两种方式：
+安装集群前，需要指定私有镜像仓库地址。有以下两种方式：
 
-- **方式一**：单独安装私有镜像仓库，请参考 [镜像仓库安装](../image-registry/README.md)。
-- **方式二**：在创建集群时同时安装镜像仓库，需要在 `inventory.yaml` 和 `config.yaml` 中添加对应配置信息（详见下文命令行安装步骤）。
+- **方式一**：单独安装私有镜像仓库，请参考[镜像仓库安装](https://github.com/kubesphere/kubekey/blob/main/docs/zh/image-registry/README.md)。
+- **方式二**：在创建集群时同时安装镜像仓库。详情请参考下文安装步骤。
+
+### 选择安装方式
+
+以下两种方法均可完成 Kubernetes 和 KubeSphere 的安装，**安装结果一致，您只需选择其中一种操作入口即可，无需同时执行**：
+
+- **方法 1：命令行安装**：适用于熟悉命令行操作、需要精细化配置集群参数的场景。
+- **方法 2：Web Installer 安装**：适用于希望通过图形化界面完成节点添加、参数配置和安装校验的场景。
+
+> **说明**：两种方法任选其一，请勿重复执行。两种方法均支持上文所述的两种私有镜像仓库部署方式（单独安装、或在创建集群时同步安装）。
 
 ### 解压离线包
 
-```shell
+```bash
 tar -zxvf artifact.tgz
 ```
 
-### 方法 1：Web Installer 安装
-
-> **提示**：Web Installer 暂不支持安装私有镜像仓库，请提前参考 [镜像仓库安装](../image-registry/README.md) 单独安装。
+### 方法 1：命令行安装
 
 #### 1. 进入离线包目录并解压工具
 
-KubeKey 工具位于 `tools/{arch}/` 目录下，根据安装机器的架构解压对应的工具：
+KubeKey 工具位于 `tools/{arch}/` 目录下，请根据安装机器的架构解压对应工具。
 
-```shell
-# 查看机器架构
+查看机器架构：
+
+```bash
 uname -m
 ```
 
-解压KubeKey 到离线包目录
+进入离线包目录：
 
-```shell
+```bash
 cd artifact/
-tar -zxvf tools/{arch}/kubekey-v4.x.x-linux-{arch}.tar.gz .
 ```
 
-#### 2. 推送镜像到私有镜像仓库
+解压 KubeKey 到离线包目录：
 
-在config.yaml中添加私有镜像仓库信息。示例
-```yaml
-apiVersion: kubekey.kubesphere.io/v1
-kind: Config
-spec:
-  image_registry:
-    auth:
-      registry: dockerhub.kubekey.local
-      username: admin
-      password: Harbor12345
-      skip_tls_verify: false
-      plain_http: false
+```bash
+tar -zxvf tools/$(uname -m)/kubekey-v4.x.x-linux-$(uname -m).tar.gz -C .
 ```
 
-各字段说明如下：
+#### 2. 推送镜像到私有镜像仓库（仅方式一：单独安装私有镜像仓库）
 
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `spec.image_registry.auth.registry` | String | 是 | 私有镜像仓库地址 |
-| `spec.image_registry.auth.username` | String | 是 | 私有镜像仓库登录用户名 |
-| `spec.image_registry.auth.password` | String | 是 | 私有镜像仓库登录密码 |
-| `spec.image_registry.auth.skip_tls_verify` | Boolean | 否 | 是否跳过 TLS 证书验证，默认为 `false` |
-| `spec.image_registry.auth.plain_http` | Boolean | 否 | 是否使用 HTTP 明文传输，默认为 `false` |
+> **说明**：仅当采用 **方式一（单独安装私有镜像仓库）** 时，需要手动执行本步骤，将离线包中的镜像推送到已部署的私有镜像仓库。如果采用 **方式二（创建集群时同步安装镜像仓库）**，KubeKey 会在执行 `kk create cluster` 时自动部署镜像仓库并推送镜像，**请跳过本步骤**。
 
 执行以下命令将离线包中的镜像推送到已部署的私有镜像仓库：
 
-```shell
-kk artifact images --push -c config.yaml -a kubekey-artifact.tgz
+```bash
+./kk artifact images --push -c config.yaml -a kubekey-artifact.tgz
 ```
 
-> **注意**：执行前请确保 `config.yaml` 中已正确配置私有镜像仓库地址。
-
-#### 3. 启动 Web Installer
-
-```shell
-kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
-```
-
-如果显示如下信息，表示 Web Installer 启动成功：
-
-```
-Web server started successfully on port 8080
-```
-
-请勿关闭命令终端，在浏览器中通过 `http://<启动节点 IP 地址>:8080` 打开 KubeKey 的 UI 页面。
-
-### 方法 2：命令行安装
-> **提示**：命令行支持 [镜像仓库安装](../image-registry/README.md) 单独安装。以及在创建集群过程中同步安装（修改inventory.yaml 以及 config.yaml 即可）。
-
-#### 1. 进入离线包目录
-
-KubeKey 工具位于 `tools/{arch}/` 目录下，根据安装机器的架构解压对应的工具：
-
-```shell
-# 查看机器架构
-uname -m
-```
-
-解压KubeKey 到离线包目录
-
-```shell
-tar -zxvf tools/{arch}/kubekey-v4.x.x-linux-{arch}.tar.gz .
-```
-
-#### 2. 推送镜像到私有镜像仓库
-
-执行以下命令将离线包中的镜像推送到已部署的私有镜像仓库：
-
-```shell
-kk artifact images --push -c config.yaml -a kubekey-artifact.tgz
-```
-
-> **注意**：执行前请确保 `config.yaml` 中已正确配置私有镜像仓库地址。
+> **注意**：执行前请确保推送所用的 `config.yaml` 中已正确配置私有镜像仓库地址（即 `spec.image_registry.auth` 字段）。该 `config.yaml` 与上文「构建离线安装包」步骤中用于打包的配置文件为同一文件。
 
 #### 3. 创建节点配置文件
 
 执行以下命令创建节点配置文件 `inventory.yaml`：
 
-```shell
+```bash
 ./kk create inventory -o .
 ```
 
-`inventory.yaml` 主要设置集群中各节点的连接信息。命令执行完毕后，将生成节点配置文件，示例如下：
+命令执行完毕后，将生成节点配置文件 `inventory.yaml`。`inventory.yaml` 主要用于设置集群中各节点的连接信息，示例如下：
 
 ```yaml
 apiVersion: kubekey.kubesphere.io/v1
@@ -299,136 +268,284 @@ kind: Inventory
 metadata:
   name: default
 spec:
-  hosts:
-    # localhost:
-    #   connector:
-    #     password: 123456
-    # node1:
-    #   connector:
-    #     type: ssh
-    #     host: node1
-    #     port: 22
-    #     user: root
-    #     password: 123456
-    #   internal_ipv4: 1.1.1.1
+  hosts: {}
   groups:
-    # 所有 Kubernetes 节点
     k8s_cluster:
       groups:
         - kube_control_plane
         - kube_worker
-    # 控制平面节点
     kube_control_plane:
       hosts:
         - localhost
-    # 工作节点
     kube_worker:
       hosts:
         - localhost
-    # etcd 节点（仅当 etcd_deployment_type 为 external 时）
     etcd:
       hosts:
         - localhost
-#    image_registry:
-#      hosts:
-#        - localhost
-    # NFS 节点（用于镜像仓库存储和 Kubernetes NFS 存储）
-#    nfs:
-#      hosts:
-#        - localhost
 ```
 
-**`spec:hosts` 中配置节点的连接参数：**
+`spec.hosts` 中的节点连接参数：
 
 | 参数 | 描述 |
-|------|------|
+|---|---|
 | `<key>` | 节点名称 |
-| `<key>:connector` | 节点连接信息 |
-| `<key>:connector:type` | 节点连接类型。支持 `local`（本地连接）和 `ssh`（远程连接）。会根据节点名称或 IP 自动识别 |
-| `<key>:connector:host` | 使用 SSH 连接节点时的地址 |
-| `<key>:connector:port` | 使用 SSH 连接节点时的端口。默认值：`22` |
-| `<key>:connector:user` | 使用 SSH 连接节点时的用户名。默认值：`root` |
-| `<key>:connector:password` | 连接节点时的密码。`local` 连接时对应 sudo 密码，`ssh` 连接时对应 SSH 密码 |
-| `<key>:connector:private_key` | SSH 连接节点时的私钥文件路径。密码和密钥任选其一 |
-| `<key>:connector:private_key_content` | SSH 连接节点时的私钥文件内容。可使用密钥内容替代密钥文件路径 |
-| `<key>:internal_ipv4` | 节点在集群中通信时的 IPv4 地址 |
-| `<key>:internal_ipv6` | 节点在集群中通信时的 IPv6 地址 |
+| `<key>.connector.type` | 节点连接类型。支持 `local`（本地连接）和 `ssh`（远程连接）。KubeKey 会根据节点名称或 IP 自动识别连接类型 |
+| `<key>.connector.host` | 使用 SSH 连接节点时的地址 |
+| `<key>.connector.port` | 使用 SSH 连接节点时的端口。默认值：`22` |
+| `<key>.connector.user` | 使用 SSH 连接节点时的用户名。默认值：`root` |
+| `<key>.connector.password` | 连接节点时的密码。`local` 连接时对应 sudo 密码，`ssh` 连接时对应 SSH 密码 |
+| `<key>.connector.private_key` | SSH 连接节点时的私钥文件路径。密码和密钥任选其一 |
+| `<key>.connector.private_key_content` | SSH 连接节点时的私钥文件内容。可使用密钥内容替代密钥文件路径 |
+| `<key>.internal_ipv4` | 节点在集群中通信时使用的 IPv4 地址 |
+| `<key>.internal_ipv6` | 节点在集群中通信时使用的 IPv6 地址 |
 
-**`spec:groups` 中配置节点的角色信息：**
+`spec.groups` 中的节点角色参数：
 
 | 参数 | 描述 |
-|------|------|
-| `k8s_cluster` | Kubernetes 集群组织节点。包含 `kube_control_plane` 和 `kube_worker`，无需额外配置 |
-| `kube_control_plane` | Kubernetes 集群中的控制平面节点。在 `kube_control_plane:hosts` 中配置 `spec:hosts` 中定义的节点名称 |
-| `kube_worker` | Kubernetes 集群中的工作节点。在 `kube_worker:hosts` 中配置 `spec:hosts` 中定义的节点名称 |
-| `etcd` | Kubernetes 集群中的 etcd 节点。在 `etcd:hosts` 中配置 `spec:hosts` 中定义的节点名称 |
+|---|---|
+| `k8s_cluster` | Kubernetes 集群节点分组。包含 `kube_control_plane` 和 `kube_worker`，无需额外配置 |
+| `kube_control_plane` | Kubernetes 集群中的控制平面节点。在 `kube_control_plane.hosts` 中配置 `spec.hosts` 中定义的节点名称 |
+| `kube_worker` | Kubernetes 集群中的工作节点。在 `kube_worker.hosts` 中配置 `spec.hosts` 中定义的节点名称 |
+| `etcd` | Kubernetes 集群中的 etcd 节点。在 `etcd.hosts` 中配置 `spec.hosts` 中定义的节点名称 |
 | `image_registry` | 用于创建私有镜像仓库的节点。离线安装时通常需要配置 |
 
->
-> 如果选择在创建集群时同时安装镜像仓库，需要在 `inventory.yaml` 中额外添加 `image_registry` 节点和分组。示例：
->
-> ```yaml
-> spec:
->   hosts:
->     harbor1:
->       connector:
->         type: ssh
->         host: 172.16.0.1
->         port: 22
->         user: root
->         password: 123456
->       internal_ipv4: 172.16.0.1
->   groups:
->     image_registry:
->       hosts:
->         - harbor1
-> ```
+如果选择在创建集群时同时安装镜像仓库，需要在 `inventory.yaml` 中额外添加 `image_registry` 节点和分组。示例如下：
 
-#### 3. 创建安装配置文件
-
-执行以下命令创建安装配置文件 `config.yaml`：
-
-```shell
-./kk create config --with-kubernetes v1.32.13 -o .
+```yaml
+spec:
+  hosts:
+    harbor1:
+      connector:
+        type: ssh
+        host: 172.16.0.1
+        port: 22
+        user: root
+        password: 123456
+      internal_ipv4: 172.16.0.1
+  groups:
+    image_registry:
+      hosts:
+        - harbor1
 ```
 
-将 `v1.32.13` 替换为实际需要的版本。KubeKey 默认支持 Kubernetes `v1.23~v1.34`。
+#### 4. 创建安装配置文件
 
-命令执行完毕后将生成安装配置文件 `config-v1.32.13.yaml`。
+> **注意**：此步骤生成的配置文件用于**安装集群**，与前面「构建离线安装包」步骤中用于**打包**的 `config.yaml` 不是同一个文件。
 
->
-> 如果选择在创建集群时同时安装镜像仓库，需要在 `config.yaml` 中补充镜像仓库配置：
->
-> ```yaml
-> spec:
->   image_registry:
->     # 镜像仓库类型。支持 harbor、docker-registry，留空则不安装
->     type: "harbor"
->     auth:
->       # 私有镜像仓库地址
->       registry: "dockerhub.kubekey.local"
-> ```
+执行以下命令创建安装配置文件。以下示例使用 `v1.34.3`，该版本已包含在前文 `config.yaml` 示例的离线资源列表中：
 
-#### 4. 配置集群参数
+```bash
+./kk create config --with-kubernetes v1.34.3 -o .
+```
 
-在 `config-v1.32.13.yaml` 中配置 Kubernetes 集群的信息：
+将 `v1.34.3` 替换为实际需要的 Kubernetes 版本。请确保替换后的版本已包含在构建离线包时使用的 `spec.download.kubernetes.kube_version` 列表中。
 
-| 参数 | 描述 |
-|------|------|
-| `zone` | 文件及镜像的下载区域。离线安装时无需联网，但此项在构建离线包时生效 |
-| `kubernetes` | Kubernetes 相关配置 |
-| `etcd` | etcd 相关配置 |
-| `image_registry` | 私有镜像仓库相关配置 |
-| `cri` | 容器运行时相关配置 |
-| `cni` | 网络插件相关配置 |
-| `storage_class` | 存储插件相关配置 |
-| `dns` | 域名解析相关配置 |
-| `image_manifests` | 需要下载的额外镜像 |
+命令执行完毕后，将生成安装配置文件 `config-v1.34.3.yaml`。
 
-> **注意**：完整的配置参数说明请参考 [配置参考](../reference/config.md)。
+如果选择在创建集群时同时安装镜像仓库，需要在 `config-v1.34.3.yaml` 中补充镜像仓库配置：
+
+```yaml
+apiVersion: kubekey.kubesphere.io/v1
+kind: Config
+spec:
+  download:
+    arch:
+      - amd64
+      - arm64
+    images:
+      policy: warn
+  image_registry:
+    auth:
+      registry: dockerhub.kubekey.local  # 替换为您的实际私有镜像仓库地址
+      username: admin
+      password: Harbor12345
+      skip_tls_verify: false
+      plain_http: false
+```
 
 #### 5. 安装集群
 
-```shell
-kk create cluster -a kubekey-artifact.tgz -i inventory.yaml -c config.yaml
+```bash
+./kk create cluster -a kubekey-artifact.tgz -i inventory.yaml -c config-v1.34.3.yaml
 ```
+
+#### 6. 安装 KubeSphere
+
+KubeKey v4.x 将 Kubernetes 和 KubeSphere 解耦安装，安装完 Kubernetes 后需手动执行以下 Helm 命令安装 KubeSphere。
+
+> **说明**：`ks-core` Helm Chart 包包含在 `kubekey-artifact.tgz` 中，解压 `kubekey-artifact.tgz` 后位于 `charts/` 目录下。
+
+```bash
+# 解压离线资源包以获取 ks-core chart
+tar -zxvf kubekey-artifact.tgz
+```
+
+```bash
+helm upgrade --install \
+  -n kubesphere-system \
+  --create-namespace \
+  ks-core \
+  ./charts/ks-core-1.2.5.tgz \
+  --debug \
+  --wait \
+  --reset-values \
+  --set auditing.enable=true \
+  --set ha.enabled=true \
+  --set redisHA.enabled=true \
+  --set global.imageRegistry=dockerhub.kubekey.local \
+  --set extension.imageRegistry=dockerhub.kubekey.local
+```
+
+> **说明**：
+> - 请将上文仓库地址替换为您实际的私有镜像仓库地址。
+> - `auditing.enable`、`ha.enabled`、`redisHA.enabled` 为生产环境推荐启用的配置项，可根据实际需求调整。
+> - Helm 版本需要 >= 3.17.0。
+
+### 方法 2：Web Installer 安装
+
+#### 1. 进入离线包目录并解压工具
+
+KubeKey 工具位于 `tools/{arch}/` 目录下，请根据安装机器的架构解压对应工具。
+
+查看机器架构：
+
+```bash
+uname -m
+```
+
+进入离线包目录：
+
+```bash
+cd artifact/
+```
+
+解压 KubeKey 到离线包目录：
+
+```bash
+tar -zxvf tools/$(uname -m)/kubekey-v4.x.x-linux-$(uname -m).tar.gz -C .
+```
+
+解压 `kubekey-artifact.tgz` 到工作目录。该文件包含安装时所需的所有资源：二进制文件、Helm Chart 包、镜像文件等。
+
+```bash
+mkdir kubekey
+tar -zxvf kubekey-artifact.tgz -C kubekey
+```
+
+#### 2. 启动 Web Installer
+
+解压 Web Installer 安装包
+
+```shell
+tar -zxvf web-installer.tgz
+```
+
+执行以下命令启动 Web Installer 页面：
+
+```shell
+./kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
+```
+
+如果显示如下信息，表示 Web Installer 启动成功：
+
+```text
+Web server started successfully on port 8080
+```
+
+请勿关闭命令终端。
+
+#### 3. 通过 Web Installer 部署 Kubernetes 和 KubeSphere
+
+在浏览器中访问 `http://<部署节点 IP 地址>:8080`，点击 **开始安装**，进入部署流程。
+
+##### 3.1 添加集群节点
+
+在 **基本信息** 页面，添加集群节点。每个节点需要指定角色，支持以下三种：
+
+- **Master**：控制平面节点，负责集群调度与管理。Master 节点上会自动安装 etcd。
+- **Worker**：工作节点，运行实际业务容器。
+- **Image**：镜像仓库节点，用于自动部署私有镜像仓库。离线安装时通常需要配置此角色。
+
+Web Installer 支持以下三种节点添加方式：
+
+- **手动添加**：适用于添加单个节点。您需要填写主机名、IP 地址、SSH 地址、SSH 认证等信息。
+- **文件上传**：适用于批量添加节点。请根据模板填写节点信息后上传文件。
+- **节点扫描**：适用于自动发现节点。您可以通过 IP CIDR 扫描节点，并根据扫描结果选择需要添加的节点。
+
+> **注意**：如果只添加一个节点，节点角色必须为 `Master & Worker`。
+
+
+##### 3.2 修改配置参数
+
+配置部署 Kubernetes 和 KubeSphere 所需的参数。
+
+Kubernetes 和 KubeSphere Core 标签页均支持 **表单模式** 和 **YAML 模式**。您可以在表单中填写配置信息（所有参数均需配置），也可以直接编辑 YAML 文件。如需了解更多配置信息，请参阅[配置示例](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md)。
+
+> **说明**：如果选择安装镜像仓库，需通过 **YAML 模式** 添加以下参数，跳过在线下载：
+>
+> ```yaml
+> download:
+>   fetch: false
+> ```
+
+**安装镜像仓库**
+
+如果需要在安装集群时同时部署私有镜像仓库，请在添加节点时添加 Image 角色的节点，并在 Kubernetes 配置参数中将镜像仓库类型设置为 `harbor` 或 `docker-registry`：
+
+- **单节点镜像仓库**：添加 1 个 Image 角色节点，在 Kubernetes 配置参数中设置镜像仓库类型。
+- **高可用镜像仓库**：添加多个 Image 角色节点（建议 ≥ 3 个），在 Kubernetes 配置参数中设置镜像仓库类型，并配置镜像仓库高可用虚拟 IP 作为访问入口。
+
+配置完成后，点击 **下一步**。
+
+##### 3.3 安装预览
+
+在 **安装预览** 页面，确认版本等信息无误后，点击 **下一步：执行安装** 开始安装。也可以返回上一步修改配置参数。
+
+##### 3.4 安装
+
+耐心等待安装完成。安装完成后，系统会自动进入安装校验步骤。
+
+若安装过程中出现异常，点击 **查看日志** 查看日志详情，退出或初始化后重新安装。
+
+> **说明**：若需要在 Web Installer 页面重新安装、修改配置参数或清除配置，点击左侧的 **初始化** 按钮，将重置 Kubernetes 节点上的所有任务并回到基本信息页面。初始化操作不可逆，请谨慎执行。
+
+##### 3.5 安装校验
+
+1. 在 **安装校验** 页面，点击 **开始检测**，系统将自动运行对应的检测脚本验证系统可用性。
+2. 若通过系统检测，点击 **完成**，可查看 KubeSphere 的访问地址、管理员用户名和默认密码。
+3. 在网页浏览器上输入访问地址，登录 KubeSphere Web 控制台，即可开始使用 KubeSphere。
+
+> **说明**：取决于您的网络环境，您可能需要配置流量转发规则并在防火墙中放行 `30880` 端口。
+
+## 访问 KubeSphere Web 控制台
+
+安装完成后，在浏览器中访问安装结果中显示的 KubeSphere 控制台地址。
+
+使用安装结果中显示的管理员用户名和默认密码登录 KubeSphere Web 控制台。首次登录后，建议立即修改默认密码。
+
+## 常见问题
+
+**Q：打包时选择的版本与安装时使用的版本不一致？**
+A：安装使用的 Kubernetes 版本必须包含在构建离线包时 `spec.download.kubernetes.kube_version` 列表中，否则离线包中不包含该版本的镜像。
+
+**Q：Web Installer 能否安装私有镜像仓库？**
+A：支持。在添加节点时添加 Image 角色的节点，并在 Kubernetes 配置参数中设置镜像仓库类型（`harbor` 或 `docker-registry`）。部署高可用镜像仓库时，需添加多个 Image 角色节点并配置镜像仓库高可用虚拟 IP 作为访问入口。
+
+**Q：镜像推送失败？**
+A：请确认 `config.yaml` 中仓库地址、用户名和密码正确，且网络可访问 `5000` 端口。
+
+**Q：为何推送镜像时会去在线拉取 hub.kubesphere.com.cn 镜像？**
+A：在推送镜像到私有镜像仓库之前，KubeKey 会先在线检查本地镜像文件的完整性（校验镜像清单与仓库中的镜像是否一致）。如无需在线检查，可在 `config.yaml` 中将 `spec.download.fetch` 设置为 `false` 来跳过该在线检查，从而完全离线完成镜像推送。
+
+**Q：单台机器如何添加？**
+A：节点角色必须为 `Master & Worker`。
+
+**Q：如何重新执行安装？**
+A：Web Installer 中点击 **初始化** 按钮（该操作不可逆）；命令行方式请在清理节点后重新执行 `kk create cluster`。
+
+**Q：如何保留 CA 证书用于后续添加节点？**
+A：如果使用 KubeKey 默认证书，请在安装完成后保留 `<工作目录>/kubekey/pki/root.crt` 文件（默认工作目录为 `/root/kubekey`）。后续添加节点时可能需要该证书。
+
+**Q：如何在有网络环境中安装？**
+A：请参考[在线安装 Kubernetes 和 KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/01-online-install-kubernetes-and-kubesphere/)。

--- a/docs/zh/installation/online.md
+++ b/docs/zh/installation/online.md
@@ -1,6 +1,6 @@
-# 在线安装 Kubernetes 和 KubeSphere
+# 在线安装 Kubernetes
 
-本节介绍如何在可访问 Internet 的环境下安装 Kubernetes 和 KubeSphere。
+本节介绍如何在可访问 Internet 的环境下安装 Kubernetes。
 
 安装过程中将使用开源工具 KubeKey 的 v4.x 版本。有关 KubeKey 的更多信息，请访问 [GitHub KubeKey 仓库](https://github.com/kubesphere/kubekey)。
 
@@ -11,24 +11,16 @@
 - **控制平面节点（Master）**：负责集群的调度与管理，通常不运行业务负载。
 - **工作节点（Worker）**：运行实际业务容器的工作负载节点。
 - **etcd**：分布式键值存储，保存集群的所有关键状态数据。
-- **容器运行时**：负责创建和运行容器的底层软件。KubeKey 支持自动安装 Docker 和 containerd 两种容器运行时。如需使用 CRI-O 或 iSula，需提前手动安装，但其与 KubeSphere 的兼容性尚未经过充分验证。
+- **容器运行时**：负责创建和运行容器的底层软件。KubeKey 支持自动安装 Docker 和 containerd 两种容器运行时。
 - **CNI（容器网络插件）**：为集群中的 Pod 提供网络连通能力，常用插件包括 Calico、Cilium、Flannel 等。
 
 ## 前提条件
 
-- 至少需要 1 台 Linux 服务器作为集群节点。在生产环境中，为确保集群具备高可用性，建议准备至少 5 台 Linux 服务器，其中 3 台作为控制平面节点，另外 2 台作为工作节点。如果您在多台 Linux 服务器上安装 KubeSphere，请确保所有服务器属于同一子网。
+- 至少需要 1 台 Linux 服务器作为集群节点。在生产环境中，为确保集群具备高可用性，建议准备至少 5 台 Linux 服务器，其中 3 台作为控制平面节点，另外 2 台作为工作节点。如果您在多台 Linux 服务器上安装 Kubernetes，请确保所有服务器属于同一子网。
 - 集群节点的操作系统和版本须为 Ubuntu 18.04、Ubuntu 20.04、Ubuntu 22.04、Ubuntu 24.04、Debian 10、Debian 11、CentOS 8、AlmaLinux 9.0 或 Kylin v10。多台服务器的操作系统可以不同。关于其它操作系统和版本支持，请咨询青云科技官方解决方案专家或交付服务专家。
 - 在生产环境中，为确保集群具有足够的计算和存储资源，建议每台集群节点配置至少 8 个 CPU 核心、16 GB 内存和 200 GB 磁盘空间。除此之外，建议在每台集群节点的 `/var/lib/docker`（对于 Docker）或 `/var/lib/containerd`（对于 containerd）目录额外挂载至少 200 GB 磁盘空间，用于存储容器运行时数据。
-- 在生产环境中，建议提前为 KubeSphere 集群配置高可用性，以避免单个控制平面节点出现故障时集群服务中断。有关更多信息，请参阅[配置高可用性](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/)。
-
-  > **说明**：如果您规划了多个控制平面节点，请务必提前为集群配置高可用性。
-
-- 默认情况下，KubeSphere 使用集群节点的本地磁盘空间作为持久化存储。在生产环境中，建议提前配置外部存储系统作为持久化存储。有关更多信息，请参阅[配置外部持久化存储](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/)。
 - 如果集群节点未安装容器运行时，安装工具 KubeKey 将在安装过程中自动为每个集群节点安装容器运行时。KubeKey 默认安装 containerd，您也可以在配置文件中指定 Docker 作为容器运行时。
-
-  > **说明**：如需使用 CRI-O 或 iSula，需提前手动安装，但其与 KubeSphere 的兼容性尚未经过充分验证，可能存在未知问题。
-
-- 请确保所有集群节点上 `/etc/resolv.conf` 文件中配置的 DNS 服务器地址可用。否则，KubeSphere 集群可能会出现域名解析问题。
+- 请确保所有集群节点上 `/etc/resolv.conf` 文件中配置的 DNS 服务器地址可用。否则，集群可能会出现域名解析问题。
 - 请确保在所有集群节点上都可以使用 `sudo`、`tar`、`curl` 和 `openssl` 命令。
 - 请确保所有集群节点时间同步。
 
@@ -36,7 +28,7 @@
 
 ## 配置防火墙规则
 
-KubeSphere 需要特定端口和协议用于服务之间的通信。如果您的基础设施环境已启用防火墙，您需要在防火墙设置中放行所需的端口和协议。如果您的基础设施环境未启用防火墙，您可以跳过此步骤。
+Kubernetes 需要特定端口和协议用于服务之间的通信。如果您的基础设施环境已启用防火墙，您需要在防火墙设置中放行所需的端口和协议。如果您的基础设施环境未启用防火墙，您可以跳过此步骤。
 
 下表列出需要在防火墙中放行的端口和协议。
 
@@ -57,18 +49,11 @@ KubeSphere 需要特定端口和协议用于服务之间的通信。如果您的
 
 如需在测试环境中临时关闭防火墙，可执行 `systemctl stop firewalld`；生产环境请按上表精确放行所需端口。
 
-## 选择安装方式
+## 安装 Kubernetes
 
-以下两种方法均可完成 Kubernetes 和 KubeSphere 的安装，**安装结果一致，您只需选择其中一种操作入口即可，无需同时执行**：
+当前仅支持命令行安装方式。
 
-- **方法 1：命令行安装**：适用于熟悉命令行操作、需要精细化配置集群参数的场景。
-- **方法 2：Web Installer 安装**：适用于希望通过图形化界面完成节点添加、参数配置和安装校验的场景。
-
-> **说明**：两种方法任选其一，请勿重复执行。
-
-### 方法 1：命令行安装
-
-#### 1. 下载 KubeKey
+### 1. 下载 KubeKey
 
 如果您访问 GitHub / Google APIs 受限，请设置如下环境变量：
 
@@ -86,7 +71,7 @@ curl -sfL https://get-kk.kubesphere.io | SKIP_WEB_INSTALLER=true SKIP_PACKAGE=tr
 
 执行完成后，会在当前目录生成 `kk` 二进制文件。
 
-#### 2. 创建节点配置文件
+### 2. 创建节点配置文件
 
 执行以下命令创建节点配置文件 `inventory.yaml`：
 
@@ -167,7 +152,7 @@ spec:
 | `etcd` | Kubernetes 集群中的 etcd 节点。在 `etcd.hosts` 中配置 `spec.hosts` 中定义的节点名称 |
 | `image_registry` | 用于创建私有镜像仓库的节点。在线安装时通常无需配置 |
 
-#### 3. 创建安装配置文件
+### 3. 创建安装配置文件
 
 执行以下命令创建安装配置文件 `config.yaml`：
 
@@ -175,11 +160,11 @@ spec:
 ./kk create config --with-kubernetes <Kubernetes version> -o .
 ```
 
-将 `<Kubernetes version>` 替换为实际需要的版本，例如 `v1.34.3`。KubeSphere 默认支持 Kubernetes `v1.23` ~ `v1.34`。
+将 `<Kubernetes version>` 替换为实际需要的版本，例如 `v1.34.3`。Kubernetes 默认支持 `v1.23` ~ `v1.34`。
 
 命令执行完毕后将生成安装配置文件 `config-<Kubernetes version>.yaml`。
 
-#### 4. 配置集群参数
+### 4. 配置集群参数
 
 在 `config-<Kubernetes version>.yaml` 中配置 Kubernetes 集群的信息。常用参数如下：
 
@@ -197,7 +182,7 @@ spec:
 
 > **注意**：各参数的完整字段说明请参考[配置参考](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md)。
 
-#### 5. 安装 Kubernetes
+### 5. 安装 Kubernetes
 
 执行以下命令安装 Kubernetes：
 
@@ -211,187 +196,22 @@ spec:
 ./kk create cluster -i inventory.yaml -c config.yaml
 ```
 
-#### 6. 安装 KubeSphere
-
-KubeKey v4.x 将 Kubernetes 和 KubeSphere 解耦安装，安装完 Kubernetes 后需手动执行以下 Helm 命令安装 KubeSphere。
-
-> **说明**：Web Installer 安装方式会自动完成 KubeSphere 的安装，无需手动执行此步骤。
-
-执行以下命令安装 KubeSphere：
+安装完成后，可通过 `kubectl get nodes` 查看集群节点状态：
 
 ```shell
-chart=oci://hub.kubesphere.com.cn/kse/ks-core
-version=1.2.5
-helm upgrade --install -n kubesphere-system --create-namespace ks-core $chart \
-  --debug --wait --version $version --reset-values --take-ownership \
-  --set global.imageRegistry=hub.kubesphere.com.cn,extension.imageRegistry=hub.kubesphere.com.cn
+kubectl get nodes
 ```
-
-> **说明**：
-> - `--take-ownership` 用于接管集群中已存在的同名资源，避免安装冲突。该参数需要 Helm >= 3.17.0。
-
-如果显示如下信息，则表示 KubeSphere 安装成功：
-
-```text
-NOTES:
-Thank you for choosing KubeSphere Helm Chart.
-
-Please be patient and wait for several seconds for the KubeSphere deployment to complete.
-
-1. Wait for Deployment Completion
-
-    Confirm that all KubeSphere components are running by executing the following command:
-
-    kubectl get pods -n kubesphere-system
-
-2. Access the KubeSphere Console
-
-    Once the deployment is complete, you can access the KubeSphere console using the following URL:
-
-    http://<节点 IP 地址>:30880
-
-3. Login to KubeSphere Console
-
-    Use the following credentials to log in:
-
-    Account: admin
-    Password: P@88w0rd
-
-NOTE: It is highly recommended to change the default password immediately after the first login.
-```
-
-### 方法 2：Web Installer 安装
-
-#### 1. 下载 KubeKey 和 Web Installer
-
-如果您访问 GitHub / Google APIs 受限，请设置如下环境变量：
-
-```shell
-export KKZONE=cn
-```
-
-执行以下命令下载 KubeKey 最新版本（含 Web Installer）：
-
-```shell
-curl -sfL https://get-kk.kubesphere.io | SKIP_PACKAGE=true sh -
-```
-
-> **说明**：`SKIP_PACKAGE=true` 表示跳过离线打包脚本（`package.sh`）的下载，在线安装场景无需此脚本。
-
-执行完成后，会在当前目录生成以下文件：
-
-| 原文件 | 解压后文件 |
-|---|---|
-| `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`：KubeKey 二进制文件 |
-| `web-installer.tgz` | `dist`：Web 页面资源；`host-check.yaml`、`kubernetes`、`kubesphere`：任务模板文件；`schema`：配置表单定义；`README.md`：安装说明文档 |
-
-#### 2. 启动 Web Installer
-
-解压 Web Installer 安装包
-
-```shell
-tar -zxvf web-installer.tgz
-```
-
-执行以下命令启动 Web Installer 页面：
-
-```shell
-./kk web --port 8080 --schema-path web-installer/schema --ui-path web-installer/dist
-```
-
-如果显示如下信息，表示 Web Installer 启动成功：
-
-```text
-Web server started successfully on port 8080
-```
-
-请勿关闭命令终端。
-
-#### 3. 通过 Web Installer 部署 Kubernetes 和 KubeSphere
-
-在浏览器中访问 `http://<启动节点 IP 地址>:8080`，打开 KubeKey 的 Web Installer 页面。
-
-在页面中点击 **开始安装**，进入安装流程。
-
-##### 3.1. 添加集群节点
-
-在 **基本信息** 页面，添加集群节点。每个节点需要指定角色，支持以下三种：
-
-- **Master**：控制平面节点，负责集群调度与管理。Master 节点上会自动安装 etcd。
-- **Worker**：工作节点，运行实际业务容器。
-- **Image**：镜像仓库节点，用于自动部署私有镜像仓库。在线安装时通常无需配置此角色。
-
-Web Installer 支持以下三种节点添加方式：
-
-- **手动添加**：适用于添加单个节点。您需要填写主机名、IP 地址、SSH 地址、SSH 认证等信息。
-- **文件上传**：适用于批量添加节点。请根据模板填写节点信息后上传文件。
-- **节点扫描**：适用于自动发现节点。您可以通过 IP CIDR 扫描节点，并根据扫描结果选择需要添加的节点。
-
-> **注意**：如果只添加一个节点，节点角色必须为 `Master & Worker`。
-
-
-##### 3.2. 修改配置参数
-
-在安装配置页面，填写部署 Kubernetes 和 KubeSphere 所需的参数。
-
-Kubernetes 和 KubeSphere Core 标签页均支持 **表单模式** 和 **YAML 模式**。您可以在表单中填写配置信息，也可以直接编辑 YAML 文件。如需了解更多配置参数，请参阅[配置示例](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md)。
-
-> **说明**：如果您访问 GitHub / Google APIs 受限，请切换到 YAML 模式并添加 `zone: cn` 参数，KubeKey 将从国内地址下载二进制文件。同时建议将镜像仓库地址设置为 `hub.kubesphere.com.cn`。切换为国内源后，仅支持有限的 Kubernetes 版本，具体支持版本请参考 [get-images.kubesphere.io](https://get-images.kubesphere.io) 页面的 Kubernetes 标签页。
-
-**安装镜像仓库（可选）**
-
-如果需要在安装集群时同时部署私有镜像仓库，请在添加节点时添加 Image 角色的节点，并在 Kubernetes 配置参数中将镜像仓库类型设置为 `harbor` 或 `docker-registry`：
-
-- **单节点镜像仓库**：添加 1 个 Image 角色节点，在 Kubernetes 配置参数中设置镜像仓库类型。
-- **高可用镜像仓库**：添加多个 Image 角色节点（建议 ≥ 3 个），在 Kubernetes 配置参数中设置镜像仓库类型，并配置镜像仓库高可用虚拟 IP 作为访问入口。
-
-
-配置完成后，点击 **下一步**。
-
-##### 3.3. 预览安装配置
-
-在 **安装预览** 页面，确认版本、节点、网络、存储等信息无误后，点击 **下一步：执行安装** 开始安装。
-
-如需修改配置，可返回上一步重新编辑配置参数。
-
-##### 3.4. 执行安装
-
-等待安装完成。安装完成后，系统会自动进入安装校验流程。
-
-如果安装过程中出现异常，可点击 **查看日志** 查看日志详情，并根据日志信息排查问题。必要时，可强制退出当前安装流程或初始化后重新安装。
-
-> **说明**：如需在 Web Installer 页面重新安装、修改配置参数或清除配置，可点击左侧的 **初始化** 按钮。初始化操作会重置 Kubernetes 节点上的所有任务，并回到基本信息页面。该操作不可逆，请谨慎执行。
-
-##### 3.5. 安装校验
-
-1. 在 **安装校验** 页面，点击 **开始检测**，系统将自动运行检测脚本验证系统可用性。
-2. 如果系统检测通过，点击 **完成**，即可查看 KubeSphere 的访问地址、管理员用户名和默认密码。
-3. 在浏览器中输入访问地址，登录 KubeSphere Web 控制台，即可开始使用 KubeSphere。
-
-> **说明**：取决于您的网络环境，您可能需要配置流量转发规则，并在防火墙中放行 `30880` 端口。
-
-## 访问 KubeSphere Web 控制台
-
-安装完成后，在浏览器中访问安装结果中显示的 KubeSphere 控制台地址。
-
-使用安装结果中显示的管理员用户名和默认密码登录 KubeSphere Web 控制台。首次登录后，建议立即修改默认密码。
 
 ## 常见问题
 
 **Q：下载时访问 GitHub 超时、速度缓慢？**
 A：请先执行 `export KKZONE=cn` 使用国内源后再下载。切换为国内源后，仅支持有限的 Kubernetes 版本，请将 Kubernetes 版本修改为 [get-images.kubesphere.io](https://get-images.kubesphere.io) 页面 **Kubernetes 标签页** 中列出的版本之一（通过 `./kk create config --with-kubernetes <版本> -o .` 指定）。
 
-**Q：单节点部署后无法访问控制台？**
-A：单节点部署时节点角色必须为 `Master & Worker`；同时请确认防火墙已放行 `30880` 端口。
-
 **Q：如何重新执行安装？**
-A：Web Installer 中点击 **初始化** 按钮（该操作不可逆）；命令行方式请在`kk delete cluster --all --with-data`清理节点后重新执行 `kk create cluster`。
+A：请先执行 `kk delete cluster --all --with-data` 清理节点，再重新执行 `kk create cluster`。
 
 **Q：如何保留 CA 证书用于后续添加节点？**
 A：如果使用 KubeKey 默认证书，请在安装完成后保留 `<工作目录>/kubekey/pki/root.crt` 文件（默认工作目录为 `/root/kubekey`）。后续添加节点时可能需要该证书。
 
 **Q：生产环境有哪些额外建议？**
 A：建议至少准备 5 台节点并提前配置高可用性，同时配置外部持久化存储，避免使用节点本地磁盘作为持久化存储。
-
-**Q：如何在无网络环境中安装？**
-A：请参考[离线安装 Kubernetes 和 KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/02-offline-install-kubernetes-and-kubesphere/)。

--- a/docs/zh/installation/online.md
+++ b/docs/zh/installation/online.md
@@ -2,21 +2,75 @@
 
 本节介绍如何在可访问 Internet 的环境下安装 Kubernetes 和 KubeSphere。
 
-安装过程中将用到开源工具 KubeKey。有关 KubeKey 的更多信息，请访问 [GitHub KubeKey 仓库](https://github.com/kubesphere/kubekey)。
+安装过程中将使用开源工具 KubeKey 的 v4.x 版本。有关 KubeKey 的更多信息，请访问 [GitHub KubeKey 仓库](https://github.com/kubesphere/kubekey)。
 
-## 安装依赖项
+## 核心概念
 
-安装过程中依赖 `tar` 工具实现软件包的压缩、解压处理，请提前确认系统环境已预装该命令。
+阅读后续步骤前，建议先了解以下基本概念：
 
-## 安装 Kubernetes 和 KubeSphere
+- **控制平面节点（Master）**：负责集群的调度与管理，通常不运行业务负载。
+- **工作节点（Worker）**：运行实际业务容器的工作负载节点。
+- **etcd**：分布式键值存储，保存集群的所有关键状态数据。
+- **容器运行时**：负责创建和运行容器的底层软件。KubeKey 支持自动安装 Docker 和 containerd 两种容器运行时。如需使用 CRI-O 或 iSula，需提前手动安装，但其与 KubeSphere 的兼容性尚未经过充分验证。
+- **CNI（容器网络插件）**：为集群中的 Pod 提供网络连通能力，常用插件包括 Calico、Cilium、Flannel 等。
 
-支持两种安装方式：**命令行安装** 和 **Web 页面安装**。
+## 前提条件
 
-### 命令行安装
+- 至少需要 1 台 Linux 服务器作为集群节点。在生产环境中，为确保集群具备高可用性，建议准备至少 5 台 Linux 服务器，其中 3 台作为控制平面节点，另外 2 台作为工作节点。如果您在多台 Linux 服务器上安装 KubeSphere，请确保所有服务器属于同一子网。
+- 集群节点的操作系统和版本须为 Ubuntu 18.04、Ubuntu 20.04、Ubuntu 22.04、Ubuntu 24.04、Debian 10、Debian 11、CentOS 8、AlmaLinux 9.0 或 Kylin v10。多台服务器的操作系统可以不同。关于其它操作系统和版本支持，请咨询青云科技官方解决方案专家或交付服务专家。
+- 在生产环境中，为确保集群具有足够的计算和存储资源，建议每台集群节点配置至少 8 个 CPU 核心、16 GB 内存和 200 GB 磁盘空间。除此之外，建议在每台集群节点的 `/var/lib/docker`（对于 Docker）或 `/var/lib/containerd`（对于 containerd）目录额外挂载至少 200 GB 磁盘空间，用于存储容器运行时数据。
+- 在生产环境中，建议提前为 KubeSphere 集群配置高可用性，以避免单个控制平面节点出现故障时集群服务中断。有关更多信息，请参阅[配置高可用性](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/02-configure-high-availability/02-configure-k8s-high-availability/)。
+
+  > **说明**：如果您规划了多个控制平面节点，请务必提前为集群配置高可用性。
+
+- 默认情况下，KubeSphere 使用集群节点的本地磁盘空间作为持久化存储。在生产环境中，建议提前配置外部存储系统作为持久化存储。有关更多信息，请参阅[配置外部持久化存储](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/01-preparations/04-configure-external-persistent-storage/)。
+- 如果集群节点未安装容器运行时，安装工具 KubeKey 将在安装过程中自动为每个集群节点安装容器运行时。KubeKey 默认安装 containerd，您也可以在配置文件中指定 Docker 作为容器运行时。
+
+  > **说明**：如需使用 CRI-O 或 iSula，需提前手动安装，但其与 KubeSphere 的兼容性尚未经过充分验证，可能存在未知问题。
+
+- 请确保所有集群节点上 `/etc/resolv.conf` 文件中配置的 DNS 服务器地址可用。否则，KubeSphere 集群可能会出现域名解析问题。
+- 请确保在所有集群节点上都可以使用 `sudo`、`tar`、`curl` 和 `openssl` 命令。
+- 请确保所有集群节点时间同步。
+
+> **说明**：KubeKey 依赖 `tar` 工具完成软件包的压缩与解压，请务必确认已安装。
+
+## 配置防火墙规则
+
+KubeSphere 需要特定端口和协议用于服务之间的通信。如果您的基础设施环境已启用防火墙，您需要在防火墙设置中放行所需的端口和协议。如果您的基础设施环境未启用防火墙，您可以跳过此步骤。
+
+下表列出需要在防火墙中放行的端口和协议。
+
+| 服务 | 协议 | 行为 | 起始端口 | 结束端口 | 备注 |
+|---|---|---|---|---|---|
+| ssh | TCP | allow | 22 | N/A | — |
+| etcd | TCP | allow | 2379 | 2380 | — |
+| apiserver | TCP | allow | 6443 | N/A | — |
+| calico | TCP | allow | 9099 | 9100 | — |
+| bgp | TCP | allow | 179 | N/A | — |
+| nodeport | TCP | allow | 30000 | 32767 | — |
+| master | TCP | allow | 10250 | 10258 | — |
+| worker | TCP | allow | 10250 | N/A | — |
+| dns | TCP | allow | 53 | N/A | — |
+| dns | UDP | allow | 53 | N/A | — |
+| rpcbind | TCP | allow | 111 | N/A | 使用 NFS 作为持久化存储时需要 |
+| ipip | IPENCAP / IPIP | allow | N/A | N/A | 使用 Calico 时需要 |
+
+如需在测试环境中临时关闭防火墙，可执行 `systemctl stop firewalld`；生产环境请按上表精确放行所需端口。
+
+## 选择安装方式
+
+以下两种方法均可完成 Kubernetes 和 KubeSphere 的安装，**安装结果一致，您只需选择其中一种操作入口即可，无需同时执行**：
+
+- **方法 1：命令行安装**：适用于熟悉命令行操作、需要精细化配置集群参数的场景。
+- **方法 2：Web Installer 安装**：适用于希望通过图形化界面完成节点添加、参数配置和安装校验的场景。
+
+> **说明**：两种方法任选其一，请勿重复执行。
+
+### 方法 1：命令行安装
 
 #### 1. 下载 KubeKey
 
-如果您访问 GitHub/GoogleAPIs 受限，请设置如下环境变量：
+如果您访问 GitHub / Google APIs 受限，请设置如下环境变量：
 
 ```shell
 export KKZONE=cn
@@ -28,11 +82,9 @@ export KKZONE=cn
 curl -sfL https://get-kk.kubesphere.io | SKIP_WEB_INSTALLER=true SKIP_PACKAGE=true sh -
 ```
 
-执行完成后，会在当前目录生成以下文件：
+> **说明**：`SKIP_WEB_INSTALLER=true` 跳过 Web Installer 资源下载，`SKIP_PACKAGE=true` 跳过离线打包脚本下载。命令行安装仅需 `kk` 二进制文件。
 
-| 原文件 | 解压后文件 |
-|--------|-----------|
-| kubekey-v4.x.x-linux-amd64.tar.gz | kk：KubeKey 二进制文件 |
+执行完成后，会在当前目录生成 `kk` 二进制文件。
 
 #### 2. 创建节点配置文件
 
@@ -50,7 +102,7 @@ kind: Inventory
 metadata:
   name: default
 spec:
-  hosts:
+  hosts: # your can set all nodes here. or set nodes on special groups.
     # localhost:
     #   connector:
     #     password: 123456
@@ -63,56 +115,56 @@ spec:
     #     password: 123456
     #   internal_ipv4: 1.1.1.1
   groups:
-    # 所有 Kubernetes 节点
+    # all kubernetes nodes.
     k8s_cluster:
       groups:
         - kube_control_plane
         - kube_worker
-    # 控制平面节点
+    # control_plane nodes
     kube_control_plane:
       hosts:
         - localhost
-    # 工作节点
+    # worker nodes
     kube_worker:
       hosts:
         - localhost
-    # etcd 节点（仅当 etcd_deployment_type 为 external 时）
+    # etcd nodes when etcd_deployment_type is external
     etcd:
       hosts:
         - localhost
 #    image_registry:
 #      hosts:
 #        - localhost
-    # NFS 节点（用于镜像仓库存储和 Kubernetes NFS 存储）
+    # nfs nodes for registry storage. and kubernetes nfs storage
 #    nfs:
 #      hosts:
 #        - localhost
+
 ```
 
-**`spec:hosts` 中配置节点的连接参数：**
+`spec.hosts` 用于配置各节点的连接参数。每个节点以节点名称作为键，例如 `localhost` 或 `node1`。
 
 | 参数 | 描述 |
-|------|------|
+|---|---|
 | `<key>` | 节点名称 |
-| `<key>:connector` | 节点连接信息 |
-| `<key>:connector:type` | 节点连接类型。支持 `local`（本地连接）和 `ssh`（远程连接）。会根据节点名称或 IP 自动识别 |
-| `<key>:connector:host` | 使用 SSH 连接节点时的地址 |
-| `<key>:connector:port` | 使用 SSH 连接节点时的端口。默认值：`22` |
-| `<key>:connector:user` | 使用 SSH 连接节点时的用户名。默认值：`root` |
-| `<key>:connector:password` | 连接节点时的密码。`local` 连接时对应 sudo 密码，`ssh` 连接时对应 SSH 密码 |
-| `<key>:connector:private_key` | SSH 连接节点时的私钥文件路径。密码和密钥任选其一 |
-| `<key>:connector:private_key_content` | SSH 连接节点时的私钥文件内容。可使用密钥内容替代密钥文件路径 |
-| `<key>:internal_ipv4` | 节点在集群中通信时的 IPv4 地址 |
-| `<key>:internal_ipv6` | 节点在集群中通信时的 IPv6 地址 |
+| `<key>.connector.type` | 节点连接类型。支持 `local`（本地连接）和 `ssh`（远程连接）。会根据节点名称或 IP 自动识别 |
+| `<key>.connector.host` | 使用 SSH 连接节点时的地址 |
+| `<key>.connector.port` | 使用 SSH 连接节点时的端口。默认值：`22` |
+| `<key>.connector.user` | 使用 SSH 连接节点时的用户名。默认值：`root` |
+| `<key>.connector.password` | 连接节点时的密码。`local` 连接时对应 sudo 密码，`ssh` 连接时对应 SSH 密码 |
+| `<key>.connector.private_key` | SSH 连接节点时的私钥文件路径。密码和密钥任选其一 |
+| `<key>.connector.private_key_content` | SSH 连接节点时的私钥文件内容。可使用密钥内容替代密钥文件路径 |
+| `<key>.internal_ipv4` | 节点在集群中通信时的 IPv4 地址 |
+| `<key>.internal_ipv6` | 节点在集群中通信时的 IPv6 地址 |
 
-**`spec:groups` 中配置节点的角色信息：**
+`spec.groups` 用于配置节点的角色信息。
 
 | 参数 | 描述 |
-|------|------|
+|---|---|
 | `k8s_cluster` | Kubernetes 集群组织节点。包含 `kube_control_plane` 和 `kube_worker`，无需额外配置 |
-| `kube_control_plane` | Kubernetes 集群中的控制平面节点。在 `kube_control_plane:hosts` 中配置 `spec:hosts` 中定义的节点名称 |
-| `kube_worker` | Kubernetes 集群中的工作节点。在 `kube_worker:hosts` 中配置 `spec:hosts` 中定义的节点名称 |
-| `etcd` | Kubernetes 集群中的 etcd 节点。在 `etcd:hosts` 中配置 `spec:hosts` 中定义的节点名称 |
+| `kube_control_plane` | Kubernetes 集群中的控制平面节点。在 `kube_control_plane.hosts` 中配置 `spec.hosts` 中定义的节点名称 |
+| `kube_worker` | Kubernetes 集群中的工作节点。在 `kube_worker.hosts` 中配置 `spec.hosts` 中定义的节点名称 |
+| `etcd` | Kubernetes 集群中的 etcd 节点。在 `etcd.hosts` 中配置 `spec.hosts` 中定义的节点名称 |
 | `image_registry` | 用于创建私有镜像仓库的节点。在线安装时通常无需配置 |
 
 #### 3. 创建安装配置文件
@@ -123,31 +175,37 @@ spec:
 ./kk create config --with-kubernetes <Kubernetes version> -o .
 ```
 
-将 `<Kubernetes version>` 替换为实际需要的版本，例如 `v1.27.4`。KubeSphere 默认支持 Kubernetes `v1.23~v1.34`。
+将 `<Kubernetes version>` 替换为实际需要的版本，例如 `v1.34.3`。KubeSphere 默认支持 Kubernetes `v1.23` ~ `v1.34`。
 
 命令执行完毕后将生成安装配置文件 `config-<Kubernetes version>.yaml`。
 
 #### 4. 配置集群参数
 
-在 `config-<Kubernetes version>.yaml` 中配置 Kubernetes 集群的信息：
+在 `config-<Kubernetes version>.yaml` 中配置 Kubernetes 集群的信息。常用参数如下：
 
 | 参数 | 描述 |
-|------|------|
-| `zone` | 文件及镜像的下载区域。如果您访问 GitHub/GoogleAPIs 受限，请将该值设置为 `cn` |
-| `kubernetes` | Kubernetes 相关配置 |
-| `etcd` | etcd 相关配置 |
-| `image_registry` | 私有镜像仓库相关配置 |
-| `cri` | 容器运行时相关配置 |
-| `cni` | 网络插件相关配置 |
-| `storage_class` | 存储插件相关配置 |
-| `dns` | 域名解析相关配置 |
-| `image_manifests` | 需要下载的额外镜像 |
+|---|---|
+| `zone` | 文件及镜像的下载区域。如果您访问 GitHub / Google APIs 受限，请将该值设置为 `cn` |
+| `kubernetes` | Kubernetes 集群配置，包括版本、控制平面端点、网络 CIDR 等 |
+| `etcd` | etcd 集群配置，包括安装方式（内置或外部）、数据目录等 |
+| `image_registry` | 私有镜像仓库配置。在线安装时通常使用默认值 |
+| `cri` | 容器运行时配置，可选择 `docker` 或 `containerd` |
+| `cni` | 网络插件配置，可选择 `calico`、`cilium`、`flannel` 等 |
+| `storage_class` | 存储插件配置，支持 `local`、`nfs` 等 |
+| `dns` | 域名解析配置 |
+| `image_manifests` | 需要额外下载的镜像列表 |
 
-> **注意**：完整的配置参数说明请参考 [配置参考](../reference/config.md)。
+> **注意**：各参数的完整字段说明请参考[配置参考](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md)。
 
 #### 5. 安装 Kubernetes
 
 执行以下命令安装 Kubernetes：
+
+```shell
+./kk create cluster -i inventory.yaml -c config-<Kubernetes version>.yaml
+```
+
+如果已将安装配置文件重命名为 `config.yaml`，则可使用以下命令：
 
 ```shell
 ./kk create cluster -i inventory.yaml -c config.yaml
@@ -155,21 +213,26 @@ spec:
 
 #### 6. 安装 KubeSphere
 
+KubeKey v4.x 将 Kubernetes 和 KubeSphere 解耦安装，安装完 Kubernetes 后需手动执行以下 Helm 命令安装 KubeSphere。
+
+> **说明**：Web Installer 安装方式会自动完成 KubeSphere 的安装，无需手动执行此步骤。
+
 执行以下命令安装 KubeSphere：
 
 ```shell
 chart=oci://hub.kubesphere.com.cn/kse/ks-core
-version=1.2.4
+version=1.2.5
 helm upgrade --install -n kubesphere-system --create-namespace ks-core $chart \
   --debug --wait --version $version --reset-values --take-ownership \
   --set global.imageRegistry=hub.kubesphere.com.cn,extension.imageRegistry=hub.kubesphere.com.cn
 ```
 
-> **注意**：Helm 版本需要 >= 3.17.0
+> **说明**：
+> - `--take-ownership` 用于接管集群中已存在的同名资源，避免安装冲突。该参数需要 Helm >= 3.17.0。
 
 如果显示如下信息，则表示 KubeSphere 安装成功：
 
-```
+```text
 NOTES:
 Thank you for choosing KubeSphere Helm Chart.
 
@@ -185,7 +248,7 @@ Please be patient and wait for several seconds for the KubeSphere deployment to 
 
     Once the deployment is complete, you can access the KubeSphere console using the following URL:
 
-    http://192.168.6.10:30880
+    http://<节点 IP 地址>:30880
 
 3. Login to KubeSphere Console
 
@@ -197,11 +260,11 @@ Please be patient and wait for several seconds for the KubeSphere deployment to 
 NOTE: It is highly recommended to change the default password immediately after the first login.
 ```
 
-### Web 页面安装
+### 方法 2：Web Installer 安装
 
-#### 1. 下载 KubeKey（含 Web Installer）
+#### 1. 下载 KubeKey 和 Web Installer
 
-如果您访问 GitHub/GoogleAPIs 受限，请设置如下环境变量：
+如果您访问 GitHub / Google APIs 受限，请设置如下环境变量：
 
 ```shell
 export KKZONE=cn
@@ -213,14 +276,22 @@ export KKZONE=cn
 curl -sfL https://get-kk.kubesphere.io | SKIP_PACKAGE=true sh -
 ```
 
+> **说明**：`SKIP_PACKAGE=true` 表示跳过离线打包脚本（`package.sh`）的下载，在线安装场景无需此脚本。
+
 执行完成后，会在当前目录生成以下文件：
 
 | 原文件 | 解压后文件 |
-|--------|-----------|
-| kubekey-v4.x.x-linux-amd64.tar.gz | kk：KubeKey 二进制文件 |
-| web-installer.tgz | dist：Web 页面资源<br>host-check.yaml、kubernetes、kubesphere：任务模板文件<br>schema：配置文件<br>README.md：安装说明文档 |
+|---|---|
+| `kubekey-v4.x.x-linux-amd64.tar.gz` | `kk`：KubeKey 二进制文件 |
+| `web-installer.tgz` | `dist`：Web 页面资源；`host-check.yaml`、`kubernetes`、`kubesphere`：任务模板文件；`schema`：配置表单定义；`README.md`：安装说明文档 |
 
 #### 2. 启动 Web Installer
+
+解压 Web Installer 安装包
+
+```shell
+tar -zxvf web-installer.tgz
+```
 
 执行以下命令启动 Web Installer 页面：
 
@@ -230,8 +301,97 @@ curl -sfL https://get-kk.kubesphere.io | SKIP_PACKAGE=true sh -
 
 如果显示如下信息，表示 Web Installer 启动成功：
 
-```
+```text
 Web server started successfully on port 8080
 ```
 
-请勿关闭命令终端，在浏览器中通过 `http://<启动节点 IP 地址>:8080` 打开 KubeKey 的 UI 页面。
+请勿关闭命令终端。
+
+#### 3. 通过 Web Installer 部署 Kubernetes 和 KubeSphere
+
+在浏览器中访问 `http://<启动节点 IP 地址>:8080`，打开 KubeKey 的 Web Installer 页面。
+
+在页面中点击 **开始安装**，进入安装流程。
+
+##### 3.1. 添加集群节点
+
+在 **基本信息** 页面，添加集群节点。每个节点需要指定角色，支持以下三种：
+
+- **Master**：控制平面节点，负责集群调度与管理。Master 节点上会自动安装 etcd。
+- **Worker**：工作节点，运行实际业务容器。
+- **Image**：镜像仓库节点，用于自动部署私有镜像仓库。在线安装时通常无需配置此角色。
+
+Web Installer 支持以下三种节点添加方式：
+
+- **手动添加**：适用于添加单个节点。您需要填写主机名、IP 地址、SSH 地址、SSH 认证等信息。
+- **文件上传**：适用于批量添加节点。请根据模板填写节点信息后上传文件。
+- **节点扫描**：适用于自动发现节点。您可以通过 IP CIDR 扫描节点，并根据扫描结果选择需要添加的节点。
+
+> **注意**：如果只添加一个节点，节点角色必须为 `Master & Worker`。
+
+
+##### 3.2. 修改配置参数
+
+在安装配置页面，填写部署 Kubernetes 和 KubeSphere 所需的参数。
+
+Kubernetes 和 KubeSphere Core 标签页均支持 **表单模式** 和 **YAML 模式**。您可以在表单中填写配置信息，也可以直接编辑 YAML 文件。如需了解更多配置参数，请参阅[配置示例](https://github.com/kubesphere/kubekey/blob/main/docs/zh/reference/config.md)。
+
+> **说明**：如果您访问 GitHub / Google APIs 受限，请切换到 YAML 模式并添加 `zone: cn` 参数，KubeKey 将从国内地址下载二进制文件。同时建议将镜像仓库地址设置为 `hub.kubesphere.com.cn`。切换为国内源后，仅支持有限的 Kubernetes 版本，具体支持版本请参考 [get-images.kubesphere.io](https://get-images.kubesphere.io) 页面的 Kubernetes 标签页。
+
+**安装镜像仓库（可选）**
+
+如果需要在安装集群时同时部署私有镜像仓库，请在添加节点时添加 Image 角色的节点，并在 Kubernetes 配置参数中将镜像仓库类型设置为 `harbor` 或 `docker-registry`：
+
+- **单节点镜像仓库**：添加 1 个 Image 角色节点，在 Kubernetes 配置参数中设置镜像仓库类型。
+- **高可用镜像仓库**：添加多个 Image 角色节点（建议 ≥ 3 个），在 Kubernetes 配置参数中设置镜像仓库类型，并配置镜像仓库高可用虚拟 IP 作为访问入口。
+
+
+配置完成后，点击 **下一步**。
+
+##### 3.3. 预览安装配置
+
+在 **安装预览** 页面，确认版本、节点、网络、存储等信息无误后，点击 **下一步：执行安装** 开始安装。
+
+如需修改配置，可返回上一步重新编辑配置参数。
+
+##### 3.4. 执行安装
+
+等待安装完成。安装完成后，系统会自动进入安装校验流程。
+
+如果安装过程中出现异常，可点击 **查看日志** 查看日志详情，并根据日志信息排查问题。必要时，可强制退出当前安装流程或初始化后重新安装。
+
+> **说明**：如需在 Web Installer 页面重新安装、修改配置参数或清除配置，可点击左侧的 **初始化** 按钮。初始化操作会重置 Kubernetes 节点上的所有任务，并回到基本信息页面。该操作不可逆，请谨慎执行。
+
+##### 3.5. 安装校验
+
+1. 在 **安装校验** 页面，点击 **开始检测**，系统将自动运行检测脚本验证系统可用性。
+2. 如果系统检测通过，点击 **完成**，即可查看 KubeSphere 的访问地址、管理员用户名和默认密码。
+3. 在浏览器中输入访问地址，登录 KubeSphere Web 控制台，即可开始使用 KubeSphere。
+
+> **说明**：取决于您的网络环境，您可能需要配置流量转发规则，并在防火墙中放行 `30880` 端口。
+
+## 访问 KubeSphere Web 控制台
+
+安装完成后，在浏览器中访问安装结果中显示的 KubeSphere 控制台地址。
+
+使用安装结果中显示的管理员用户名和默认密码登录 KubeSphere Web 控制台。首次登录后，建议立即修改默认密码。
+
+## 常见问题
+
+**Q：下载时访问 GitHub 超时、速度缓慢？**
+A：请先执行 `export KKZONE=cn` 使用国内源后再下载。切换为国内源后，仅支持有限的 Kubernetes 版本，请将 Kubernetes 版本修改为 [get-images.kubesphere.io](https://get-images.kubesphere.io) 页面 **Kubernetes 标签页** 中列出的版本之一（通过 `./kk create config --with-kubernetes <版本> -o .` 指定）。
+
+**Q：单节点部署后无法访问控制台？**
+A：单节点部署时节点角色必须为 `Master & Worker`；同时请确认防火墙已放行 `30880` 端口。
+
+**Q：如何重新执行安装？**
+A：Web Installer 中点击 **初始化** 按钮（该操作不可逆）；命令行方式请在`kk delete cluster --all --with-data`清理节点后重新执行 `kk create cluster`。
+
+**Q：如何保留 CA 证书用于后续添加节点？**
+A：如果使用 KubeKey 默认证书，请在安装完成后保留 `<工作目录>/kubekey/pki/root.crt` 文件（默认工作目录为 `/root/kubekey`）。后续添加节点时可能需要该证书。
+
+**Q：生产环境有哪些额外建议？**
+A：建议至少准备 5 台节点并提前配置高可用性，同时配置外部持久化存储，避免使用节点本地磁盘作为持久化存储。
+
+**Q：如何在无网络环境中安装？**
+A：请参考[离线安装 Kubernetes 和 KubeSphere](https://docs.kubesphere.com.cn/v4.2.1/03-installation-and-upgrade/02-install-kubesphere/02-offline-install-kubernetes-and-kubesphere/)。


### PR DESCRIPTION
/kind documentation

## What does this PR do

Update the online & offline installation guides for Kubernetes and KubeSphere, keeping the zh and en docs consistent.

### Background / Motivation

The zh docs were a short base version and the en docs were even older (missing core concepts, firewall rules, the full Web Installer flow, and the ks-core deploy command). This PR aligns them all to a single, complete structure and version baseline.

### Implementation

Based on the expanded zh draft, translated/synced to en so all four entries (zh/en × online/offline) share the same structure. Sample Kubernetes version aligned to `v1.34.3`, ks-core bumped to `1.2.5`. Added the core concepts, firewall rules (including the offline `local-registry`/`local-apt` ports), the Web Installer flow, the ks-core Helm deploy command, and an FAQ section.

### Key Changes

| File | What changed |
|---|---|
| `docs/zh/installation/offline.md` | Expanded to cover overview, roles, firewall, Web Installer flow, ks-core deploy; K8s sample → v1.34.3; fixed typos |
| `docs/zh/installation/online.md` | Expanded with core concepts, prerequisites, firewall, Web Installer flow, FAQ; sample → v1.34.3, ks-core → 1.2.5 |
| `docs/en/installation/offline.md` | Fully rewritten to mirror the expanded zh offline doc; sample → v1.34.3, ks-core-1.2.5.tgz |
| `docs/en/installation/online.md` | Fully rewritten to mirror the expanded zh online doc; sample → v1.34.3, version=1.2.5 |

## Impact

- **Affected modules**: documentation only (`docs/{zh,en}/installation/`)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

None

## Testing

### Verification performed

- [ ] Unit tests pass (N/A — docs only)
- [ ] Integration / E2E tests pass (N/A — docs only)
- [x] Manual verification

### Steps to verify

1. Checked that the sample Kubernetes version (`v1.34.3`) and ks-core version (`1.2.5`) are consistent across `docs/zh` and `docs/en`.
2. Verified online (OCI chart, `version=1.2.5`) and offline (local `ks-core-1.2.5.tgz`) paths match their respective scenarios.
3. Rendered each markdown file to confirm headings, tables, and code blocks are valid.

### Test coverage

No code changed; version-consistency grep checks performed between zh and en docs.

## Rollback

Plain revert of this commit.

### Does this PR introduce a user-facing change?

```release-note
None
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated (N/A — docs only)
- [x] Docs / CHANGELOG updated
- [ ] Local lint and build pass (N/A — docs only)
- [x] Breaking changes marked above (None)

### Additional documentation, usage docs, etc.:

```docs
```

## Notes for Reviewer

Focus on whether the expanded zh and en docs remain technically accurate (versions, commands, firewall ports) and consistent with the repo's current defaults.
