### PR TITLE
fix(cilium ): close semver conditional with if block

### DIFF
--- a/builtin/core/roles/cni/cilium/templates/values.yaml
+++ b/builtin/core/roles/cni/cilium/templates/values.yaml
@@ -97,7 +97,7 @@ authentication:
     spire:
       # Settings to control the SPIRE installation and configuration
       install:
-        {{- .cni.cilium_version | semverCompare ">=1.15.0" }}
+        {{- if .cni.cilium_version | semverCompare ">=1.15.0" }}
         # -- init container image of SPIRE agent and server
         initImage:
           repository: "{{ .image_registry.dockerio_registry }}/library/busybox"


### PR DESCRIPTION
/kind bug

## What does this PR do

Fixes the malformed Cilium SPIRE version conditional that causes KubeKey cluster creation to fail with `unexpected {{end}}`.

### Background / Motivation

When installing Kubernetes 1.34.3 with Cilium 1.19.1, KubeKey fails while generating the default Cilium values file. The template contains a `semverCompare` expression followed by `{{- end }}`, but the opening expression is not an `if` block.

The failure occurs before Helm installs Cilium and prevents cluster creation from completing.

### Implementation

Change the opening template expression to an `if` conditional so that it matches the existing closing `{{- end }}`. This is the smallest possible fix and preserves the existing version-dependent behavior.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/cni/cilium/templates/values.yaml` | Changed the SPIRE `initImage` conditional from a standalone `semverCompare` expression to an `if` block. |

## Impact

- **Affected modules**: Cilium installation template.
- **API changes**: None.
- **Database / state changes**: None.
- **Config changes**: None.
- **Dependency changes**: None.

## Breaking Changes

None.

### Which issue(s) this PR fixes:

Fixes #3205

## Testing

### Verification performed

- [x] Unit tests pass (`go test ./...`)
- [ ] Integration / E2E tests pass (`N/A; no automated integration test was added`)
- [x] Manual verification

The issue was reproduced before the patch with the following error:

```text
template: kubekey:104: unexpected {{end}}
