### PR TITLE
fix: comment out explicit LimitNOFILE in all container runtime units

### DIFF
--- a/builtin/capkk/roles/init/init-os/templates/init-os.sh
+++ b/builtin/capkk/roles/init/init-os/templates/init-os.sh
@@ -138,6 +138,12 @@ mv $tmpfile /etc/sysctl.conf
 # ------------------------ 4. Security Limit ------------------------------------
 
 # ulimit
+# NOTE: written to /etc/security/limits.conf, which is a PAM mechanism. These
+# limits apply ONLY to login sessions (SSH/console/su/cron), NOT to
+# systemd-managed services such as containerd/kubelet, and therefore do NOT
+# affect containers or in-container processes. Changing them does not change the
+# limits containers inherit; for that, adjust the container runtime's systemd
+# unit LimitNOFILE instead.
 echo "* soft nofile 1048576" >> /etc/security/limits.conf
 echo "* hard nofile 1048576" >> /etc/security/limits.conf
 echo "* soft nproc 65536" >> /etc/security/limits.conf

--- a/builtin/capkk/roles/install/cri/files/containerd.service
+++ b/builtin/capkk/roles/install/cri/files/containerd.service
@@ -16,7 +16,13 @@ RestartSec=5
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=1048576
+# LimitNOFILE is intentionally commented out: a high value is inherited by every
+# container spawned by containerd, forcing in-container subprocesses that close
+# inherited FDs (e.g. Python 2 subprocess.Popen with close_fds=True) to scan up
+# to that many file descriptors on every spawn, which is very slow. Let it fall
+# back to the systemd default (1024:524288) so high-FD workloads can still raise
+# their own limit via ulimit/setrlimit in the container entrypoint.
+# LimitNOFILE=1048576
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this version.
 TasksMax=infinity

--- a/builtin/capkk/roles/install/cri/files/docker.service
+++ b/builtin/capkk/roles/install/cri/files/docker.service
@@ -28,7 +28,13 @@ StartLimitInterval=60s
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
+# LimitNOFILE is intentionally commented out: a high value is inherited by every
+# container spawned by docker/containerd, forcing in-container subprocesses that
+# close inherited FDs (e.g. Python 2 subprocess.Popen with close_fds=True) to
+# scan up to that many file descriptors on every spawn, which is very slow.
+# Let it fall back to the systemd default (1024:524288) so high-FD workloads can
+# still raise their own limit via ulimit/setrlimit in the container entrypoint.
+# LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 

--- a/builtin/capkk/roles/install/cri/templates/cri-dockerd.service
+++ b/builtin/capkk/roles/install/cri/templates/cri-dockerd.service
@@ -22,7 +22,13 @@ StartLimitInterval=60s
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
+# LimitNOFILE is intentionally commented out: a high value is inherited by every
+# container spawned by docker/containerd, forcing in-container subprocesses that
+# close inherited FDs (e.g. Python 2 subprocess.Popen with close_fds=True) to
+# scan up to that many file descriptors on every spawn, which is very slow.
+# Let it fall back to the systemd default (1024:524288) so high-FD workloads can
+# still raise their own limit via ulimit/setrlimit in the container entrypoint.
+# LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 

--- a/builtin/core/roles/cri/containerd/files/containerd.service
+++ b/builtin/core/roles/cri/containerd/files/containerd.service
@@ -16,7 +16,13 @@ RestartSec=5
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=1048576
+# LimitNOFILE is intentionally commented out: a high value is inherited by every
+# container spawned by containerd, forcing in-container subprocesses that close
+# inherited FDs (e.g. Python 2 subprocess.Popen with close_fds=True) to scan up
+# to that many file descriptors on every spawn, which is very slow. Let it fall
+# back to the systemd default (1024:524288) so high-FD workloads can still raise
+# their own limit via ulimit/setrlimit in the container entrypoint.
+# LimitNOFILE=1048576
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this version.
 TasksMax=infinity

--- a/builtin/core/roles/cri/docker/files/containerd.service
+++ b/builtin/core/roles/cri/docker/files/containerd.service
@@ -16,7 +16,13 @@ RestartSec=5
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=1048576
+# LimitNOFILE is intentionally commented out: a high value is inherited by every
+# container spawned by containerd, forcing in-container subprocesses that close
+# inherited FDs (e.g. Python 2 subprocess.Popen with close_fds=True) to scan up
+# to that many file descriptors on every spawn, which is very slow. Let it fall
+# back to the systemd default (1024:524288) so high-FD workloads can still raise
+# their own limit via ulimit/setrlimit in the container entrypoint.
+# LimitNOFILE=1048576
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this version.
 TasksMax=infinity

--- a/builtin/core/roles/cri/docker/files/docker.service
+++ b/builtin/core/roles/cri/docker/files/docker.service
@@ -28,7 +28,13 @@ StartLimitInterval=60s
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
+# LimitNOFILE is intentionally commented out: a high value is inherited by every
+# container spawned by docker/containerd, forcing in-container subprocesses that
+# close inherited FDs (e.g. Python 2 subprocess.Popen with close_fds=True) to
+# scan up to that many file descriptors on every spawn, which is very slow.
+# Let it fall back to the systemd default (1024:524288) so high-FD workloads can
+# still raise their own limit via ulimit/setrlimit in the container entrypoint.
+# LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 

--- a/builtin/core/roles/cri/docker/templates/cri-dockerd.service
+++ b/builtin/core/roles/cri/docker/templates/cri-dockerd.service
@@ -22,7 +22,13 @@ StartLimitInterval=60s
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
+# LimitNOFILE is intentionally commented out: a high value is inherited by every
+# container spawned by docker/containerd, forcing in-container subprocesses that
+# close inherited FDs (e.g. Python 2 subprocess.Popen with close_fds=True) to
+# scan up to that many file descriptors on every spawn, which is very slow.
+# Let it fall back to the systemd default (1024:524288) so high-FD workloads can
+# still raise their own limit via ulimit/setrlimit in the container entrypoint.
+# LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 

--- a/builtin/core/roles/native/init/templates/init-os.sh
+++ b/builtin/core/roles/native/init/templates/init-os.sh
@@ -149,6 +149,15 @@ mv $tmpfile /etc/sysctl.conf
 # ------------------------ 4. Security Limit ------------------------------------
 
 # ulimit
+# NOTE: the settings below are written to /etc/security/limits.d/99-kube.conf,
+# which is a PAM mechanism. They ONLY take effect for login sessions (SSH,
+# console, su, cron) and processes started from such sessions.
+# systemd-managed services (containerd, kubelet, kube-proxy, ...) IGNORE these
+# values; they are governed by the LimitNOFILE=/LimitNPROC= directives in their
+# own unit files (or the systemd default). Therefore these limits do NOT
+# propagate into containers, and changing them will NOT affect in-container
+# processes such as compute-server. To adjust the file-descriptor limit that
+# containers inherit, modify the container runtime's systemd unit instead.
 cat << 'EOF' | tee /etc/security/limits.d/99-kube.conf
 * soft nofile 1048576
 * hard nofile 1048576


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
/kind cleanup

## What does this PR do

Comments out (disables) the explicit `LimitNOFILE` directive in **all** container runtime units shipped by KubeKey (containerd, docker, cri-dockerd). The original lines are kept but prefixed with `#`, so the units fall back to the systemd default instead of pinning/inheriting a huge nofile into every container. Also documents that the init-os ulimit settings are PAM-scoped and do not affect containers.

## Background / Motivation

An explicit (million-level or `infinity`) `LimitNOFILE` on the container runtime unit is inherited by every container it spawns. In-container processes that close inherited file descriptors on fork (e.g. Python 2 `subprocess.Popen(close_fds=True)`) scan up to that many file descriptors on every spawn, which is extremely slow. This also matches containerd 2.0's decision (PR #8924) to remove `LimitNOFILE` from its reference unit, since the daemon's rlimit is inherited by containers.

## Implementation

Comment out the `LimitNOFILE` line in every container runtime unit (kept for reference, disabled):
- `containerd.service`: `# LimitNOFILE=1048576`
- `docker.service` / `cri-dockerd.service`: `# LimitNOFILE=infinity`
- both `builtin/core` and `builtin/capkk`

init-os templates got comments clarifying that their ulimit settings are PAM-only and do NOT propagate into containers.

## Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/cri/containerd/files/containerd.service` | comment out `LimitNOFILE=1048576` + note |
| `builtin/core/roles/cri/docker/files/containerd.service` | comment out `LimitNOFILE=1048576` + note |
| `builtin/capkk/roles/install/cri/files/containerd.service` | comment out `LimitNOFILE=1048576` + note |
| `builtin/core/roles/cri/docker/files/docker.service` | comment out `LimitNOFILE=infinity` + note |
| `builtin/core/roles/cri/docker/templates/cri-dockerd.service` | comment out `LimitNOFILE=infinity` + note |
| `builtin/capkk/roles/install/cri/files/docker.service` | comment out `LimitNOFILE=infinity` + note |
| `builtin/capkk/roles/install/cri/templates/cri-dockerd.service` | comment out `LimitNOFILE=infinity` + note |
| `builtin/core/roles/native/init/templates/init-os.sh` | add PAM-scope comment for ulimit block |
| `builtin/capkk/roles/init/init-os/templates/init-os.sh` | add PAM-scope comment for ulimit block |

## Impact

- **Affected modules**: `builtin/core/roles/cri/*`, `builtin/core/roles/native/init`, `builtin/capkk/roles/install/cri/*`, `builtin/capkk/roles/init`
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: container runtime systemd units no longer set an active `LimitNOFILE`; containers inherit the systemd default instead of `1048576`/`infinity`.
- **Dependency changes**: N/A

## Breaking Changes

None for systemd >= 240 (default `1024:524288`). On systemd < 240 the default falls back to the kernel default `1024:4096`; if a node must support higher FD ceilings, uncomment the line or raise it inside the container via `ulimit`/`setrlimit`. High-FD workloads (log collectors, gateways, databases) can always raise their own limit in the container entrypoint.

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Manual verification (grep confirms no active `^LimitNOFILE=` remains in container runtime units)

### Steps to verify

1. Deploy a node with this change and run `cat /proc/$(pgrep containerd)/limits` -> `Max open files` should show the systemd default (e.g. `1024` soft / `524288` hard on systemd >= 240), not `1048576`.
2. Start a sample container and run `cat /proc/<pid>/limits` inside it -> it should inherit the systemd default, not `1048576`/`infinity`.
3. For docker runtime, check `cat /proc/$(pgrep dockerd)/limits` -> no active `LimitNOFILE` (systemd default applies).
4. Verify in-container `subprocess.Popen(close_fds=True)` latency improves (was ~581ms per spawn at 1048576).

### Test coverage

No automated tests for systemd unit templates; behavior is verified manually on a node as above.

## Rollback

Plain revert of this PR restores the active `LimitNOFILE=1048576` / `infinity` values.

### Does this PR introduce a user-facing change?

```release-note
Container runtime systemd units (containerd/docker/cri-dockerd) no longer set an active LimitNOFILE (the lines are commented out); they now use the systemd default. Containers no longer inherit a million-level FD limit. High-FD workloads should raise their own limit via ulimit/setrlimit in the container entrypoint if needed.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [ ] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

- The original `LimitNOFILE` lines are intentionally kept (commented) rather than deleted, so the previous behavior is easy to restore/reference.
- The init-os `nofile 1048576` values are PAM-only and intentionally left as-is; the added comments explain they do not affect containers.
