### PR TITLE
fix: route docker_registry artifact download through the KubeKey mirror

### DIFF
--- a/builtin/core/roles/defaults/defaults/main/10-download.yaml
+++ b/builtin/core/roles/defaults/defaults/main/10-download.yaml
@@ -52,8 +52,7 @@ download:
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}
       github.com/projectcalico/calico/releases/download/{{ "{{ .version }}" }}/calicoctl-linux-{{ "{{ .arch }}" }}
     docker_registry: >-
-      {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}
-      docker.io/registry/{{ "{{ .version }}" }}/docker-registry-{{ "{{ .version }}" }}-linux-{{ "{{ .arch }}" }}.tgz
+      https://{{ .download.cn_host}}/docker.io/registry/{{ "{{ .version }}" }}/docker-registry-{{ "{{ .version }}" }}-linux-{{ "{{ .arch }}" }}.tgz
     docker_compose: >-
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}
       github.com/docker/compose/releases/download/{{ "{{ .version }}" }}/docker-compose-linux-

--- a/pkg/converter/tmpl/template_test.go
+++ b/pkg/converter/tmpl/template_test.go
@@ -146,6 +146,45 @@ func TestKubeVipTemplatesRenderDefaults(t *testing.T) {
 	})
 }
 
+// TestDockerRegistryArtifactURLUsesMirrorHost renders the real docker_registry
+// artifact_url template the same way pkg/modules/http_get_file does: first as
+// the defaults file's own self-referential template, then through tpl with the
+// download item. docker-registry-*.tgz is a KubeKey-repackaged asset that only
+// exists on the cn_host mirror, so the resulting URL must route through
+// cn_host regardless of zone; falling back to a bare "https://docker.io/..."
+// host for non-cn zones 404s (docker.io redirects to www.docker.com).
+func TestDockerRegistryArtifactURLUsesMirrorHost(t *testing.T) {
+	raw, err := os.ReadFile("../../../builtin/core/roles/defaults/defaults/main/10-download.yaml")
+	assert.NoError(t, err)
+
+	var defaults map[string]any
+	assert.NoError(t, yaml.Unmarshal(raw, &defaults))
+
+	download, ok := defaults["download"].(map[string]any)
+	assert.True(t, ok)
+	artifactURL, ok := download["artifact_url"].(map[string]any)
+	assert.True(t, ok)
+	tmplStr, ok := artifactURL["docker_registry"].(string)
+	assert.True(t, ok)
+
+	for _, zone := range []string{"", "cn"} {
+		variable := map[string]any{
+			"zone": zone,
+			"download": map[string]any{
+				"cn_host": download["cn_host"],
+			},
+		}
+
+		rendered, err := Parse(variable, tmplStr)
+		assert.NoError(t, err)
+
+		final, err := Parse(map[string]any{"version": "2.8.3", "arch": "amd64"}, string(rendered))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "https://kubekey.pek3b.qingstor.com/docker.io/registry/2.8.3/docker-registry-2.8.3-linux-amd64.tgz", string(final))
+	}
+}
+
 func TestParseBool(t *testing.T) {
 	testcases := []struct {
 		name      string


### PR DESCRIPTION
### What type of PR is this?

/kind bug

## What does this PR do

Fixes the `docker_registry` artifact download URL so it always resolves to a real host instead of 404ing for non-China zones.

### Background / Motivation

`download.artifact_url.docker_registry` in `builtin/core/roles/defaults/defaults/main/10-download.yaml` used a zone-conditional ternary: for `zone: "cn"` it downloads from `https://{{ .download.cn_host}}/...`, otherwise it fell back to a literal `https://docker.io/registry/{{ .version }}/docker-registry-{{ .version }}-linux-{{ .arch }}.tgz`.

`docker.io` is Docker Hub's marketing domain, not a file host: it 302-redirects to `https://www.docker.com/...`, which 404s for this path. Worse, `docker-registry-<version>-linux-<arch>.tgz` isn't even the real upstream asset name — the actual `distribution/distribution` GitHub releases publish `registry_<version>_linux_<arch>.tar.gz`. The `docker-registry-*.tgz` name is a KubeKey-repackaged asset that only exists on KubeKey's own mirror bucket. So for any non-`cn` zone, this download was guaranteed to 404 regardless of version — not specific to `2.8.3`.

### Implementation

`keepalived`, a few lines below in the same file, already has this exact problem solved: it always downloads from `https://{{ .download.cn_host}}/...` unconditionally, with no zone ternary, because that binary is likewise only available on KubeKey's own mirror. This PR makes `docker_registry` follow the same unconditional pattern, removing the broken non-cn branch instead of trying to find (or fake) a working public mirror for it.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/defaults/defaults/main/10-download.yaml` | `docker_registry` artifact URL always routes through `.download.cn_host`, matching the existing `keepalived` entry, instead of falling back to a broken `https://docker.io/...` URL for non-`cn` zones |
| `pkg/converter/tmpl/template_test.go` | Added `TestDockerRegistryArtifactURLUsesMirrorHost`, a regression test that renders the real template string (two-stage, matching how `builtin/core/roles/download/tasks/binary.yaml` invokes `tpl .download.artifact_url.docker_registry .item`) and asserts the resulting URL for both `zone: ""` and `zone: "cn"` |

## Impact

- **Affected modules**: `builtin/core` download defaults (used by artifact export/import and by `init_registry.yaml` when installing a self-hosted `docker-registry` image registry)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: `download.artifact_url.docker_registry` default value changed; no schema change, still overridable via the same config key
- **Dependency changes**: N/A

## Breaking Changes

None. Users who never set `zone` (or set it to anything other than `"cn"`) previously always got a 404 on this step; they now get a working download from the same mirror bucket already used for `zone: "cn"` and for `keepalived`.

### Which issue(s) this PR fixes:
Fixes #

## Testing

### Verification performed

- [x] Unit tests pass (`go test ./pkg/converter/tmpl/...`)
- [ ] Integration / E2E tests pass (not applicable / not run — see notes)
- [x] Manual verification

### Steps to verify

1. `curl -sIL https://docker.io/registry/2.8.3/docker-registry-2.8.3-linux-amd64.tgz` → redirects to `https://www.docker.com/registry/...` → `404` (confirms the reported failure, independent of version).
2. `curl -s -o /dev/null -w '%{http_code}' https://kubekey.pek3b.qingstor.com/docker.io/registry/2.8.3/docker-registry-2.8.3-linux-amd64.tgz` → `200` (confirms the fix's target host actually serves the file).
3. `go test ./pkg/converter/tmpl/... -run TestDockerRegistryArtifactURLUsesMirrorHost -v` — added test fails on the pre-fix YAML (renders `https://docker.io/registry/2.8.3/docker-registry-2.8.3-linux-amd64.tgz`) and passes on the post-fix YAML (renders `https://kubekey.pek3b.qingstor.com/docker.io/registry/2.8.3/docker-registry-2.8.3-linux-amd64.tgz`).
4. `go build ./...`, `go test ./...`, `make lint` (golangci-lint on changed packages), and `ALL_VERIFY_CHECKS="goimports" make verify` all pass locally.

I could not run a full offline-artifact-export or cluster-install end-to-end (needs a real target host/cluster), so this is disclosed rather than claimed: the fix is validated by a live HTTP check of both URLs plus a fail-then-passing unit test that renders the exact template string production code renders, not by re-running the full `kk artifact export` flow.

### Test coverage

Added `TestDockerRegistryArtifactURLUsesMirrorHost` in `pkg/converter/tmpl/template_test.go`.

## Rollback

Plain revert of this commit; no data or state migration involved.

### Does this PR introduce a user-facing change?

```release-note
Fixed the `docker_registry` artifact download URL always failing with HTTP 404 for non-`cn` zones (e.g. when packaging an offline artifact or installing a self-hosted docker-registry image registry with `zone` unset or not `"cn"`).
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [ ] All commits are GPG-signed (GitHub shows Verified)
- [x] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

`docs/en/reference/config.md` and `docs/zh/reference/config.md` embed a copy of this defaults YAML as a reference snippet and still show the old, buggy ternary for `docker_registry`. There's no generator/test tying those docs to the source YAML, so it's out of scope for this minimal fix, but a maintainer may want a follow-up doc update.

Fixes #3215