### PR TITLE
fix(cni): clean up node-local residue of the active CNI on uninstall

### DIFF
--- a/builtin/core/roles/uninstall/kubernetes/tasks/network.yaml
+++ b/builtin/core/roles/uninstall/kubernetes/tasks/network.yaml
@@ -18,9 +18,12 @@
     {{- end }}
     {{- if .cni.type | eq "cilium" }}
     ip link del cilium_host
+    ip link del cilium_net
     ip link del cilium_vxlan
     {{- end }}
     {{- if .cni.type | eq "calico" }}
+    ip link del tunl0
+    ip link del vxlan.calico
     ip -br link show | grep cali[a-f0-9]* | awk -F @ '{print $1}' | xargs -r -t -n 1 ip link del
     {{- end }}
     ip netns show 2>/dev/null | grep cni- | awk '{print $1}' | xargs -r -t -n 1 ip netns del
@@ -31,9 +34,18 @@
     rm -rf /opt/cni/bin/
     rm -rf /var/lib/cni/
     {{- if .cni.type | eq "calico" }}
+    # `kubeadm reset` does not remove Calico node-local runtime state (nodename, mtu
+    # and the BIRD sockets). On a reused node it would carry into the next cluster and
+    # point BGP at stale, no-longer-existing pod IPs, so clean it up here.
+    rm -rf /var/lib/calico/
+    rm -rf /var/run/calico/
     if path=$(command -v calicoctl 2>/dev/null); then 
       rm -f "$path"
     fi
+    {{- end }}
+    {{- if .cni.type | eq "cilium" }}
+    rm -rf /var/lib/cilium/
+    rm -rf /var/run/cilium/
     {{- end }}
 
 - name: Network | Remove ARP and IP address entries for kube-vip


### PR DESCRIPTION
/kind bug

## What does this PR do

Fill the missing node-local CNI cleanup gaps in `kk delete`'s `network.yaml` — keeping the existing `.cni.type`-guarded branches intact, and only adding the residue deletion that belongs to each branch.

### Background / Motivation

`kk delete`'s network cleanup already removed CNI network config, but it left real residue behind on the node:

- The **Calico** branch never removed Calico's node-local runtime state (`/var/lib/calico`, `/var/run/calico` — `nodename`, `mtu`, and the BIRD sockets). `kubeadm reset` does not clean these. On a reused node they carry into the next cluster: `calico-node` inherits the stale node, and BIRD points its BGP peers at old, no-longer-existing pod IPs → the new cluster's cross-node connectivity stays broken until cleaned by hand (observed as `calico-node 0/1`, `BIRD not ready: BGP not established with <stale pod IPs>` on the control-plane node of a recreated 3-node cluster).
- The **Cilium** branch missed the `cilium_net` interface and Cilium's agent state dirs (`/var/lib/cilium`, `/var/run/cilium`).
- The **Calico** interface block missed `tunl0` and `vxlan.calico`.

### Implementation

Add the missing deletions inside the **existing** `{{- if .cni.type | eq "..." }}` blocks instead of deleting those conditionals. Node-local cleanup stays scoped to the CNI the cluster actually runs, so `rm -rf` never touches directories that belong to a CNI this `kk delete` does not manage.

- Calico state block: add `rm -rf /var/lib/calico/ /var/run/calico/` (the confirmed root-cause fix).
- Cilium state block (new, guarded): `rm -rf /var/lib/cilium/ /var/run/cilium/`.
- Cilium interface block: add `ip link del cilium_net`.
- Calico interface block: add `ip link del tunl0` and `ip link del vxlan.calico`.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/uninstall/kubernetes/tasks/network.yaml` | Add missing per-type node-local CNI residue cleanup inside the `.cni.type`-guarded branches. No conditional was removed. |

## Impact

- **Affected modules**: `uninstall` roles (kubernetes network cleanup)
- **API changes**: N/A
- **Database / state changes**: N/A (deletes node-local CNI runtime state on `kk delete`)
- **Config changes**: N/A
- **Dependency changes**: None

## Breaking Changes

None.

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Unit tests pass — see below
- [x] Manual verification

### Steps to verify

1. `make kk GOOS=linux GOARCH=amd64 BUILDTAGS=builtin`.
2. On a 3-node cluster recreated on reused nodes after `kk delete --with-data`, confirm no leftover Calico/Cilium state and that all `calico-node` pods reach `1/1 Ready` with a fully established BGP mesh.

### Test coverage

- Manual verification only (the E2E harness is maintained separately and not shipped here).
- Existing unit tests: `go test -tags builtin ./...`.

## Rollback

Plain revert of this commit.

### Does this PR introduce a user-facing change?
```release-note
`kk delete` now also removes the Calico/Cilium node-local runtime state and remaining virtual interfaces that `kubeadm reset` leaves behind, preventing residue on reused nodes from breaking the next cluster's cross-node connectivity.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated (manual only)
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`go build -tags builtin`)
- [ ] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

- The `.cni.type` conditionals are preserved; only previously-missing cleanup lines were added inside each CNI's own guard, so `rm -rf` stays scoped to the CNI this uninstall manages.
- `rm -rf` on dirs that do not exist, and `ip link del` on missing links, are no-ops — safe when the CNI was never used.
