### PR TITLE
docs: add cluster upgrade guide and fix upgrade switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ curl -sfL https://get-kk.kubesphere.io | sh -
   - [Offline Installation](docs/en/installation/offline.md)
   - [Add Cluster Nodes](docs/en/installation/add-nodes.md)
   - [Delete Cluster Nodes](docs/en/installation/delete-nodes.md)
+  - [Upgrade Cluster](docs/en/installation/upgrade-cluster.md)
 - **[Configuration Reference](docs/en/reference/config.md)**
 - **Playbooks**
   - [Create Kubernetes Cluster](docs/en/reference/playbooks/create_cluster.md)

--- a/docs/en/installation/README.md
+++ b/docs/en/installation/README.md
@@ -133,6 +133,7 @@ After the cluster is created, you can scale nodes according to business requirem
 
 - **Add Nodes**: Add new control plane, worker, or etcd nodes to an existing Kubernetes cluster. For detailed steps, see [Add Cluster Nodes](add-nodes.md).
 - **Delete Nodes**: Safely remove specified nodes from a Kubernetes cluster. For detailed steps, see [Delete Cluster Nodes](delete-nodes.md).
+- **Upgrade Cluster**: Upgrade the Kubernetes version of an existing cluster, and optionally etcd, the container runtime, the CNI plugin, and the StorageClass provisioner. For detailed steps, see [Upgrade Cluster](upgrade-cluster.md).
 
 ## Enable kubectl autocompletion
 

--- a/docs/en/installation/upgrade-cluster.md
+++ b/docs/en/installation/upgrade-cluster.md
@@ -1,0 +1,103 @@
+# Upgrade Cluster
+
+This section describes how to use KubeKey to upgrade an existing Kubernetes cluster, including the Kubernetes control plane and worker nodes, and optionally etcd, the container runtime, the CNI plugin, and the StorageClass provisioner.
+
+## Prerequisites
+
+- An existing Kubernetes cluster deployed by KubeKey.
+- The target Kubernetes version must be higher than the currently installed version.
+- Back up the cluster before upgrading (especially etcd data) so you can recover if the upgrade fails.
+
+> **Note**: Web Installer does not currently support upgrading the cluster. Please use the command line instead.
+
+## Retrieve Current Cluster Configuration Files
+
+If the cluster was installed via the **Web Installer**, you can retrieve the current cluster configuration files as follows.
+
+### Retrieve inventory.yaml
+
+```shell
+cp kubekey/runtime/kubekey.kubesphere.io/v1/inventories/default/default.yaml kkv4-inventory.yaml
+```
+
+### Retrieve config.yaml
+
+```shell
+cat schema/config.json | jq '{spec: .["kubernetes.json"]}' > kkv4-config.json
+```
+
+## Upgrade Cluster
+
+By default, `kk upgrade cluster` upgrades only the Kubernetes control plane and worker node binaries (`kubeadm` / `kubelet`); other components must be enabled explicitly.
+
+### Upgrade the Kubernetes Version Only
+
+Set the target version with `--with-kubernetes` (or `kubernetes.kube_version` in `config.yaml`):
+
+```shell
+./kk upgrade cluster -i inventory.yaml -c config.yaml --with-kubernetes v1.34.11
+```
+
+KubeKey performs a rolling upgrade: the first control plane node runs `kubeadm upgrade apply`, the remaining control plane nodes run `kubeadm upgrade node`, and all worker nodes are upgraded in parallel.
+
+### Upgrade Components Together
+
+Use `--all` to upgrade etcd, the container runtime, the CNI plugin, and the StorageClass provisioner together with Kubernetes:
+
+```shell
+./kk upgrade cluster -i inventory.yaml -c config.yaml --with-kubernetes v1.34.11 --all
+```
+
+Or enable individual components with `--set`:
+
+```shell
+./kk upgrade cluster -i inventory.yaml -c config.yaml --with-kubernetes v1.34.11 --set upgrade.cni=true
+```
+
+### Upgrade a Single Component Only
+
+The following subcommands upgrade only the named component and leave the Kubernetes control plane and other components untouched:
+
+```shell
+./kk upgrade etcd -i inventory.yaml -c config.yaml
+./kk upgrade cri -i inventory.yaml -c config.yaml
+./kk upgrade cni -i inventory.yaml -c config.yaml
+./kk upgrade storageclass -i inventory.yaml -c config.yaml
+```
+
+## Upgrade Switches
+
+The `upgrade` section in `config.yaml` controls whether optional components are upgraded together:
+
+```yaml
+upgrade:
+  etcd: false          # Whether to upgrade the external etcd cluster
+  cri: false           # Whether to upgrade the container runtime (docker/containerd)
+  cni: false           # Whether to upgrade the CNI plugin
+  storage_class: false # Whether to upgrade the StorageClass provisioner
+```
+
+The switches above can also be overridden on the command line with `--all` or `--set upgrade.<component>=true`.
+
+> **Note**: CoreDNS / NodeLocalDNS are upgraded together with Kubernetes and do not require a separate switch. `image_registry` and `nfs` are not supported for upgrade.
+
+## Multi-Minor Upgrades
+
+`kubeadm` only allows a single-minor upgrade at a time. When the target version spans multiple minor versions, KubeKey automatically steps through them one minor at a time, using the recommended patch version for each intermediate minor defined in `cluster_require.kube_upgrade_path`. You can override a specific hop with `--set cluster_require.kube_upgrade_path.v1.24=v1.24.10`.
+
+## Parameter Reference
+
+| Parameter | Description |
+|-----------|-------------|
+| `-i, --inventory` | Path to the inventory file defining node connection information |
+| `-c, --config` | Path to the config file defining key cluster configuration |
+| `--with-kubernetes` | Specifies the target Kubernetes version to upgrade to. Defaults to `kubernetes.kube_version` in config |
+| `--all` | Upgrades all related components, including etcd, cri, cni and storage_class |
+| `--set` | Overrides a value in config. Format: `--set key=val` or `--set k1=v1,k2=v2` |
+| `-a, --artifact` | Path to the offline package, used in air-gapped environments |
+
+## Important Notes
+
+- **Rolling Upgrade**: KubeKey upgrades the control plane nodes one by one, but worker nodes are upgraded in parallel and are not automatically `cordon`-ed or `drain`-ed. If workload replicas are insufficient or concentrated on certain nodes, services may become briefly unavailable. Manually `drain` nodes beforehand if a strict rolling upgrade is required.
+- **Container Runtime**: When `upgrade.cri=true`, the container runtime service is restarted. With containerd, running containers are usually preserved; with Docker, restarting dockerd may stop running containers unless `live-restore` is enabled.
+- **Backup**: Back up the cluster (especially etcd data) before upgrading so you can recover if the upgrade fails.

--- a/docs/en/reference/playbooks/upgrade_cluster.md
+++ b/docs/en/reference/playbooks/upgrade_cluster.md
@@ -8,16 +8,15 @@ The `upgrade` section in `config.yaml` controls whether optional components are 
 
 ```yaml
 upgrade:
-  cri: false          # Whether to upgrade the container runtime (docker/containerd)
   etcd: false         # Whether to upgrade the external etcd cluster
-  dns: false          # Whether to upgrade CoreDNS / NodeLocalDNS
-  image_registry: false
+  cri: false          # Whether to upgrade the container runtime (docker/containerd)
   cni: false          # Whether to upgrade the CNI plugin
-  storage_class: false
-  nfs: false
+  storage_class: false # Whether to upgrade the StorageClass provisioner
 ```
 
 You can also override them on the command line with `--all` or `--set upgrade.xxx=true`.
+
+> **Note**: CoreDNS / NodeLocalDNS are upgraded together with Kubernetes and do not require a separate switch. `image_registry` and `nfs` are not supported for upgrade.
 
 ## pre_hook
 

--- a/docs/zh/installation/README.md
+++ b/docs/zh/installation/README.md
@@ -128,6 +128,7 @@ KubeKey 支持**在线安装**和**离线安装**两种方式。
 
 - **添加节点**：向已有 Kubernetes 集群添加新的控制平面节点、工作节点或 etcd 节点。详细步骤请参考 [添加集群节点](add-nodes.md)。
 - **删除节点**：从 Kubernetes 集群中安全移除指定节点。详细步骤请参考 [删除集群节点](delete-nodes.md)。
+- **升级集群**：升级已有集群的 Kubernetes 版本，并可选择升级 etcd、容器运行时、CNI 插件和 StorageClass 存储插件。详细步骤请参考 [升级集群](upgrade-cluster.md)。
 
 ## 启用 kubectl 自动补全
 

--- a/docs/zh/installation/upgrade-cluster.md
+++ b/docs/zh/installation/upgrade-cluster.md
@@ -1,0 +1,103 @@
+# 升级集群
+
+本节介绍如何使用 KubeKey 升级已有的 Kubernetes 集群，包括 Kubernetes 控制平面和工作节点，以及可选的 etcd、容器运行时、CNI 插件和 StorageClass 存储插件。
+
+## 前置条件
+
+- 已有一个使用 KubeKey 部署的 Kubernetes 集群。
+- 目标 Kubernetes 版本需高于集群当前安装的版本。
+- 升级前请备份集群（尤其是 etcd 数据），以便升级失败时恢复。
+
+> **注意**：当前 Web Installer 暂不支持升级集群，请通过命令行操作。
+
+## 获取当前集群配置文件
+
+如果集群是通过 **Web Installer** 安装的，可通过以下方式获取当前集群的配置文件。
+
+### 获取 inventory.yaml
+
+```shell
+cp kubekey/runtime/kubekey.kubesphere.io/v1/inventories/default/default.yaml kkv4-inventory.yaml
+```
+
+### 获取 config.yaml
+
+```shell
+cat schema/config.json | jq '{spec: .["kubernetes.json"]}' > kkv4-config.json
+```
+
+## 升级集群
+
+默认情况下，`kk upgrade cluster` 只升级 Kubernetes 控制平面和工作节点二进制（`kubeadm` / `kubelet`），其他组件需显式开启。
+
+### 仅升级 Kubernetes 版本
+
+通过 `--with-kubernetes` 指定目标版本（或在 `config.yaml` 中设置 `kubernetes.kube_version`）：
+
+```shell
+./kk upgrade cluster -i inventory.yaml -c config.yaml --with-kubernetes v1.34.11
+```
+
+KubeKey 会进行滚动升级：第一个控制平面节点执行 `kubeadm upgrade apply`，其余控制平面节点执行 `kubeadm upgrade node`，所有工作节点并行升级。
+
+### 同时升级相关组件
+
+使用 `--all` 将 etcd、容器运行时、CNI 插件和 StorageClass 存储插件随 Kubernetes 一并升级：
+
+```shell
+./kk upgrade cluster -i inventory.yaml -c config.yaml --with-kubernetes v1.34.11 --all
+```
+
+也可用 `--set` 单独开启某个组件：
+
+```shell
+./kk upgrade cluster -i inventory.yaml -c config.yaml --with-kubernetes v1.34.11 --set upgrade.cni=true
+```
+
+### 仅升级单个组件
+
+以下子命令只升级指定组件，不影响 Kubernetes 控制平面及其他组件：
+
+```shell
+./kk upgrade etcd -i inventory.yaml -c config.yaml
+./kk upgrade cri -i inventory.yaml -c config.yaml
+./kk upgrade cni -i inventory.yaml -c config.yaml
+./kk upgrade storageclass -i inventory.yaml -c config.yaml
+```
+
+## 升级开关
+
+`config.yaml` 中的 `upgrade` 段控制是否随集群一并升级可选组件：
+
+```yaml
+upgrade:
+  etcd: false          # 是否升级 external etcd 集群
+  cri: false           # 是否升级容器运行时（docker/containerd）
+  cni: false           # 是否升级 CNI 插件
+  storage_class: false # 是否升级 StorageClass 存储插件
+```
+
+以上开关也可通过命令行 `--all` 或 `--set upgrade.<component>=true` 覆盖。
+
+> **注意**：CoreDNS / NodeLocalDNS 会随 Kubernetes 一并升级，无需单独开关；`image_registry` 和 `nfs` 不支持升级。
+
+## 跨多个小版本升级
+
+`kubeadm` 一次只允许升级一个小版本。当目标版本跨越多个小版本时，KubeKey 会自动逐个小版本升级，中间跳点使用 `cluster_require.kube_upgrade_path` 中定义的各小版本推荐补丁版本。可通过 `--set cluster_require.kube_upgrade_path.v1.24=v1.24.10` 覆盖某个跳点版本。
+
+## 参数说明
+
+| 参数 | 描述 |
+|------|------|
+| `-i, --inventory` | Inventory 文件路径，定义节点连接信息 |
+| `-c, --config` | Config 文件路径，定义集群关键配置 |
+| `--with-kubernetes` | 指定要升级到的目标 Kubernetes 版本，默认使用 config 中的 `kubernetes.kube_version` |
+| `--all` | 升级所有相关组件，包括 etcd、cri、cni 和 storage_class |
+| `--set` | 覆盖 config 中的值，格式 `--set key=val` 或 `--set k1=v1,k2=v2` |
+| `-a, --artifact` | 离线包路径，离线环境时使用 |
+
+## 注意事项
+
+- **滚动升级**：KubeKey 对控制平面节点逐个升级，但工作节点是并行升级的，且不会自动执行 `cordon` 或 `drain`。若工作负载副本不足或集中于某些节点，服务可能短暂不可用。如需严格滚动升级，可先手动 `drain` 节点。
+- **容器运行时**：当 `upgrade.cri=true` 时，容器运行时服务会重启。使用 containerd 时运行中的容器通常不受影响；使用 Docker 时，若未开启 `live-restore`，重启 dockerd 可能中断运行中的容器。
+- **备份**：升级前请备份集群（尤其是 etcd 数据），以便升级失败时恢复。

--- a/docs/zh/reference/playbooks/upgrade_cluster.md
+++ b/docs/zh/reference/playbooks/upgrade_cluster.md
@@ -8,16 +8,15 @@
 
 ```yaml
 upgrade:
-  cri: false          # 是否同步升级容器运行时（docker/containerd）
   etcd: false         # 是否同步升级外部 etcd 集群
-  dns: false          # 是否同步升级 CoreDNS / NodeLocalDNS
-  image_registry: false
+  cri: false          # 是否同步升级容器运行时（docker/containerd）
   cni: false          # 是否同步升级网络插件
-  storage_class: false
-  nfs: false
+  storage_class: false # 是否同步升级 StorageClass provisioner
 ```
 
 也可以在命令行通过 `--all` 或 `--set upgrade.xxx=true` 覆盖。
+
+> **注意**：CoreDNS / NodeLocalDNS 会随 Kubernetes 一并升级，无需单独开关；`image_registry` 和 `nfs` 不支持升级。
 
 ## pre_hook
 


### PR DESCRIPTION
### What type of PR is this?
/kind documentation

## What does this PR do

Add a cluster upgrade guide and fix the upgrade switches documented in the upgrade cluster playbook reference.

### Background / Motivation

`kk upgrade cluster` has been available, but the installation docs had no guide for upgrading an existing cluster. At the same time, the `upgrade` switches listed in `docs/*/reference/playbooks/upgrade_cluster.md` included `dns`, `image_registry`, and `nfs`, which are not independently upgradable: CoreDNS / NodeLocalDNS upgrade together with Kubernetes, and `image_registry` / `nfs` are not supported for upgrade.

### Implementation

- Add a cluster upgrade guide (`upgrade-cluster.md`, EN + ZH) covering the default behavior, component switches, single-component subcommands, and multi-minor auto-stepping.
- Add an "Upgrade Cluster" entry to the installation navigation and the root README.
- Fix the upgrade switches in `upgrade_cluster.md` to only list the four wired components (`etcd`, `cri`, `cni`, `storage_class`).

### Key Changes

| File | What changed |
|---|---|
| docs/en/installation/upgrade-cluster.md | Add the English cluster upgrade guide |
| docs/zh/installation/upgrade-cluster.md | Add the Chinese cluster upgrade guide |
| docs/en/installation/README.md | Add an "Upgrade Cluster" navigation entry |
| docs/zh/installation/README.md | Add an "升级集群" navigation entry |
| docs/en/reference/playbooks/upgrade_cluster.md | Fix upgrade switches to the four wired components |
| docs/zh/reference/playbooks/upgrade_cluster.md | Fix upgrade switches to the four wired components |
| README.md | Add an "Upgrade Cluster" navigation entry |

## Impact

- **Affected modules**: docs
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Manual verification

### Steps to verify

1. Open `docs/en/installation/README.md` and confirm the "Upgrade Cluster" entry appears under "Delete Nodes".
2. Open `docs/en/installation/upgrade-cluster.md` and confirm the command examples and switches match the source (`cmd/kk/app/options/builtin/upgrade.go`).

### Test coverage

Documentation-only change; no tests are needed.

## Rollback

Plain revert.

### Does this PR introduce a user-facing change?

```release-note
None
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [x] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

The switch list was narrowed down based on `cmd/kk/app/options/builtin/upgrade.go`, where `upgradeComponents` only contains `etcd`, `cri`, `cni`, and `storage_class`.
