### PR TITLE
fix(cni): preserve existing values on CNI upgrade

### DIFF
--- a/builtin/core/roles/cni/calico/tasks/main.yaml
+++ b/builtin/core/roles/cni/calico/tasks/main.yaml
@@ -74,4 +74,4 @@
 
 - name: Calico | Deploy Calico using Helm
   command: |
-    helm upgrade --install --create-namespace --namespace tigera-operator calico /etc/kubernetes/cni/tigera-operator-{{ .cni.calico_version }}.tgz -f /etc/kubernetes/cni/calico-default-values.yaml {{ if .cni.calico.values | empty | not }}-f /etc/kubernetes/cni/calico-custom-values.yaml{{ end }} 
+    helm upgrade --install --reuse-values --create-namespace --namespace tigera-operator calico /etc/kubernetes/cni/tigera-operator-{{ .cni.calico_version }}.tgz -f /etc/kubernetes/cni/calico-default-values.yaml {{ if .cni.calico.values | empty | not }}-f /etc/kubernetes/cni/calico-custom-values.yaml{{ end }} 

--- a/builtin/core/roles/cni/cilium/tasks/main.yaml
+++ b/builtin/core/roles/cni/cilium/tasks/main.yaml
@@ -21,4 +21,4 @@
 # See: https://docs.cilium.io/en/stable/installation/k8s-install-helm/
 - name: Cilium | Deploy cilium with Helm
   command: |
-    helm upgrade --install --namespace kube-system cilium /etc/kubernetes/cni/cilium-{{ .cni.cilium_version }}.tgz -f /etc/kubernetes/cni/cilium-default-values.yaml {{ if .cni.cilium.values | empty | not }}-f /etc/kubernetes/cni/cilium-custom-values.yaml{{ end }}
+    helm upgrade --install --reuse-values --namespace kube-system cilium /etc/kubernetes/cni/cilium-{{ .cni.cilium_version }}.tgz -f /etc/kubernetes/cni/cilium-default-values.yaml {{ if .cni.cilium.values | empty | not }}-f /etc/kubernetes/cni/cilium-custom-values.yaml{{ end }}

--- a/builtin/core/roles/cni/flannel/tasks/main.yaml
+++ b/builtin/core/roles/cni/flannel/tasks/main.yaml
@@ -24,4 +24,4 @@
     # Needs manual creation of namespace to avoid Helm error
     kubectl create ns kube-flannel
     kubectl label --overwrite ns kube-flannel pod-security.kubernetes.io/enforce=privileged
-    helm upgrade --install --create-namespace --namespace kube-flannel flannel /etc/kubernetes/cni/flannel-{{ .cni.flannel_version }}.tgz -f /etc/kubernetes/cni/flannel-default-values.yaml {{ if .cni.flannel.values | empty | not }}-f /etc/kubernetes/cni/flannel-custom-values.yaml{{ end }}
+    helm upgrade --install --reuse-values --create-namespace --namespace kube-flannel flannel /etc/kubernetes/cni/flannel-{{ .cni.flannel_version }}.tgz -f /etc/kubernetes/cni/flannel-default-values.yaml {{ if .cni.flannel.values | empty | not }}-f /etc/kubernetes/cni/flannel-custom-values.yaml{{ end }}

--- a/builtin/core/roles/cni/hybridnet/tasks/main.yaml
+++ b/builtin/core/roles/cni/hybridnet/tasks/main.yaml
@@ -21,4 +21,4 @@
 # Reference: https://artifacthub.io/packages/helm/hybridnet/hybridnet
 - name: Hybridnet | Install Hybridnet using Helm
   command: |
-    helm upgrade --install --namespace kube-system hybridnet /etc/kubernetes/cni/hybridnet-{{ .cni.hybridnet_version }}.tgz -f /etc/kubernetes/cni/hybridnet-default-values.yaml {{ if .cni.hybridnet.values | empty | not }}-f /etc/kubernetes/cni/hybridnet-custom-values.yaml{{ end }}
+    helm upgrade --install --reuse-values --namespace kube-system hybridnet /etc/kubernetes/cni/hybridnet-{{ .cni.hybridnet_version }}.tgz -f /etc/kubernetes/cni/hybridnet-default-values.yaml {{ if .cni.hybridnet.values | empty | not }}-f /etc/kubernetes/cni/hybridnet-custom-values.yaml{{ end }}

--- a/builtin/core/roles/cni/kubeovn/tasks/main.yaml
+++ b/builtin/core/roles/cni/kubeovn/tasks/main.yaml
@@ -26,4 +26,4 @@
 
 - name: Kubeovn | Install Kube-OVN using Helm with custom values
   command: |
-    helm upgrade --install --namespace kubeovn-system kubeovn /etc/kubernetes/cni/kubeovn-{{ .cni.kubeovn_version }}.tgz -f /etc/kubernetes/cni/kubeovn-default-values.yaml {{ if .cni.kubeovn.values | empty | not }}-f /etc/kubernetes/cni/kubeovn-custom-values.yaml{{ end }}
+    helm upgrade --install --reuse-values --namespace kubeovn-system kubeovn /etc/kubernetes/cni/kubeovn-{{ .cni.kubeovn_version }}.tgz -f /etc/kubernetes/cni/kubeovn-default-values.yaml {{ if .cni.kubeovn.values | empty | not }}-f /etc/kubernetes/cni/kubeovn-custom-values.yaml{{ end }}

--- a/builtin/core/roles/cni/multi-cni/spiderpool/tasks/main.yaml
+++ b/builtin/core/roles/cni/multi-cni/spiderpool/tasks/main.yaml
@@ -20,4 +20,4 @@
 
 - name: Spiderpool | Install Spiderpool using Helm with custom values
   command: |
-    helm upgrade --install --namespace kube-system spiderpool /etc/kubernetes/cni/spiderpool-{{ .cni.spiderpool_version }}.tgz -f /etc/kubernetes/cni/spiderpool-default-values.yaml {{ if .cni.spiderpool.values | empty | not }}-f /etc/kubernetes/cni/spiderpool-custom-values.yaml{{ end }}
+    helm upgrade --install --reuse-values --namespace kube-system spiderpool /etc/kubernetes/cni/spiderpool-{{ .cni.spiderpool_version }}.tgz -f /etc/kubernetes/cni/spiderpool-default-values.yaml {{ if .cni.spiderpool.values | empty | not }}-f /etc/kubernetes/cni/spiderpool-custom-values.yaml{{ end }}


### PR DESCRIPTION
/kind bug

## What does this PR do

Add `--reuse-values` to the `helm upgrade --install` invocation in all core CNI roles so CNI upgrades preserve runtime customizations instead of silently resetting them to chart defaults.

### Background / Motivation

The CNI roles run `helm upgrade --install` without `--reuse-values`. Helm therefore recomputes the release values from the chart defaults plus the explicitly passed `-f <cni>-default-values.yaml` and (when set) `-f <cni>-custom-values.yaml`. Any value that exists in the live release but is absent from both files is silently dropped and reset to the chart default, which clobbers runtime customizations (for example, out-of-band `helm upgrade --set ...` changes).

### Implementation

Add `--reuse-values` to the `helm upgrade --install` command in every core CNI role. The resulting value precedence (low to high) is:

1. chart defaults
2. existing release values (`--reuse-values`)
3. kk presets (`default-values.yaml`)
4. user-supplied values (`custom-values.yaml`)

`--reuse-values` was chosen over `--reset-then-reuse-values` because the latter requires Helm >= 3.12, while KubeKey's older Kubernetes baselines ship Helm v3.10.3 (v1.24) and v3.11.2 (v1.26). On first install `--reuse-values` is a no-op, so the install path is unchanged.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/cni/calico/tasks/main.yaml` | Add `--reuse-values` to Helm deploy |
| `builtin/core/roles/cni/cilium/tasks/main.yaml` | Add `--reuse-values` to Helm deploy |
| `builtin/core/roles/cni/flannel/tasks/main.yaml` | Add `--reuse-values` to Helm deploy |
| `builtin/core/roles/cni/hybridnet/tasks/main.yaml` | Add `--reuse-values` to Helm deploy |
| `builtin/core/roles/cni/kubeovn/tasks/main.yaml` | Add `--reuse-values` to Helm deploy |
| `builtin/core/roles/cni/multi-cni/spiderpool/tasks/main.yaml` | Add `--reuse-values` to Helm deploy |

## Impact

- **Affected modules**: `builtin/core/roles/cni` (calico, cilium, flannel, hybridnet, kubeovn, spiderpool)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A (no new config items; behavior change only)
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

N/A

## Testing

### Verification performed

- [ ] Unit tests pass
- [ ] Integration / E2E tests pass
- [ ] Manual verification

### Steps to verify

1. Deploy a cluster with a CNI plugin (e.g. calico).
2. Apply an out-of-band value to the live release, e.g. `helm upgrade --set <key>=<value> ...`.
3. Run `kk upgrade cluster --with-kubernetes <ver> --set upgrade.cni=true`.
4. Verify the out-of-band value is preserved while kk presets (registry, CIDR, ipam) are still applied.

### Test coverage

No new tests: the change is a one-line flag addition to each CNI role's Helm command (no Go code). CNI upgrade E2E validation is performed separately.

## Rollback

Revert this commit (plain `git revert`); it is a flag-only change with no state or config migration.

### Does this PR introduce a user-facing change?

```release-note
CNI upgrades now pass `--reuse-values` to `helm upgrade --install`, preserving values set outside KubeKey's default/custom values files. KubeKey presets and user-supplied values still take precedence.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

- `--reuse-values` also carries forward the previous release's computed chart defaults; fields KubeKey controls (registry, CIDR, ipam, etc.) are re-asserted by the freshly rendered `default-values.yaml` on top, so they do not go stale. This is why `--reset-then-reuse-values` would be cleaner, but it requires Helm >= 3.12 which older K8s baselines do not ship.
- The capkk install path (`builtin/capkk/roles/install/cni/tasks/{calico,cilium,flannel}.yaml`) uses a single values file and is intentionally left unchanged in this PR.
- First install is unaffected: `--reuse-values` only applies "when upgrading", so when the release does not exist (a fresh `kk create cluster`, or a rebuild after the cluster was destroyed) the flag is a no-op and the install path behaves exactly as before. Confirmed against `helm upgrade --help` (the flag is documented as "when upgrading") and by an A/B dry-run with Helm v4.1.1, where the flag's presence did not change the outcome.
- Behavior change worth flagging: with `--reuse-values`, removing a key from `cni.<cni>.values` no longer reverts that key to the chart default — the previously deployed value is retained. To restore a default, the value must be set explicitly; KubeKey does not expose `--reset-values`.
