### PR TITLE
feat(cmd): add kk create convert for v3-to-v4 config migration

### DIFF
--- a/cmd/kk/app/builtin/create.go
+++ b/cmd/kk/app/builtin/create.go
@@ -35,6 +35,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.AddCommand(newCreateClusterCommand())
 	cmd.AddCommand(newCreateConfigCommand())
 	cmd.AddCommand(newCreateInventoryCommand())
+	cmd.AddCommand(newConvertCommand())
 
 	return cmd
 }
@@ -86,6 +87,24 @@ func newCreateInventoryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inventory",
 		Short: "Create a default inventory",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return o.Run()
+		},
+	}
+	flags := cmd.Flags()
+	for _, f := range o.Flags().FlagSets {
+		flags.AddFlagSet(f)
+	}
+
+	return cmd
+}
+
+func newConvertCommand() *cobra.Command {
+	o := builtin.NewConvertOptions()
+
+	cmd := &cobra.Command{
+		Use:   "convert",
+		Short: "Convert a KubeKey v3 (v1alpha2) cluster configuration to v4 inventory and config files",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return o.Run()
 		},

--- a/cmd/kk/app/options/builtin/convert.go
+++ b/cmd/kk/app/options/builtin/convert.go
@@ -1,0 +1,106 @@
+//go:build builtin
+// +build builtin
+
+/*
+Copyright 2026 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builtin
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cockroachdb/errors"
+	cliflag "k8s.io/component-base/cli/flag"
+
+	_const "github.com/kubesphere/kubekey/v4/pkg/const"
+	"github.com/kubesphere/kubekey/v4/pkg/convert"
+)
+
+// NewConvertOptions for newConvertCommand
+func NewConvertOptions() *ConvertOptions {
+	return &ConvertOptions{}
+}
+
+// ConvertOptions for NewConvertOptions
+type ConvertOptions struct {
+	// Input is the path of the KubeKey v3 (v1alpha2) cluster configuration file.
+	Input string
+	// OutputPath is the output directory for the generated files. When empty,
+	// both documents are printed to stdout as a multi-document YAML stream.
+	OutputPath string
+}
+
+// Flags add to newConvertCommand
+func (o *ConvertOptions) Flags() cliflag.NamedFlagSets {
+	fss := cliflag.NamedFlagSets{}
+	cfs := fss.FlagSet("convert")
+	cfs.StringVar(&o.Input, "input", o.Input, "Path of the KubeKey v3 (v1alpha2) cluster configuration file (required)")
+	cfs.StringVarP(&o.OutputPath, "output", "o", o.OutputPath, "Output directory for inventory.yaml and config.yaml. if not set will output to stdout")
+
+	return fss
+}
+
+// Run executes the conversion: it reads the v3 cluster configuration, converts
+// it and either writes inventory.yaml/config.yaml to the output directory or
+// prints both documents to stdout.
+func (o *ConvertOptions) Run() error {
+	if o.Input == "" {
+		return errors.New("--input is required, please set it to the path of the v3 cluster configuration file")
+	}
+	data, err := os.ReadFile(o.Input)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read v3 cluster configuration file %q", o.Input)
+	}
+
+	inventoryYAML, configYAML, warnings, err := convert.ConvertInventoryAndConfig(data)
+	if err != nil {
+		return err
+	}
+
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", w)
+	}
+	if len(warnings) > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: %d field(s) could not be converted automatically, please review the output files.\n", len(warnings))
+	}
+
+	if o.OutputPath == "" {
+		fmt.Printf("---\n%s\n---\n%s\n", inventoryYAML, configYAML)
+		return nil
+	}
+
+	info, err := os.Stat(o.OutputPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to access output path %q, it must be an existing directory", o.OutputPath)
+	}
+	if !info.IsDir() {
+		return errors.Errorf("output path %q is not a directory, please set -o to the directory for inventory.yaml and config.yaml", o.OutputPath)
+	}
+
+	for name, content := range map[string][]byte{
+		"inventory.yaml": inventoryYAML,
+		"config.yaml":    configYAML,
+	} {
+		filename := fmt.Sprintf("%s/%s", o.OutputPath, name)
+		if err := os.WriteFile(filename, content, _const.PermFilePublic); err != nil {
+			return errors.Wrapf(err, "failed to write %s", filename)
+		}
+		fmt.Printf("write %s to %s success.\n", name, filename)
+	}
+
+	return nil
+}

--- a/docs/en/installation/README.md
+++ b/docs/en/installation/README.md
@@ -85,6 +85,8 @@ spec:
 
 For disk formatting and multipath settings, see [Storage and Multipath Configuration](../reference/storage.md).
 
+If you have an existing v3 (v1alpha2) cluster configuration, use `kk create convert` to migrate it to v4 `inventory.yaml` and `config.yaml`. See [Migrate a v3 Configuration to v4](../reference/config-migration.md) for the full field mapping.
+
 ## Define Key Configuration
 
 KubeKey uses the `Config` resource to define key cluster configuration.

--- a/docs/en/reference/config-migration.md
+++ b/docs/en/reference/config-migration.md
@@ -200,7 +200,6 @@ prints a warning for each so you can adjust `config.yaml` by hand.
 | `system.rpms` / `system.debs` | manual | install via hook playbooks |
 | `system.preInstall` / `postClusterInstall` / `postInstall` | manual | migrate to hook playbooks |
 | `system.skipConfigureOS` | dropped | — |
-| `controlPlaneEndpoint.address` (haproxy) | warning | v4 haproxy listens on `127.0.0.1` |
 
 ## Parsed but not yet converted
 

--- a/docs/en/reference/config-migration.md
+++ b/docs/en/reference/config-migration.md
@@ -101,6 +101,7 @@ including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,
 | `nodelocaldns` | `dns.nodelocaldns.enabled` | see DNS |
 | `kubeletArgs` (`K=V`) | `kubelet.extra_args` | map form (consumed by kubeadm `kubelet.extraArgs`) |
 | `kubeProxyConfiguration` | `kube_proxy.config` | map form (consumed by kubeadm `kubeProxy.config`) |
+| `kubeProxyArgs` (`--flag`) | `kube_proxy.mode` (--proxy-mode) + `kube_proxy.config` (KubeProxyConfiguration) | unsupported flags → **warning**; boolean flags become `true`, comma-separated slices become `[]string` |
 | `kubeletConfiguration` | `kubelet.<scalar>` + `kubelet.extra_config` | `maxPods`/`podPidsLimit` map to scalars; remaining keys → `extra_config` |
 | `containerRuntimeEndpoint` | `cri.cri_socket` | consumed by kubeadm `nodeRegistration.criSocket` |
 
@@ -143,6 +144,8 @@ including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,
 | `backupDir` | `backup.backup_dir` | |
 | `keepBackupNumber` | `backup.keep_backup_number` | |
 | `backupScript` | `backup.etcd_backup_script` | |
+| `backupPeriod` | `backup.on_calendar` | minutes → `*/N * * * *` (systemd timer, runs every N minutes); **warning** notes the conversion |
+| `extraArgs` (`--flag`) | `env.<snake_key>` | supported flags map to `etcd.env.*` (e.g. `--data-dir`→`env.data_dir`); unsupported flags (incl. listen/advertise URLs, which v4 computes from the inventory) → **warning** |
 
 ### registry → config.yaml cri.registry + image_registry
 
@@ -173,24 +176,28 @@ including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,
 These v3 fields are either dropped or require manual migration. The converter
 prints a warning for each so you can adjust `config.yaml` by hand.
 
+Some fields that previously required manual migration are now auto-mapped
+(`kubernetes.kubeProxyArgs`, `etcd.backupPeriod`, `etcd.extraArgs`; see the
+mapping tables above). Their **unsupported sub-flags** still produce a warning.
+
 | v3 field | Outcome | Suggestion |
 |---|---|---|
-| `kubernetes.kubeProxyArgs` | dropped | — |
+| `kubernetes.kubeProxyArgs` | auto-mapped → `kube_proxy.mode` / `kube_proxy.config` | see kubernetes mapping table; unsupported flags → warning |
 | `kubernetes.nodeFeatureDiscovery` | dropped | — |
 | `kubernetes.kata` | dropped | — |
 | `kubernetes.nvidiaRuntime` | dropped | — |
 | `kubernetes.type` | ignored | v4 has no cluster type |
-| `network.calico.ipipMode` (non-Always) | manual | configure calico values |
-| `network.calico.vxlanMode` (non-Never) | manual | configure calico values |
-| `network.calico.vethMTU` | manual | configure calico values |
-| `network.calico.ipAutoDetectionMethod` | manual | configure calico values |
-| `network.calico.ipv4NatOutgoing=false` | manual | configure calico values |
-| `network.calico.typha` / `controller` | manual | configure calico values |
+| `network.calico.ipipMode` (non-Always) | manual | configure via `cni.calico.values` (Calico helm custom values file, targeting the Calico Installation spec) |
+| `network.calico.vxlanMode` (non-Never) | manual | configure via `cni.calico.values` (Calico helm custom values file, targeting the Calico Installation spec) |
+| `network.calico.vethMTU` | manual | configure via `cni.calico.values` (Calico helm custom values file, targeting the Calico Installation spec) |
+| `network.calico.ipAutoDetectionMethod` | manual | configure via `cni.calico.values` (Calico helm custom values file, targeting the Calico Installation spec) |
+| `network.calico.ipv4NatOutgoing=false` | manual | configure via `cni.calico.values` (Calico helm custom values file, targeting the Calico Installation spec) |
+| `network.calico.typha` / `controller` | manual | configure via `cni.calico.values` (Calico helm custom values file, targeting the Calico Installation spec) |
 | `network.flannel` / `kubeovn` / `hybridnet` | manual | v4 does not expose per-plugin details |
 | `dns.coredns` | manual | migrate to `dns.coredns.zone_configs` |
 | `dns.nodelocaldns.externalZones` | manual | — |
-| `etcd.backupPeriod` | manual | v4 uses `etcd.backup.on_calendar` |
-| `etcd.extraArgs` | dropped | — |
+| `etcd.backupPeriod` | auto-mapped → `etcd.backup.on_calendar` | see etcd mapping table |
+| `etcd.extraArgs` | auto-mapped → `etcd.env.<snake_key>` | see etcd mapping table; unsupported flags → warning |
 | `etcd.external` (endpoints/certs) | manual | configure the etcd group + certs |
 | `registry.bridgeIP` | dropped | — |
 | `registry.namespaceOverride` | manual | review image naming |

--- a/docs/en/reference/config-migration.md
+++ b/docs/en/reference/config-migration.md
@@ -1,0 +1,214 @@
+# Migrate a v3 (v1alpha2) Configuration to v4
+
+KubeKey v4 defines a cluster with two files:
+
+- `inventory.yaml` — the `Inventory` resource (hosts and groups).
+- `config.yaml` — the `Config` resource (cluster spec; `spec` is an unstructured map).
+
+KubeKey v3 (the `3.x` branch) uses a single `Cluster` manifest of API version
+`kubekey.kubesphere.io/v1alpha2`. To reduce the manual rewrite when adopting v4,
+`kk create convert` parses a v3 config and emits the v4 `inventory.yaml` and
+`config.yaml`.
+
+```bash
+# Print both documents to stdout, separated by `---`
+kk create convert --input config-v3.yaml
+
+# Or write them to a directory
+kk create convert --input config-v3.yaml -o ./out
+# ./out/inventory.yaml
+# ./out/config.yaml
+```
+
+Fields that have no clean 1:1 v4 equivalent (for example KubeSphere enablement,
+advanced CoreDNS, or `system.rpms`) are **not silently dropped** — they are
+reported as warnings on stderr. Review the warnings and adjust the generated
+`config.yaml` by hand where needed.
+
+## How the converter reads v3
+
+`pkg/convert/v1alpha2.go` is a **minimal mirror** of the v3 schema: it declares
+only the fields needed for conversion. The YAML decoder ignores unknown fields,
+and composite helper types (`CustomScripts`, `MirrorConfig`, `NamespaceRewrite`)
+are preserved as raw values, so parsing never loses data. `metadata` is reduced
+to `name` only.
+
+## Field mapping
+
+All paths below are relative to the generated file. `inventory.yaml` paths are
+under `spec`; `config.yaml` paths are under `spec`.
+
+### Hosts → inventory.yaml
+
+| v3 `spec.hosts[]` | v4 `inventory.yaml` | Note |
+|---|---|---|
+| `name` | `spec.hosts.<name>` (map key) | |
+| `address` | `spec.hosts.<name>.connector.host` | |
+| `port` | `connector.port` | `0` → default `22` |
+| `user` | `connector.user` | `""` → default `root` |
+| `password` | `connector.password` | |
+| `privateKeyPath` | `connector.private_key` | |
+| `privateKey` | `connector.private_key_content` | |
+| `internalAddress` | `internal_ipv4` / `internal_ipv6` | comma-split dual-stack |
+| `arch` | `arch` | |
+| `labels` | `labels` | |
+
+### roleGroups → inventory.yaml groups
+
+v3 `HostCfg` carries no role/taint info; roles come only from `roleGroups`,
+including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,`node3`).
+
+| v3 `roleGroups` key | v4 group |
+|---|---|
+| `master` / `control-plane` / `controlplane` | `kube_control_plane` (merged) |
+| `worker` | `kube_worker` |
+| `etcd` | `etcd` |
+| `registry` | `image_registry` |
+| any other key | no v4 group → **warning** |
+| aggregate | `k8s_cluster.groups = [kube_control_plane, kube_worker]` |
+
+### controlPlaneEndpoint → config.yaml kubernetes.control_plane_endpoint
+
+| v3 `controlPlaneEndpoint` | v4 `kubernetes.control_plane_endpoint` | Note |
+|---|---|---|
+| `domain` | `host` | |
+| `port` | `port` | |
+| `internalLoadbalancer` = `""` / `none` | `type: local` | `address` → `local.address` |
+| `internalLoadbalancer` = `kubevip` | `type: kube-vip` | `address` → `kube_vip.address`; `kubevip.mode` → `kube_vip.mode` |
+| `internalLoadbalancer` = `haproxy` | `type: haproxy` | `address` → **warning** (v4 haproxy listens on `127.0.0.1`) |
+| `internalLoadbalancer` = other | `type: local` | **warning** |
+
+### kubernetes → config.yaml kubernetes
+
+| v3 `kubernetes` | v4 `kubernetes` | Note |
+|---|---|---|
+| `version` | `kube_version` | |
+| `clusterName` | `cluster_name` | |
+| `autoRenewCerts` | `certs.renew` | |
+| `apiserverCertExtraSans` | `apiserver.certSANs` | |
+| `apiserverArgs` (`K=V`) | `apiserver.extra_args` | map form |
+| `featureGates` | `apiserver.extra_args.feature-gates` | joined as `K=true,K2=false` |
+| `controllerManagerArgs` | `controller_manager.extra_args` | |
+| `schedulerArgs` | `scheduler.extra_args` | |
+| `proxyMode` | `kube_proxy.mode` | |
+| `masqueradeAll` | `kube_proxy.config.iptables.masqueradeAll` | |
+| `disableKubeProxy` | `kube_proxy.manage.enabled = false` | **warning** |
+| `maxPods` | `kubelet.max_pods` | |
+| `podPidsLimit` | `kubelet.pod_pids_limit` | |
+| `nodeCidrMaskSize` | `cni.ipv4_mask_size` | see CNI |
+| `nodeCidrMaskSizeIPv6` | `cni.ipv6_mask_size` | see CNI |
+| `dnsDomain` | `dns.domain` | see DNS |
+| `nodelocaldns` | `dns.nodelocaldns.enabled` | see DNS |
+
+### network → config.yaml cni
+
+| v3 `network` | v4 `cni` | Note |
+|---|---|---|
+| `plugin` | `type` | `calico`/`cilium`/`flannel`/`kubeovn`/`hybridnet`; unknown → `other` + **warning** |
+| `kubePodsCIDR` | `pod_cidr` | |
+| `kubeServiceCIDR` | `service_cidr` | |
+| `multusCNI.enabled` | `multi_cni = "multus"` | **warning** |
+
+### dns → config.yaml dns (top-level)
+
+| v3 | v4 `dns` | Note |
+|---|---|---|
+| `kubernetes.dnsDomain` | `domain` | |
+| `kubernetes.nodelocaldns` | `nodelocaldns.enabled` | |
+
+### etcd → config.yaml etcd
+
+| v3 `etcd` | v4 `etcd` | Note |
+|---|---|---|
+| `type` = `kubekey`/`kubeadm`/`""` | `deployment_type: internal` | |
+| `type` = `external` | `deployment_type: external` | **warning** on external endpoints/certs |
+| `port` | `port` | |
+| `peerPort` | `peer_port` | |
+| `dataDir` | `env.data_dir` | |
+| `heartbeatInterval` | `env.heartbeat_interval` | |
+| `electionTimeout` | `env.election_timeout` | |
+| `snapshotCount` | `env.snapshot_count` | |
+| `autoCompactionRetention` | `env.compaction_retention` | |
+| `metrics` | `env.metrics` | |
+| `quotaBackendBytes` | `env.quota_backend_bytes` | |
+| `maxRequestBytes` | `env.max_request_bytes` | |
+| `maxSnapshots` | `env.max_snapshots` | |
+| `maxWals` | `env.max_wals` | |
+| `logLevel` | `env.log_level` | |
+| `backupDir` | `backup.backup_dir` | |
+| `keepBackupNumber` | `backup.keep_backup_number` | |
+
+### registry → config.yaml cri.registry + image_registry
+
+| v3 `registry` | v4 | Note |
+|---|---|---|
+| `registryMirrors` | `cri.registry.mirrors` | |
+| `insecureRegistries` | `cri.registry.insecure_registries` | |
+| `auths` (map keyed by registry) | `cri.registry.auths` | list of `{registry, username, password, skip_tls_verify}` |
+| `containerdDataDir` | `cri.containerd.data_root` | |
+| `dockerDataDir` | `cri.docker.daemon.data-root` | |
+| `privateRegistry` | `image_registry.auth.registry` | **warning**: v4 uses it as the pull/push registry |
+
+### system → config.yaml native
+
+| v3 `system` | v4 `native` | Note |
+|---|---|---|
+| `ntpServers` | `ntp.servers` | |
+| `timezone` | `timezone` | |
+
+### storage → config.yaml storage_class
+
+| v3 `storage.openebs.basePath` | v4 `storage_class` | Note |
+|---|---|---|
+| `basePath` | `local.enabled = true`, `local.path = <basePath>` | |
+
+## Fields with no direct v4 equivalent (reported as warnings)
+
+These v3 fields are either dropped or require manual migration. The converter
+prints a warning for each so you can adjust `config.yaml` by hand.
+
+| v3 field | Outcome | Suggestion |
+|---|---|---|
+| `kubernetes.kubeProxyArgs` | dropped | — |
+| `kubernetes.kubeProxyConfiguration` | manual | migrate to `kubernetes.kube_proxy.config` |
+| `kubernetes.kubeletArgs` | dropped | — |
+| `kubernetes.kubeletConfiguration` | manual | migrate to `kubernetes.kubelet` |
+| `kubernetes.containerRuntimeEndpoint` | dropped | — |
+| `kubernetes.nodeFeatureDiscovery` | dropped | — |
+| `kubernetes.kata` | dropped | — |
+| `kubernetes.nvidiaRuntime` | dropped | — |
+| `kubernetes.type` | ignored | v4 has no cluster type |
+| `network.calico.ipipMode` (non-Always) | manual | configure calico values |
+| `network.calico.vxlanMode` (non-Never) | manual | configure calico values |
+| `network.calico.vethMTU` | manual | configure calico values |
+| `network.calico.ipAutoDetectionMethod` | manual | configure calico values |
+| `network.calico.ipv4NatOutgoing=false` | manual | configure calico values |
+| `network.calico.typha` / `controller` | manual | configure calico values |
+| `network.flannel` / `kubeovn` / `hybridnet` | manual | v4 does not expose per-plugin details |
+| `dns.coredns` | manual | migrate to `dns.coredns.zone_configs` |
+| `dns.nodelocaldns.externalZones` | manual | — |
+| `dns.dnsEtcHosts` / `dns.nodeEtcHosts` | manual | review `dns.coredns.dns_etc_hosts` |
+| `etcd.backupPeriod` | manual | v4 uses `etcd.backup.on_calendar` |
+| `etcd.backupScript` | manual | use `etcd.backup.etcd_backup_script` |
+| `etcd.extraArgs` | dropped | — |
+| `etcd.external` (endpoints/certs) | manual | configure the etcd group + certs |
+| `registry.bridgeIP` | dropped | — |
+| `registry.namespaceOverride` | manual | review image naming |
+| `registry.namespaceRewrite` | dropped | — |
+| `registry.remoteMirrors` | dropped | — |
+| `registry.type` | ignored | use `image_registry.type` |
+| `system.rpms` / `system.debs` | manual | install via hook playbooks |
+| `system.preInstall` / `postClusterInstall` / `postInstall` | manual | migrate to hook playbooks |
+| `system.skipConfigureOS` | dropped | — |
+| `controlPlaneEndpoint.address` (haproxy) | warning | v4 haproxy listens on `127.0.0.1` |
+
+## Parsed but not yet converted
+
+The following v3 fields are captured by the parser but have no `config.yaml`
+equivalent in the converter yet, so they are currently ignored (no warning):
+
+- `spec.kubesphere` (`enabled` / `version` / `configurations`) — v4 does not
+  enable KubeSphere through `config.yaml`; deploy KubeSphere separately.
+- `spec.addons` — v4 has no direct `config.yaml` addons mapping.
+
+Plan to add explicit handling (and warnings) for these in a later release.

--- a/docs/en/reference/config-migration.md
+++ b/docs/en/reference/config-migration.md
@@ -75,7 +75,7 @@ including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,
 | `port` | `port` | |
 | `internalLoadbalancer` = `""` / `none` | `type: local` | `address` → `local.address` |
 | `internalLoadbalancer` = `kubevip` | `type: kube-vip` | `address` → `kube_vip.address`; `kubevip.mode` → `kube_vip.mode` |
-| `internalLoadbalancer` = `haproxy` | `type: haproxy` | `address` → **warning** (v4 haproxy listens on `127.0.0.1`) |
+| `internalLoadbalancer` = `haproxy` | `type: haproxy` | `address` → `haproxy.address` |
 | `internalLoadbalancer` = other | `type: local` | **warning** |
 
 ### kubernetes → config.yaml kubernetes
@@ -99,6 +99,10 @@ including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,
 | `nodeCidrMaskSizeIPv6` | `cni.ipv6_mask_size` | see CNI |
 | `dnsDomain` | `dns.domain` | see DNS |
 | `nodelocaldns` | `dns.nodelocaldns.enabled` | see DNS |
+| `kubeletArgs` (`K=V`) | `kubelet.extra_args` | map form (consumed by kubeadm `kubelet.extraArgs`) |
+| `kubeProxyConfiguration` | `kube_proxy.config` | map form (consumed by kubeadm `kubeProxy.config`) |
+| `kubeletConfiguration` | `kubelet.<scalar>` + `kubelet.extra_config` | `maxPods`/`podPidsLimit` map to scalars; remaining keys → `extra_config` |
+| `containerRuntimeEndpoint` | `cri.cri_socket` | consumed by kubeadm `nodeRegistration.criSocket` |
 
 ### network → config.yaml cni
 
@@ -115,6 +119,7 @@ including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,
 |---|---|---|
 | `kubernetes.dnsDomain` | `domain` | |
 | `kubernetes.nodelocaldns` | `nodelocaldns.enabled` | |
+| `dns.dnsEtcHosts` | `coredns.dns_etc_hosts` | |
 
 ### etcd → config.yaml etcd
 
@@ -137,6 +142,7 @@ including the `node[i:j]` range shorthand (e.g. `node[1:3]` → `node1`,`node2`,
 | `logLevel` | `env.log_level` | |
 | `backupDir` | `backup.backup_dir` | |
 | `keepBackupNumber` | `backup.keep_backup_number` | |
+| `backupScript` | `backup.etcd_backup_script` | |
 
 ### registry → config.yaml cri.registry + image_registry
 
@@ -170,10 +176,6 @@ prints a warning for each so you can adjust `config.yaml` by hand.
 | v3 field | Outcome | Suggestion |
 |---|---|---|
 | `kubernetes.kubeProxyArgs` | dropped | — |
-| `kubernetes.kubeProxyConfiguration` | manual | migrate to `kubernetes.kube_proxy.config` |
-| `kubernetes.kubeletArgs` | dropped | — |
-| `kubernetes.kubeletConfiguration` | manual | migrate to `kubernetes.kubelet` |
-| `kubernetes.containerRuntimeEndpoint` | dropped | — |
 | `kubernetes.nodeFeatureDiscovery` | dropped | — |
 | `kubernetes.kata` | dropped | — |
 | `kubernetes.nvidiaRuntime` | dropped | — |
@@ -187,9 +189,7 @@ prints a warning for each so you can adjust `config.yaml` by hand.
 | `network.flannel` / `kubeovn` / `hybridnet` | manual | v4 does not expose per-plugin details |
 | `dns.coredns` | manual | migrate to `dns.coredns.zone_configs` |
 | `dns.nodelocaldns.externalZones` | manual | — |
-| `dns.dnsEtcHosts` / `dns.nodeEtcHosts` | manual | review `dns.coredns.dns_etc_hosts` |
 | `etcd.backupPeriod` | manual | v4 uses `etcd.backup.on_calendar` |
-| `etcd.backupScript` | manual | use `etcd.backup.etcd_backup_script` |
 | `etcd.extraArgs` | dropped | — |
 | `etcd.external` (endpoints/certs) | manual | configure the etcd group + certs |
 | `registry.bridgeIP` | dropped | — |

--- a/docs/zh/installation/README.md
+++ b/docs/zh/installation/README.md
@@ -84,6 +84,8 @@ spec:
 
 节点磁盘格式化与 multipath 配置见 [存储与 Multipath 配置](../reference/storage.md)。
 
+如果你已有 v3（v1alpha2）版本的集群配置，可使用 `kk create convert` 将其迁移为 v4 的 `inventory.yaml` 与 `config.yaml`。完整的字段映射见 [将 v3 配置迁移到 v4](../reference/config-migration.md)。
+
 ## 定义关键配置信息
 
 KubeKey 使用 `Config` 资源来定义集群的关键配置信息。

--- a/docs/zh/reference/config-migration.md
+++ b/docs/zh/reference/config-migration.md
@@ -99,6 +99,7 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | `nodelocaldns` | `dns.nodelocaldns.enabled` | 见 DNS |
 | `kubeletArgs`（`K=V`） | `kubelet.extra_args` | map 形式（被 kubeadm `kubelet.extraArgs` 消费） |
 | `kubeProxyConfiguration` | `kube_proxy.config` | map 形式（被 kubeadm `kubeProxy.config` 消费） |
+| `kubeProxyArgs`（`--flag`） | `kube_proxy.mode`（--proxy-mode）+ `kube_proxy.config`（KubeProxyConfiguration） | 不支持的 flag → **告警**；布尔 flag 转为 `true`，逗号分隔的切片转为 `[]string` |
 | `kubeletConfiguration` | `kubelet.<标量>` + `kubelet.extra_config` | `maxPods`/`podPidsLimit` 映射到标量；其余键 → `extra_config` |
 | `containerRuntimeEndpoint` | `cri.cri_socket` | 被 kubeadm `nodeRegistration.criSocket` 消费 |
 
@@ -141,6 +142,8 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | `backupDir` | `backup.backup_dir` | |
 | `keepBackupNumber` | `backup.keep_backup_number` | |
 | `backupScript` | `backup.etcd_backup_script` | |
+| `backupPeriod` | `backup.on_calendar` | 分钟 → `*/N * * * *`（systemd timer，每 N 分钟执行一次）；**告警**会说明该转换 |
+| `extraArgs`（`--flag`） | `env.<snake_key>` | 支持的 flag 映射到 `etcd.env.*`（如 `--data-dir`→`env.data_dir`）；不支持的 flag（含 listen/advertise 类 URL，v4 会据 inventory 自动生成）→ **告警** |
 
 ### registry → config.yaml cri.registry + image_registry
 
@@ -171,24 +174,28 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 以下 v3 字段要么被丢弃，要么需要手工迁移。转换器会针对每一项打印告警，
 方便你手工调整 `config.yaml`。
 
+部分原先需要手工迁移的字段现已自动转换（`kubernetes.kubeProxyArgs`、
+`etcd.backupPeriod`、`etcd.extraArgs`，见上方映射表），其**不支持的子 flag**
+仍会输出告警。
+
 | v3 字段 | 处理结果 | 建议 |
 |---|---|---|
-| `kubernetes.kubeProxyArgs` | 丢弃 | — |
+| `kubernetes.kubeProxyArgs` | 自动映射 → `kube_proxy.mode` / `kube_proxy.config` | 见 kubernetes 映射表；不支持的 flag → 告警 |
 | `kubernetes.nodeFeatureDiscovery` | 丢弃 | — |
 | `kubernetes.kata` | 丢弃 | — |
 | `kubernetes.nvidiaRuntime` | 丢弃 | — |
 | `kubernetes.type` | 忽略 | v4 无集群类型概念 |
-| `network.calico.ipipMode`（非 Always） | 手工 | 配置 calico values |
-| `network.calico.vxlanMode`（非 Never） | 手工 | 配置 calico values |
-| `network.calico.vethMTU` | 手工 | 配置 calico values |
-| `network.calico.ipAutoDetectionMethod` | 手工 | 配置 calico values |
-| `network.calico.ipv4NatOutgoing=false` | 手工 | 配置 calico values |
-| `network.calico.typha` / `controller` | 手工 | 配置 calico values |
+| `network.calico.ipipMode`（非 Always） | 手工 | 通过 `cni.calico.values`（Calico helm 自定义 values 文件，对应 Calico Installation spec）配置 |
+| `network.calico.vxlanMode`（非 Never） | 手工 | 通过 `cni.calico.values`（Calico helm 自定义 values 文件，对应 Calico Installation spec）配置 |
+| `network.calico.vethMTU` | 手工 | 通过 `cni.calico.values`（Calico helm 自定义 values 文件，对应 Calico Installation spec）配置 |
+| `network.calico.ipAutoDetectionMethod` | 手工 | 通过 `cni.calico.values`（Calico helm 自定义 values 文件，对应 Calico Installation spec）配置 |
+| `network.calico.ipv4NatOutgoing=false` | 手工 | 通过 `cni.calico.values`（Calico helm 自定义 values 文件，对应 Calico Installation spec）配置 |
+| `network.calico.typha` / `controller` | 手工 | 通过 `cni.calico.values`（Calico helm 自定义 values 文件，对应 Calico Installation spec）配置 |
 | `network.flannel` / `kubeovn` / `hybridnet` | 手工 | v4 未暴露各插件细节 |
 | `dns.coredns` | 手工 | 迁移到 `dns.coredns.zone_configs` |
 | `dns.nodelocaldns.externalZones` | 手工 | — |
-| `etcd.backupPeriod` | 手工 | v4 使用 `etcd.backup.on_calendar` |
-| `etcd.extraArgs` | 丢弃 | — |
+| `etcd.backupPeriod` | 自动映射 → `etcd.backup.on_calendar` | 见 etcd 映射表 |
+| `etcd.extraArgs` | 自动映射 → `etcd.env.<snake_key>` | 见 etcd 映射表；不支持的 flag → 告警 |
 | `etcd.external`（端点/证书） | 手工 | 配置 etcd 主机组与证书 |
 | `registry.bridgeIP` | 丢弃 | — |
 | `registry.namespaceOverride` | 手工 | 复核镜像命名 |

--- a/docs/zh/reference/config-migration.md
+++ b/docs/zh/reference/config-migration.md
@@ -73,7 +73,7 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | `port` | `port` | |
 | `internalLoadbalancer` = `""` / `none` | `type: local` | `address` → `local.address` |
 | `internalLoadbalancer` = `kubevip` | `type: kube-vip` | `address` → `kube_vip.address`；`kubevip.mode` → `kube_vip.mode` |
-| `internalLoadbalancer` = `haproxy` | `type: haproxy` | `address` → **告警**（v4 haproxy 监听 `127.0.0.1`） |
+| `internalLoadbalancer` = `haproxy` | `type: haproxy` | `address` → `haproxy.address` |
 | `internalLoadbalancer` = 其他 | `type: local` | **告警** |
 
 ### kubernetes → config.yaml kubernetes
@@ -97,6 +97,10 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | `nodeCidrMaskSizeIPv6` | `cni.ipv6_mask_size` | 见 CNI |
 | `dnsDomain` | `dns.domain` | 见 DNS |
 | `nodelocaldns` | `dns.nodelocaldns.enabled` | 见 DNS |
+| `kubeletArgs`（`K=V`） | `kubelet.extra_args` | map 形式（被 kubeadm `kubelet.extraArgs` 消费） |
+| `kubeProxyConfiguration` | `kube_proxy.config` | map 形式（被 kubeadm `kubeProxy.config` 消费） |
+| `kubeletConfiguration` | `kubelet.<标量>` + `kubelet.extra_config` | `maxPods`/`podPidsLimit` 映射到标量；其余键 → `extra_config` |
+| `containerRuntimeEndpoint` | `cri.cri_socket` | 被 kubeadm `nodeRegistration.criSocket` 消费 |
 
 ### network → config.yaml cni
 
@@ -113,6 +117,7 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 |---|---|---|
 | `kubernetes.dnsDomain` | `domain` | |
 | `kubernetes.nodelocaldns` | `nodelocaldns.enabled` | |
+| `dns.dnsEtcHosts` | `coredns.dns_etc_hosts` | |
 
 ### etcd → config.yaml etcd
 
@@ -135,6 +140,7 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | `logLevel` | `env.log_level` | |
 | `backupDir` | `backup.backup_dir` | |
 | `keepBackupNumber` | `backup.keep_backup_number` | |
+| `backupScript` | `backup.etcd_backup_script` | |
 
 ### registry → config.yaml cri.registry + image_registry
 
@@ -168,10 +174,6 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | v3 字段 | 处理结果 | 建议 |
 |---|---|---|
 | `kubernetes.kubeProxyArgs` | 丢弃 | — |
-| `kubernetes.kubeProxyConfiguration` | 手工 | 迁移到 `kubernetes.kube_proxy.config` |
-| `kubernetes.kubeletArgs` | 丢弃 | — |
-| `kubernetes.kubeletConfiguration` | 手工 | 迁移到 `kubernetes.kubelet` |
-| `kubernetes.containerRuntimeEndpoint` | 丢弃 | — |
 | `kubernetes.nodeFeatureDiscovery` | 丢弃 | — |
 | `kubernetes.kata` | 丢弃 | — |
 | `kubernetes.nvidiaRuntime` | 丢弃 | — |
@@ -185,9 +187,7 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | `network.flannel` / `kubeovn` / `hybridnet` | 手工 | v4 未暴露各插件细节 |
 | `dns.coredns` | 手工 | 迁移到 `dns.coredns.zone_configs` |
 | `dns.nodelocaldns.externalZones` | 手工 | — |
-| `dns.dnsEtcHosts` / `dns.nodeEtcHosts` | 手工 | 参考 `dns.coredns.dns_etc_hosts` |
 | `etcd.backupPeriod` | 手工 | v4 使用 `etcd.backup.on_calendar` |
-| `etcd.backupScript` | 手工 | 使用 `etcd.backup.etcd_backup_script` |
 | `etcd.extraArgs` | 丢弃 | — |
 | `etcd.external`（端点/证书） | 手工 | 配置 etcd 主机组与证书 |
 | `registry.bridgeIP` | 丢弃 | — |

--- a/docs/zh/reference/config-migration.md
+++ b/docs/zh/reference/config-migration.md
@@ -1,0 +1,212 @@
+# 将 v3（v1alpha2）配置迁移到 v4
+
+KubeKey v4 使用两个文件来定义一个集群：
+
+- `inventory.yaml` —— `Inventory` 资源（节点与主机组）。
+- `config.yaml` —— `Config` 资源（集群规格；`spec` 为 unstructured 结构）。
+
+KubeKey v3（`3.x` 分支）使用单一的 `Cluster` 清单，API 版本为
+`kubekey.kubesphere.io/v1alpha2`。为了降低升级到 v4 时手写改写的成本，
+`kk create convert` 会解析一份 v3 配置并生成 v4 的 `inventory.yaml` 与
+`config.yaml`。
+
+```bash
+# 将两个文档打印到 stdout，以 `---` 分隔
+kk create convert --input config-v3.yaml
+
+# 或写入到指定目录
+kk create convert --input config-v3.yaml -o ./out
+# ./out/inventory.yaml
+# ./out/config.yaml
+```
+
+没有清晰 1:1 v4 对应项的字段（例如 KubeSphere 启用、高级 CoreDNS、
+`system.rpms` 等）**不会被静默丢弃** —— 它们会以告警形式输出到 stderr。
+请审阅这些告警，并在需要时手工调整生成的 `config.yaml`。
+
+## 转换器如何读取 v3
+
+`pkg/convert/v1alpha2.go` 是 v3 schema 的**最小镜像**：只声明转换所需的字段。
+YAML 解码器会忽略未知字段，复合辅助类型（`CustomScripts`、`MirrorConfig`、
+`NamespaceRewrite`）以原始值保留，因此解析过程不会丢失数据。`metadata` 仅保留
+`name`。
+
+## 字段映射
+
+以下所有路径均相对于生成文件。`inventory.yaml` 的路径在 `spec` 之下；
+`config.yaml` 的路径在 `spec` 之下。
+
+### Hosts → inventory.yaml
+
+| v3 `spec.hosts[]` | v4 `inventory.yaml` | 说明 |
+|---|---|---|
+| `name` | `spec.hosts.<name>`（map 键） | |
+| `address` | `spec.hosts.<name>.connector.host` | |
+| `port` | `connector.port` | `0` → 默认 `22` |
+| `user` | `connector.user` | `""` → 默认 `root` |
+| `password` | `connector.password` | |
+| `privateKeyPath` | `connector.private_key` | |
+| `privateKey` | `connector.private_key_content` | |
+| `internalAddress` | `internal_ipv4` / `internal_ipv6` | 逗号分隔的双栈地址拆分 |
+| `arch` | `arch` | |
+| `labels` | `labels` | |
+
+### roleGroups → inventory.yaml 主机组
+
+v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`，
+并支持 `node[i:j]` 范围简写（例如 `node[1:3]` → `node1`、`node2`、`node3`）。
+
+| v3 `roleGroups` 键 | v4 主机组 |
+|---|---|
+| `master` / `control-plane` / `controlplane` | `kube_control_plane`（合并） |
+| `worker` | `kube_worker` |
+| `etcd` | `etcd` |
+| `registry` | `image_registry` |
+| 其他任意键 | 无对应 v4 组 → **告警** |
+| 聚合 | `k8s_cluster.groups = [kube_control_plane, kube_worker]` |
+
+### controlPlaneEndpoint → config.yaml kubernetes.control_plane_endpoint
+
+| v3 `controlPlaneEndpoint` | v4 `kubernetes.control_plane_endpoint` | 说明 |
+|---|---|---|
+| `domain` | `host` | |
+| `port` | `port` | |
+| `internalLoadbalancer` = `""` / `none` | `type: local` | `address` → `local.address` |
+| `internalLoadbalancer` = `kubevip` | `type: kube-vip` | `address` → `kube_vip.address`；`kubevip.mode` → `kube_vip.mode` |
+| `internalLoadbalancer` = `haproxy` | `type: haproxy` | `address` → **告警**（v4 haproxy 监听 `127.0.0.1`） |
+| `internalLoadbalancer` = 其他 | `type: local` | **告警** |
+
+### kubernetes → config.yaml kubernetes
+
+| v3 `kubernetes` | v4 `kubernetes` | 说明 |
+|---|---|---|
+| `version` | `kube_version` | |
+| `clusterName` | `cluster_name` | |
+| `autoRenewCerts` | `certs.renew` | |
+| `apiserverCertExtraSans` | `apiserver.certSANs` | |
+| `apiserverArgs`（`K=V`） | `apiserver.extra_args` | map 形式 |
+| `featureGates` | `apiserver.extra_args.feature-gates` | 拼接为 `K=true,K2=false` |
+| `controllerManagerArgs` | `controller_manager.extra_args` | |
+| `schedulerArgs` | `scheduler.extra_args` | |
+| `proxyMode` | `kube_proxy.mode` | |
+| `masqueradeAll` | `kube_proxy.config.iptables.masqueradeAll` | |
+| `disableKubeProxy` | `kube_proxy.manage.enabled = false` | **告警** |
+| `maxPods` | `kubelet.max_pods` | |
+| `podPidsLimit` | `kubelet.pod_pids_limit` | |
+| `nodeCidrMaskSize` | `cni.ipv4_mask_size` | 见 CNI |
+| `nodeCidrMaskSizeIPv6` | `cni.ipv6_mask_size` | 见 CNI |
+| `dnsDomain` | `dns.domain` | 见 DNS |
+| `nodelocaldns` | `dns.nodelocaldns.enabled` | 见 DNS |
+
+### network → config.yaml cni
+
+| v3 `network` | v4 `cni` | 说明 |
+|---|---|---|
+| `plugin` | `type` | `calico`/`cilium`/`flannel`/`kubeovn`/`hybridnet`；未知 → `other` + **告警** |
+| `kubePodsCIDR` | `pod_cidr` | |
+| `kubeServiceCIDR` | `service_cidr` | |
+| `multusCNI.enabled` | `multi_cni = "multus"` | **告警** |
+
+### dns → config.yaml dns（顶层）
+
+| v3 | v4 `dns` | 说明 |
+|---|---|---|
+| `kubernetes.dnsDomain` | `domain` | |
+| `kubernetes.nodelocaldns` | `nodelocaldns.enabled` | |
+
+### etcd → config.yaml etcd
+
+| v3 `etcd` | v4 `etcd` | 说明 |
+|---|---|---|
+| `type` = `kubekey`/`kubeadm`/`""` | `deployment_type: internal` | |
+| `type` = `external` | `deployment_type: external` | 外部端点/证书 → **告警** |
+| `port` | `port` | |
+| `peerPort` | `peer_port` | |
+| `dataDir` | `env.data_dir` | |
+| `heartbeatInterval` | `env.heartbeat_interval` | |
+| `electionTimeout` | `env.election_timeout` | |
+| `snapshotCount` | `env.snapshot_count` | |
+| `autoCompactionRetention` | `env.compaction_retention` | |
+| `metrics` | `env.metrics` | |
+| `quotaBackendBytes` | `env.quota_backend_bytes` | |
+| `maxRequestBytes` | `env.max_request_bytes` | |
+| `maxSnapshots` | `env.max_snapshots` | |
+| `maxWals` | `env.max_wals` | |
+| `logLevel` | `env.log_level` | |
+| `backupDir` | `backup.backup_dir` | |
+| `keepBackupNumber` | `backup.keep_backup_number` | |
+
+### registry → config.yaml cri.registry + image_registry
+
+| v3 `registry` | v4 | 说明 |
+|---|---|---|
+| `registryMirrors` | `cri.registry.mirrors` | |
+| `insecureRegistries` | `cri.registry.insecure_registries` | |
+| `auths`（以 registry 为键的 map） | `cri.registry.auths` | 列表，元素为 `{registry, username, password, skip_tls_verify}` |
+| `containerdDataDir` | `cri.containerd.data_root` | |
+| `dockerDataDir` | `cri.docker.daemon.data-root` | |
+| `privateRegistry` | `image_registry.auth.registry` | **告警**：v4 将其用作拉取/推送镜像的仓库 |
+
+### system → config.yaml native
+
+| v3 `system` | v4 `native` | 说明 |
+|---|---|---|
+| `ntpServers` | `ntp.servers` | |
+| `timezone` | `timezone` | |
+
+### storage → config.yaml storage_class
+
+| v3 `storage.openebs.basePath` | v4 `storage_class` | 说明 |
+|---|---|---|
+| `basePath` | `local.enabled = true`、`local.path = <basePath>` | |
+
+## 无直接 v4 对应项的字段（以告警形式报告）
+
+以下 v3 字段要么被丢弃，要么需要手工迁移。转换器会针对每一项打印告警，
+方便你手工调整 `config.yaml`。
+
+| v3 字段 | 处理结果 | 建议 |
+|---|---|---|
+| `kubernetes.kubeProxyArgs` | 丢弃 | — |
+| `kubernetes.kubeProxyConfiguration` | 手工 | 迁移到 `kubernetes.kube_proxy.config` |
+| `kubernetes.kubeletArgs` | 丢弃 | — |
+| `kubernetes.kubeletConfiguration` | 手工 | 迁移到 `kubernetes.kubelet` |
+| `kubernetes.containerRuntimeEndpoint` | 丢弃 | — |
+| `kubernetes.nodeFeatureDiscovery` | 丢弃 | — |
+| `kubernetes.kata` | 丢弃 | — |
+| `kubernetes.nvidiaRuntime` | 丢弃 | — |
+| `kubernetes.type` | 忽略 | v4 无集群类型概念 |
+| `network.calico.ipipMode`（非 Always） | 手工 | 配置 calico values |
+| `network.calico.vxlanMode`（非 Never） | 手工 | 配置 calico values |
+| `network.calico.vethMTU` | 手工 | 配置 calico values |
+| `network.calico.ipAutoDetectionMethod` | 手工 | 配置 calico values |
+| `network.calico.ipv4NatOutgoing=false` | 手工 | 配置 calico values |
+| `network.calico.typha` / `controller` | 手工 | 配置 calico values |
+| `network.flannel` / `kubeovn` / `hybridnet` | 手工 | v4 未暴露各插件细节 |
+| `dns.coredns` | 手工 | 迁移到 `dns.coredns.zone_configs` |
+| `dns.nodelocaldns.externalZones` | 手工 | — |
+| `dns.dnsEtcHosts` / `dns.nodeEtcHosts` | 手工 | 参考 `dns.coredns.dns_etc_hosts` |
+| `etcd.backupPeriod` | 手工 | v4 使用 `etcd.backup.on_calendar` |
+| `etcd.backupScript` | 手工 | 使用 `etcd.backup.etcd_backup_script` |
+| `etcd.extraArgs` | 丢弃 | — |
+| `etcd.external`（端点/证书） | 手工 | 配置 etcd 主机组与证书 |
+| `registry.bridgeIP` | 丢弃 | — |
+| `registry.namespaceOverride` | 手工 | 复核镜像命名 |
+| `registry.namespaceRewrite` | 丢弃 | — |
+| `registry.remoteMirrors` | 丢弃 | — |
+| `registry.type` | 忽略 | 使用 `image_registry.type` |
+| `system.rpms` / `system.debs` | 手工 | 通过 hook playbook 安装 |
+| `system.preInstall` / `postClusterInstall` / `postInstall` | 手工 | 迁移到 hook playbook |
+| `system.skipConfigureOS` | 丢弃 | — |
+| `controlPlaneEndpoint.address`（haproxy） | 告警 | v4 haproxy 监听 `127.0.0.1` |
+
+## 已解析但尚未转换
+
+以下 v3 字段会被解析器捕获，但转换器中尚无对应的 `config.yaml` 等价项，
+因此当前被忽略（不打印告警）：
+
+- `spec.kubesphere`（`enabled` / `version` / `configurations`）—— v4 不通过
+  `config.yaml` 启用 KubeSphere，请单独部署 KubeSphere。
+- `spec.addons` —— v4 的 `config.yaml` 无直接的 addons 映射。
+
+后续版本计划为这些字段补充显式处理（及告警）。

--- a/docs/zh/reference/config-migration.md
+++ b/docs/zh/reference/config-migration.md
@@ -198,7 +198,6 @@ v3 的 `HostCfg` 本身不带 role/taint 信息；角色仅来自 `roleGroups`�
 | `system.rpms` / `system.debs` | 手工 | 通过 hook playbook 安装 |
 | `system.preInstall` / `postClusterInstall` / `postInstall` | 手工 | 迁移到 hook playbook |
 | `system.skipConfigureOS` | 丢弃 | — |
-| `controlPlaneEndpoint.address`（haproxy） | 告警 | v4 haproxy 监听 `127.0.0.1` |
 
 ## 已解析但尚未转换
 

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -1,0 +1,823 @@
+/*
+Copyright 2026 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package convert converts a KubeKey v3 (v1alpha2) cluster configuration into
+// the KubeKey v4 inventory.yaml and config.yaml files.
+package convert
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	kkcorev1 "github.com/kubesphere/kubekey/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// v4 inventory group names.
+const (
+	groupCluster      = "k8s_cluster"
+	groupControlPlane = "kube_control_plane"
+	groupWorker       = "kube_worker"
+	groupEtcd         = "etcd"
+	groupRegistry     = "image_registry"
+)
+
+// v3 etcd deployment types.
+const (
+	v3EtcdKubeKey  = "kubekey"
+	v3EtcdKubeadm  = "kubeadm"
+	v3EtcdExternal = "external"
+)
+
+// Result holds the conversion output.
+type Result struct {
+	// Inventory is the converted v4 Inventory object.
+	Inventory *kkcorev1.Inventory
+	// Config is the converted v4 Config spec as an unstructured map.
+	Config map[string]any
+	// Warnings lists fields that could not be converted automatically and
+	// require manual review.
+	Warnings []string
+}
+
+func (r *Result) warnf(format string, args ...any) {
+	r.Warnings = append(r.Warnings, fmt.Sprintf(format, args...))
+}
+
+// Convert transforms a parsed v3 cluster configuration into v4 Inventory and
+// Config objects. Fields that have no v4 equivalent or whose semantics differ
+// are reported in Result.Warnings instead of being silently dropped.
+func Convert(cluster *Cluster) (*Result, error) {
+	r := &Result{}
+
+	roleGroups, err := expandRoleGroups(cluster.Spec.RoleGroups, hostNames(cluster.Spec.Hosts))
+	if err != nil {
+		return nil, err
+	}
+
+	r.convertInventory(cluster, roleGroups)
+	r.convertConfig(cluster, roleGroups)
+
+	return r, nil
+}
+
+func hostNames(hosts []HostCfg) []string {
+	names := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		names = append(names, h.Name)
+	}
+	return names
+}
+
+// convertInventory builds the v4 Inventory from v3 hosts and roleGroups.
+func (r *Result) convertInventory(cluster *Cluster, roleGroups map[string][]string) {
+	name := cluster.Metadata.Name
+	if name == "" {
+		name = "default"
+	}
+
+	hosts := make(map[string]runtime.RawExtension, len(cluster.Spec.Hosts))
+	for _, h := range cluster.Spec.Hosts {
+		connector := map[string]any{
+			"type": "ssh",
+			"host": h.Address,
+			"port": h.Port,
+			"user": h.User,
+		}
+		if h.Port == 0 {
+			connector["port"] = 22
+		}
+		if h.User == "" {
+			connector["user"] = "root"
+		}
+		if h.Password != "" {
+			connector["password"] = h.Password
+		}
+		if h.PrivateKeyPath != "" {
+			connector["private_key"] = h.PrivateKeyPath
+		}
+		if h.PrivateKey != "" {
+			connector["private_key_content"] = h.PrivateKey
+		}
+
+		vars := map[string]any{"connector": connector}
+		if h.InternalAddress != "" {
+			ipv4, ipv6 := splitInternalAddress(h.InternalAddress)
+			if ipv4 != "" {
+				vars["internal_ipv4"] = ipv4
+			}
+			if ipv6 != "" {
+				vars["internal_ipv6"] = ipv6
+			}
+		}
+		if h.Arch != "" {
+			vars["arch"] = h.Arch
+		}
+		if len(h.Labels) > 0 {
+			vars["labels"] = h.Labels
+		}
+
+		raw, err := toRawExtension(vars)
+		if err != nil {
+			r.warnf("failed to serialize vars for host %q: %v", h.Name, err)
+			continue
+		}
+		hosts[h.Name] = raw
+	}
+
+	groups := map[string]kkcorev1.InventoryGroup{}
+	appendGroup := func(group string, names []string) {
+		if len(names) == 0 {
+			return
+		}
+		groups[group] = kkcorev1.InventoryGroup{Hosts: names}
+	}
+	appendGroup(groupControlPlane, mergeUnique(roleGroups[v3RoleMaster], roleGroups[v3RoleControlPlane], roleGroups[v3RoleControlPlane2]))
+	appendGroup(groupWorker, roleGroups[v3RoleWorker])
+	appendGroup(groupEtcd, roleGroups[v3RoleEtcd])
+	appendGroup(groupRegistry, mergeUnique(roleGroups[v3RoleRegistry]))
+
+	for role := range roleGroups {
+		switch role {
+		case v3RoleMaster, v3RoleControlPlane, v3RoleControlPlane2, v3RoleWorker, v3RoleEtcd, v3RoleRegistry:
+		default:
+			r.warnf("roleGroups/%s has no v4 inventory group equivalent, its hosts are not converted", role)
+		}
+	}
+	if _, ok := groups[groupEtcd]; !ok && cluster.Spec.Etcd.Type != v3EtcdExternal {
+		r.warnf("no etcd roleGroup defined; etcd hosts must be added to the %q group manually", groupEtcd)
+	}
+
+	// k8s_cluster aggregates control plane and worker groups.
+	clusterGroups := []string{groupControlPlane}
+	if _, ok := groups[groupWorker]; ok {
+		clusterGroups = append(clusterGroups, groupWorker)
+	}
+	groups[groupCluster] = kkcorev1.InventoryGroup{Groups: clusterGroups}
+
+	r.Inventory = &kkcorev1.Inventory{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubekey.kubesphere.io/v1",
+			Kind:       "Inventory",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kkcorev1.InventorySpec{
+			Hosts:  hosts,
+			Groups: groups,
+		},
+	}
+}
+
+// convertConfig builds the v4 Config spec from v3 fields. Only fields that are
+// explicitly set in the v3 configuration are written; the rest fall back to v4
+// defaults at install time.
+func (r *Result) convertConfig(cluster *Cluster, roleGroups map[string][]string) {
+	spec := map[string]any{}
+	spec["kubernetes"] = r.convertKubernetes(cluster)
+	if cni := r.convertCNI(cluster); cni != nil {
+		spec["cni"] = cni
+	}
+	if dns := r.convertDNS(cluster); dns != nil {
+		spec["dns"] = dns
+	}
+	if etcd := r.convertEtcd(cluster); etcd != nil {
+		spec["etcd"] = etcd
+	}
+	if cri := r.convertCRI(cluster); cri != nil {
+		spec["cri"] = cri
+	}
+	if registry := r.convertImageRegistry(cluster); registry != nil {
+		spec["image_registry"] = registry
+	}
+	if storage := r.convertStorage(cluster); storage != nil {
+		spec["storage_class"] = storage
+	}
+	if native := r.convertNative(cluster); native != nil {
+		spec["native"] = native
+	}
+	if audit := cluster.Spec.Kubernetes.Audit; len(audit) > 0 {
+		if enabled, ok := audit["enabled"].(bool); ok && enabled {
+			spec["audit"] = true
+		}
+	}
+	r.Config = spec
+}
+
+func (r *Result) convertKubernetes(cluster *Cluster) map[string]any {
+	k3 := cluster.Spec.Kubernetes
+	k := map[string]any{}
+
+	if k3.Version != "" {
+		k["kube_version"] = k3.Version
+	}
+	if k3.ClusterName != "" {
+		k["cluster_name"] = k3.ClusterName
+	}
+
+	// control_plane_endpoint
+	cpe := map[string]any{}
+	if cluster.Spec.ControlPlaneEndpoint.Domain != "" {
+		cpe["host"] = cluster.Spec.ControlPlaneEndpoint.Domain
+	}
+	if cluster.Spec.ControlPlaneEndpoint.Port != 0 {
+		cpe["port"] = cluster.Spec.ControlPlaneEndpoint.Port
+	}
+	switch cluster.Spec.ControlPlaneEndpoint.InternalLoadbalancer {
+	case "", "none":
+		cpe["type"] = "local"
+		if cluster.Spec.ControlPlaneEndpoint.Address != "" {
+			cpe["local"] = map[string]any{"address": cluster.Spec.ControlPlaneEndpoint.Address}
+		}
+	case "kubevip":
+		cpe["type"] = "kube-vip"
+		kv := map[string]any{}
+		if cluster.Spec.ControlPlaneEndpoint.Address != "" {
+			kv["address"] = cluster.Spec.ControlPlaneEndpoint.Address
+		}
+		if cluster.Spec.ControlPlaneEndpoint.KubeVip.Mode != "" {
+			kv["mode"] = cluster.Spec.ControlPlaneEndpoint.KubeVip.Mode
+		}
+		if len(kv) > 0 {
+			cpe["kube_vip"] = kv
+		}
+	case "haproxy":
+		cpe["type"] = "haproxy"
+		if cluster.Spec.ControlPlaneEndpoint.Address != "" {
+			r.warnf("controlPlaneEndpoint.address %q has no direct equivalent when type is haproxy (v4 haproxy listens on 127.0.0.1); review kubernetes.control_plane_endpoint", cluster.Spec.ControlPlaneEndpoint.Address)
+		}
+	default:
+		r.warnf("unsupported controlPlaneEndpoint.internalLoadbalancer %q, converted to type local", cluster.Spec.ControlPlaneEndpoint.InternalLoadbalancer)
+		cpe["type"] = "local"
+	}
+	k["control_plane_endpoint"] = cpe
+
+	if k3.AutoRenewCerts != nil {
+		setNested(k, *k3.AutoRenewCerts, "certs", "renew")
+	}
+
+	// apiserver
+	api := map[string]any{}
+	if len(k3.ApiserverCertExtraSans) > 0 {
+		api["certSANs"] = k3.ApiserverCertExtraSans
+	}
+	if args := argsToMap(k3.ApiServerArgs); len(args) > 0 {
+		api["extra_args"] = args
+	}
+	if fg := featureGatesArg(k3.FeatureGates); fg != "" {
+		extra, _ := api["extra_args"].(map[string]any)
+		if extra == nil {
+			extra = map[string]any{}
+		}
+		if existing, ok := extra["feature-gates"].(string); ok && existing != "" {
+			extra["feature-gates"] = existing + "," + fg
+		} else {
+			extra["feature-gates"] = fg
+		}
+		api["extra_args"] = extra
+	}
+	if len(api) > 0 {
+		k["apiserver"] = api
+	}
+
+	if args := argsToMap(k3.ControllerManagerArgs); len(args) > 0 {
+		setNested(k, args, "controller_manager", "extra_args")
+	}
+	if args := argsToMap(k3.SchedulerArgs); len(args) > 0 {
+		setNested(k, args, "scheduler", "extra_args")
+	}
+
+	// kube_proxy
+	kp := map[string]any{}
+	if k3.ProxyMode != "" {
+		kp["mode"] = k3.ProxyMode
+	}
+	if k3.MasqueradeAll {
+		setNested(kp, true, "config", "iptables", "masqueradeAll")
+	}
+	if k3.DisableKubeProxy {
+		setNested(kp, false, "manage", "enabled")
+		r.warnf("kubernetes.disableKubeProxy is mapped to kube_proxy.manage.enabled=false; verify kube-proxy deployment ownership")
+	}
+	if len(kp) > 0 {
+		k["kube_proxy"] = kp
+	}
+	if len(k3.KubeProxyArgs) > 0 {
+		r.warnf("kubernetes.kubeProxyArgs has no v4 equivalent and is dropped")
+	}
+	if len(k3.KubeProxyConfiguration) > 0 {
+		r.warnf("kubernetes.kubeProxyConfiguration has no direct v4 equivalent; migrate entries to kubernetes.kube_proxy.config manually")
+	}
+
+	// kubelet
+	kubelet := map[string]any{}
+	if k3.MaxPods != 0 {
+		kubelet["max_pods"] = k3.MaxPods
+	}
+	if k3.PodPidsLimit != 0 {
+		kubelet["pod_pids_limit"] = k3.PodPidsLimit
+	}
+	if len(kubelet) > 0 {
+		k["kubelet"] = kubelet
+	}
+	if len(k3.KubeletArgs) > 0 {
+		r.warnf("kubernetes.kubeletArgs has no v4 equivalent and is dropped")
+	}
+	if len(k3.KubeletConfiguration) > 0 {
+		r.warnf("kubernetes.kubeletConfiguration has no direct v4 equivalent; migrate entries to kubernetes.kubelet manually")
+	}
+
+	if k3.ContainerRuntimeEndpoint != "" {
+		r.warnf("kubernetes.containerRuntimeEndpoint has no v4 equivalent and is dropped")
+	}
+	if len(k3.NodeFeatureDiscovery) > 0 {
+		r.warnf("kubernetes.nodeFeatureDiscovery has no v4 equivalent and is dropped")
+	}
+	if len(k3.Kata) > 0 {
+		r.warnf("kubernetes.kata has no v4 equivalent and is dropped")
+	}
+	if k3.NvidiaRuntime != nil && *k3.NvidiaRuntime {
+		r.warnf("kubernetes.nvidiaRuntime has no v4 equivalent and is dropped")
+	}
+	if k3.Type != "" {
+		r.warnf("kubernetes.type %q is ignored by v4", k3.Type)
+	}
+
+	return k
+}
+
+func (r *Result) convertCNI(cluster *Cluster) map[string]any {
+	n := cluster.Spec.Network
+	cni := map[string]any{}
+
+	switch n.Plugin {
+	case "":
+		return nil
+	case "calico", "cilium", "flannel", "kubeovn", "hybridnet":
+		cni["type"] = n.Plugin
+	default:
+		r.warnf("network.plugin %q has no v4 cni.type equivalent, use \"other\" and configure it manually", n.Plugin)
+		cni["type"] = "other"
+	}
+	if n.KubePodsCIDR != "" {
+		cni["pod_cidr"] = n.KubePodsCIDR
+	}
+	if n.KubeServiceCIDR != "" {
+		cni["service_cidr"] = n.KubeServiceCIDR
+	}
+	if cluster.Spec.Kubernetes.NodeCidrMaskSize != 0 {
+		cni["ipv4_mask_size"] = cluster.Spec.Kubernetes.NodeCidrMaskSize
+	}
+	if cluster.Spec.Kubernetes.NodeCidrMaskSizeIPv6 != 0 {
+		cni["ipv6_mask_size"] = cluster.Spec.Kubernetes.NodeCidrMaskSizeIPv6
+	}
+
+	// Per-plugin details are largely not exposed by v4 defaults.
+	if !calicoEmpty(n.Calico) {
+		c := n.Calico
+		if c.IPIPMode != "" && c.IPIPMode != "Always" {
+			r.warnf("network.calico.ipipMode %q has no v4 equivalent; configure calico values manually", c.IPIPMode)
+		}
+		if c.VXLANMode != "" && c.VXLANMode != "Never" {
+			r.warnf("network.calico.vxlanMode %q has no v4 equivalent; configure calico values manually", c.VXLANMode)
+		}
+		if c.VethMTU != 0 {
+			r.warnf("network.calico.vethMTU %d has no v4 equivalent; configure calico values manually", c.VethMTU)
+		}
+		if c.IPAutoDetectionMethod != "" {
+			r.warnf("network.calico.ipAutoDetectionMethod %q has no v4 equivalent; configure calico values manually", c.IPAutoDetectionMethod)
+		}
+		if c.Ipv4NatOutgoing != nil && !*c.Ipv4NatOutgoing {
+			r.warnf("network.calico.ipv4NatOutgoing=false has no v4 equivalent; configure calico values manually")
+		}
+		if len(c.Typha) > 0 || len(c.Controller) > 0 {
+			r.warnf("network.calico.typha/controller have no v4 equivalent; configure calico values manually")
+		}
+	}
+	for _, p := range []struct {
+		name string
+		cfg  map[string]any
+	}{{"flannel", n.Flannel}, {"kubeovn", n.Kubeovn}, {"hybridnet", n.Hybridnet}} {
+		if len(p.cfg) > 0 {
+			r.warnf("network.%s has no direct v4 equivalent; review and configure it manually", p.name)
+		}
+	}
+	if v, ok := n.MultusCNI["enabled"].(bool); ok && v {
+		cni["multi_cni"] = "multus"
+		r.warnf("network.multusCNI.enabled is mapped to cni.multi_cni=multus; verify multus settings")
+	}
+
+	return cni
+}
+
+// convertDNS builds the top-level v4 dns section from the v3 kubernetes
+// dnsDomain/nodelocaldns fields and the v3 dns block.
+func (r *Result) convertDNS(cluster *Cluster) map[string]any {
+	dns := map[string]any{}
+
+	if k3 := cluster.Spec.Kubernetes; k3.DNSDomain != "" {
+		dns["domain"] = k3.DNSDomain
+	}
+	if k3 := cluster.Spec.Kubernetes; k3.Nodelocaldns != nil {
+		setNested(dns, *k3.Nodelocaldns, "nodelocaldns", "enabled")
+	}
+
+	d3 := cluster.Spec.DNS
+	if len(d3.CoreDNS) > 0 {
+		r.warnf("dns.coredns advanced settings (additionalConfigs/externalZones/rewriteBlock/upstreamDNSServers) have no direct v4 equivalent; migrate them to dns.coredns.zone_configs manually")
+	}
+	if len(d3.NodeLocalDNS) > 0 {
+		r.warnf("dns.nodelocaldns.externalZones have no direct v4 equivalent; migrate them manually")
+	}
+	if d3.DNSEtcHosts != "" || d3.NodeEtcHosts != "" {
+		r.warnf("dns.dnsEtcHosts/nodeEtcHosts have no direct v4 equivalent; review dns.coredns.dns_etc_hosts and node /etc/hosts handling manually")
+	}
+
+	if len(dns) == 0 {
+		return nil
+	}
+	return dns
+}
+
+func (r *Result) convertEtcd(cluster *Cluster) map[string]any {
+	e3 := cluster.Spec.Etcd
+	etcd := map[string]any{}
+
+	switch e3.Type {
+	case "", v3EtcdKubeKey, v3EtcdKubeadm:
+		etcd["deployment_type"] = "internal"
+	case v3EtcdExternal:
+		etcd["deployment_type"] = "external"
+		if len(e3.External) > 0 {
+			r.warnf("etcd.external endpoints/certs have no direct v4 equivalent; configure the etcd host group and certificates manually")
+		}
+	default:
+		r.warnf("unsupported etcd.type %q, converted to deployment_type internal", e3.Type)
+		etcd["deployment_type"] = "internal"
+	}
+	if e3.Port != nil {
+		etcd["port"] = *e3.Port
+	}
+	if e3.PeerPort != nil {
+		etcd["peer_port"] = *e3.PeerPort
+	}
+
+	env := map[string]any{}
+	if e3.DataDir != nil && *e3.DataDir != "" {
+		env["data_dir"] = *e3.DataDir
+	}
+	if e3.HeartbeatInterval != nil {
+		env["heartbeat_interval"] = *e3.HeartbeatInterval
+	}
+	if e3.ElectionTimeout != nil {
+		env["election_timeout"] = *e3.ElectionTimeout
+	}
+	if e3.SnapshotCount != nil {
+		env["snapshot_count"] = *e3.SnapshotCount
+	}
+	if e3.AutoCompactionRetention != nil {
+		env["compaction_retention"] = *e3.AutoCompactionRetention
+	}
+	if e3.Metrics != nil && *e3.Metrics != "" {
+		env["metrics"] = *e3.Metrics
+	}
+	if e3.QuotaBackendBytes != nil {
+		env["quota_backend_bytes"] = *e3.QuotaBackendBytes
+	}
+	if e3.MaxRequestBytes != nil {
+		env["max_request_bytes"] = *e3.MaxRequestBytes
+	}
+	if e3.MaxSnapshots != nil {
+		env["max_snapshots"] = *e3.MaxSnapshots
+	}
+	if e3.MaxWals != nil {
+		env["max_wals"] = *e3.MaxWals
+	}
+	if e3.LogLevel != nil && *e3.LogLevel != "" {
+		env["log_level"] = *e3.LogLevel
+	}
+	if len(env) > 0 {
+		etcd["env"] = env
+	}
+
+	backup := map[string]any{}
+	if e3.BackupDir != "" {
+		backup["backup_dir"] = e3.BackupDir
+	}
+	if e3.KeepBackupNumber != 0 {
+		backup["keep_backup_number"] = e3.KeepBackupNumber
+	}
+	if len(backup) > 0 {
+		etcd["backup"] = backup
+	}
+	if e3.BackupPeriod != 0 {
+		r.warnf("etcd.backupPeriod %d uses a different scheduling model in v4 (etcd.backup.on_calendar); review it manually", e3.BackupPeriod)
+	}
+	if e3.BackupScriptDir != "" {
+		r.warnf("etcd.backupScript %q has no direct v4 equivalent (etcd.backup.etcd_backup_script); review it manually", e3.BackupScriptDir)
+	}
+	if len(e3.ExtraArgs) > 0 {
+		r.warnf("etcd.extraArgs has no v4 equivalent and is dropped")
+	}
+
+	return etcd
+}
+
+func (r *Result) convertCRI(cluster *Cluster) map[string]any {
+	cri := map[string]any{}
+
+	if cm := cluster.Spec.Kubernetes.ContainerManager; cm != "" {
+		cri["container_manager"] = cm
+	}
+
+	reg := cluster.Spec.Registry
+	criRegistry := map[string]any{}
+	if len(reg.RegistryMirrors) > 0 {
+		criRegistry["mirrors"] = reg.RegistryMirrors
+	}
+	if len(reg.InsecureRegistries) > 0 {
+		criRegistry["insecure_registries"] = reg.InsecureRegistries
+	}
+	if len(reg.Auths) > 0 {
+		auths := convertRegistryAuths(reg.Auths, r)
+		if len(auths) > 0 {
+			criRegistry["auths"] = auths
+		}
+	}
+	if len(criRegistry) > 0 {
+		cri["registry"] = criRegistry
+	}
+
+	if reg.ContainerdDataDir != "" {
+		setNested(cri, reg.ContainerdDataDir, "containerd", "data_root")
+	}
+	if reg.DockerDataDir != "" {
+		setNested(cri, reg.DockerDataDir, "docker", "daemon", "data-root")
+	}
+	if reg.BridgeIP != "" {
+		r.warnf("registry.bridgeIP has no v4 equivalent and is dropped")
+	}
+	if reg.NamespaceOverride != "" {
+		r.warnf("registry.namespaceOverride %q has no direct v4 equivalent; review image naming manually", reg.NamespaceOverride)
+	}
+	if len(reg.NamespaceRewrite) > 0 {
+		r.warnf("registry.namespaceRewrite has no v4 equivalent and is dropped")
+	}
+	if len(reg.RemoteMirrors) > 0 {
+		r.warnf("registry.remoteMirrors has no v4 equivalent and is dropped")
+	}
+	if reg.Type != "" {
+		r.warnf("registry.type %q is ignored by v4; use image_registry.type instead", reg.Type)
+	}
+
+	if len(cri) == 0 {
+		return nil
+	}
+	return cri
+}
+
+// convertRegistryAuths converts the v3 auths map (keyed by registry) into the
+// v4 auths list ({registry, username, password, skip_tls_verify, ...}).
+func convertRegistryAuths(auths map[string]any, r *Result) []map[string]any {
+	keys := make([]string, 0, len(auths))
+	for k := range auths {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	result := make([]map[string]any, 0, len(auths))
+	for _, registry := range keys {
+		entry, ok := auths[registry].(map[string]any)
+		if !ok {
+			r.warnf("registry.auths[%q] has an unexpected format and is dropped", registry)
+			continue
+		}
+		item := map[string]any{"registry": registry}
+		for src, dst := range map[string]string{
+			"username":      "username",
+			"password":      "password",
+			"skipTLSVerify": "skip_tls_verify",
+		} {
+			if v, ok := entry[src]; ok {
+				item[dst] = v
+			}
+		}
+		if v, ok := entry["plainHTTP"].(bool); ok && v {
+			r.warnf("registry.auths[%q].plainHTTP has no v4 auths equivalent; use image_registry.auth.plain_http", registry)
+		}
+		if v, ok := entry["certsPath"].(string); ok && v != "" {
+			r.warnf("registry.auths[%q].certsPath has no direct v4 equivalent; use auths ca_cert/cert_file/key_file", registry)
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func (r *Result) convertImageRegistry(cluster *Cluster) map[string]any {
+	reg := cluster.Spec.Registry
+	ir := map[string]any{}
+
+	if reg.PrivateRegistry != "" {
+		ir["auth"] = map[string]any{"registry": reg.PrivateRegistry}
+		r.warnf("registry.privateRegistry is mapped to image_registry.auth.registry; v4 uses it as the pull/push registry, verify the value %q", reg.PrivateRegistry)
+	}
+	if reg.RegistryDataDir != "" {
+		r.warnf("registry.registryDataDir has no v4 equivalent and is dropped")
+	}
+	if len(ir) == 0 {
+		return nil
+	}
+	return ir
+}
+
+func (r *Result) convertStorage(cluster *Cluster) map[string]any {
+	basePath := cluster.Spec.Storage.OpenEBS.BasePath
+	if basePath == "" {
+		return nil
+	}
+	return map[string]any{
+		"local": map[string]any{
+			"enabled": true,
+			"path":    basePath,
+		},
+	}
+}
+
+func (r *Result) convertNative(cluster *Cluster) map[string]any {
+	sys := cluster.Spec.System
+	native := map[string]any{}
+
+	if len(sys.NtpServers) > 0 {
+		setNested(native, sys.NtpServers, "ntp", "servers")
+	}
+	if sys.Timezone != "" {
+		native["timezone"] = sys.Timezone
+	}
+	if len(sys.Rpms) > 0 || len(sys.Debs) > 0 {
+		r.warnf("system.rpms/debs have no v4 equivalent; install extra packages via hook playbooks")
+	}
+	if len(sys.PreInstall) > 0 || len(sys.PostClusterInstall) > 0 || len(sys.PostInstall) > 0 {
+		r.warnf("system.preInstall/postClusterInstall/postInstall scripts have no v4 equivalent; migrate them to hook playbooks")
+	}
+	if sys.SkipConfigureOS {
+		r.warnf("system.skipConfigureOS has no v4 equivalent and is dropped")
+	}
+
+	if len(native) == 0 {
+		return nil
+	}
+	return native
+}
+
+// calicoEmpty reports whether no calico field is set.
+func calicoEmpty(c CalicoCfg) bool {
+	return c.IPIPMode == "" && c.IPAutoDetectionMethod == "" && c.VXLANMode == "" && c.VethMTU == 0 &&
+		c.Ipv4NatOutgoing == nil && c.Ipv6NatOutgoing == nil && c.DefaultIPPOOL == nil &&
+		len(c.Typha) == 0 && len(c.Controller) == 0
+}
+
+// argsToMap converts v3 component args ("K=V" strings) into the v4 extra_args map.
+func argsToMap(args []string) map[string]any {
+	if len(args) == 0 {
+		return nil
+	}
+	m := make(map[string]any, len(args))
+	for _, arg := range args {
+		k, v, found := strings.Cut(arg, "=")
+		if !found {
+			m[k] = ""
+			continue
+		}
+		m[k] = v
+	}
+	return m
+}
+
+// featureGatesArg joins feature gates into the "A=true,B=false" argument value.
+func featureGatesArg(gates map[string]bool) string {
+	if len(gates) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(gates))
+	for k := range gates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%t", k, gates[k]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func mergeUnique(lists ...[]string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0)
+	for _, list := range lists {
+		for _, item := range list {
+			if _, ok := seen[item]; ok {
+				continue
+			}
+			seen[item] = struct{}{}
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+// setNested sets a nested value in a map[string]any tree, creating
+// intermediate maps as needed. It panics-free overwrites existing values.
+func setNested(obj map[string]any, value any, fields ...string) {
+	for i, field := range fields {
+		if i == len(fields)-1 {
+			obj[field] = value
+			return
+		}
+		next, ok := obj[field].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			obj[field] = next
+		}
+		obj = next
+	}
+}
+
+// ConvertInventoryAndConfig converts v3 configuration YAML bytes into v4
+// inventory and config YAML bytes.
+func ConvertInventoryAndConfig(data []byte) (inventoryYAML, configYAML []byte, warnings []string, err error) {
+	cluster, err := ParseCluster(data)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	result, err := Convert(cluster)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	inventoryYAML, err = marshalYAML(inventoryOutputMap(result.Inventory))
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to marshal inventory")
+	}
+	configYAML, err = marshalYAML(map[string]any{
+		"apiVersion": "kubekey.kubesphere.io/v1",
+		"kind":       "Config",
+		"spec":       result.Config,
+	})
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to marshal config")
+	}
+	return inventoryYAML, configYAML, result.Warnings, nil
+}
+
+// inventoryOutputMap renders the Inventory as a clean output document without
+// CRD zero values (empty status, null vars, ...).
+func inventoryOutputMap(inv *kkcorev1.Inventory) map[string]any {
+	hosts := make(map[string]any, len(inv.Spec.Hosts))
+	for name, raw := range inv.Spec.Hosts {
+		vars := map[string]any{}
+		if len(raw.Raw) > 0 {
+			if err := json.Unmarshal(raw.Raw, &vars); err != nil {
+				vars = map[string]any{}
+			}
+		}
+		hosts[name] = vars
+	}
+
+	groups := make(map[string]any, len(inv.Spec.Groups))
+	for name, group := range inv.Spec.Groups {
+		g := map[string]any{}
+		if len(group.Groups) > 0 {
+			g["groups"] = group.Groups
+		}
+		if len(group.Hosts) > 0 {
+			g["hosts"] = group.Hosts
+		}
+		groups[name] = g
+	}
+
+	return map[string]any{
+		"apiVersion": "kubekey.kubesphere.io/v1",
+		"kind":       "Inventory",
+		"metadata":   map[string]any{"name": inv.Name},
+		"spec": map[string]any{
+			"hosts":  hosts,
+			"groups": groups,
+		},
+	}
+}

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -315,14 +316,19 @@ func (r *Result) convertKubernetes(cluster *Cluster) map[string]any {
 		setNested(kp, false, "manage", "enabled")
 		r.warnf("kubernetes.disableKubeProxy is mapped to kube_proxy.manage.enabled=false; verify kube-proxy deployment ownership")
 	}
-	if len(kp) > 0 {
-		k["kube_proxy"] = kp
-	}
+	// kubernetes.kubeProxyArgs are kube-proxy component flags; they map onto
+	// kube_proxy.mode (--proxy-mode) and the kube_proxy.config KubeProxyConfiguration
+	// (every other flag). Unsupported flags are reported and dropped.
 	if len(k3.KubeProxyArgs) > 0 {
-		r.warnf("kubernetes.kubeProxyArgs has no v4 equivalent and is dropped")
+		r.convertKubeProxyArgs(k3.KubeProxyArgs, kp)
 	}
 	if len(k3.KubeProxyConfiguration) > 0 {
-		setNested(k, k3.KubeProxyConfiguration, "kube_proxy", "config")
+		// Merge the structured KubeProxyConfiguration on top of any args-derived
+		// config; an explicit kubeProxyConfiguration wins over kubeProxyArgs.
+		mergeMap(getOrCreateMap(kp, "config"), k3.KubeProxyConfiguration)
+	}
+	if len(kp) > 0 {
+		k["kube_proxy"] = kp
 	}
 
 	// kubelet
@@ -390,26 +396,40 @@ func (r *Result) convertCNI(cluster *Cluster) map[string]any {
 		cni["ipv6_mask_size"] = cluster.Spec.Kubernetes.NodeCidrMaskSizeIPv6
 	}
 
-	// Per-plugin details are largely not exposed by v4 defaults.
+	// Per-plugin details: v4 does not expose Calico (or other CNI plugins) through
+	// structured config keys. Instead it renders the plugin from a helm chart and lets
+	// the user override it via cni.<plugin>.values (a Calico/Cilium helm custom values
+	// file). Collect the non-default calico fields and point the user at that values
+	// file, which targets the Calico Installation spec.
 	if !calicoEmpty(n.Calico) {
 		c := n.Calico
-		if c.IPIPMode != "" && c.IPIPMode != "Always" {
-			r.warnf("network.calico.ipipMode %q has no v4 equivalent; configure calico values manually", c.IPIPMode)
+		var fields []string
+		if c.IPIPMode != "" {
+			fields = append(fields, "ipipMode="+c.IPIPMode)
 		}
-		if c.VXLANMode != "" && c.VXLANMode != "Never" {
-			r.warnf("network.calico.vxlanMode %q has no v4 equivalent; configure calico values manually", c.VXLANMode)
+		if c.VXLANMode != "" {
+			fields = append(fields, "vxlanMode="+c.VXLANMode)
 		}
 		if c.VethMTU != 0 {
-			r.warnf("network.calico.vethMTU %d has no v4 equivalent; configure calico values manually", c.VethMTU)
+			fields = append(fields, fmt.Sprintf("vethMTU=%d", c.VethMTU))
 		}
 		if c.IPAutoDetectionMethod != "" {
-			r.warnf("network.calico.ipAutoDetectionMethod %q has no v4 equivalent; configure calico values manually", c.IPAutoDetectionMethod)
+			fields = append(fields, "ipAutoDetectionMethod="+c.IPAutoDetectionMethod)
 		}
-		if c.Ipv4NatOutgoing != nil && !*c.Ipv4NatOutgoing {
-			r.warnf("network.calico.ipv4NatOutgoing=false has no v4 equivalent; configure calico values manually")
+		if c.Ipv4NatOutgoing != nil {
+			fields = append(fields, fmt.Sprintf("ipv4NatOutgoing=%t", *c.Ipv4NatOutgoing))
 		}
-		if len(c.Typha) > 0 || len(c.Controller) > 0 {
-			r.warnf("network.calico.typha/controller have no v4 equivalent; configure calico values manually")
+		if c.Ipv6NatOutgoing != nil {
+			fields = append(fields, fmt.Sprintf("ipv6NatOutgoing=%t", *c.Ipv6NatOutgoing))
+		}
+		if len(c.Typha) > 0 {
+			fields = append(fields, "typha")
+		}
+		if len(c.Controller) > 0 {
+			fields = append(fields, "controller")
+		}
+		if len(fields) > 0 {
+			r.warnf("network.calico fields [%s] have no direct v4 config keys; migrate them via cni.calico.values (Calico helm custom values file, see cni/calico/tasks) targeting the Calico Installation spec", strings.Join(fields, ", "))
 		}
 	}
 	for _, p := range []struct {
@@ -531,14 +551,24 @@ func (r *Result) convertEtcd(cluster *Cluster) map[string]any {
 	if e3.BackupScriptDir != "" {
 		backup["etcd_backup_script"] = e3.BackupScriptDir
 	}
+	if e3.BackupPeriod != 0 {
+		// v4 schedules backups with a systemd OnCalendar expression. A 3.x
+		// backupPeriod is an interval in minutes, which maps to "every N minutes".
+		cal := fmt.Sprintf("*/%d * * * *", e3.BackupPeriod)
+		backup["on_calendar"] = cal
+		r.warnf("etcd.backupPeriod %d (minutes) auto-converted to etcd.backup.on_calendar=%q (systemd timer, runs every %d minutes); verify the schedule matches your expectation", e3.BackupPeriod, cal, e3.BackupPeriod)
+	}
 	if len(backup) > 0 {
 		etcd["backup"] = backup
 	}
-	if e3.BackupPeriod != 0 {
-		r.warnf("etcd.backupPeriod %d uses a different scheduling model in v4 (etcd.backup.on_calendar); review it manually", e3.BackupPeriod)
-	}
+
+	// etcd.extraArgs are etcd component flags ("--flag=value"). v4 feeds etcd via
+	// the etcd.env template, which exposes a fixed set of ETCD_* env keys through
+	// etcd.env.<snake_key>. Map the supported flags there; unsupported flags (e.g.
+	// listen/advertise URLs, which v4 computes from the inventory) are reported and
+	// dropped.
 	if len(e3.ExtraArgs) > 0 {
-		r.warnf("etcd.extraArgs has no v4 equivalent and is dropped")
+		r.convertEtcdExtraArgs(e3.ExtraArgs, etcd)
 	}
 
 	return etcd
@@ -818,6 +848,163 @@ func setNested(obj map[string]any, value any, fields ...string) {
 		}
 		obj = next
 	}
+}
+
+// getOrCreateMap returns m[key] as a map[string]any, creating and storing an
+// empty map if it is absent or not already a map.
+func getOrCreateMap(m map[string]any, key string) map[string]any {
+	if sub, ok := m[key].(map[string]any); ok {
+		return sub
+	}
+	sub := map[string]any{}
+	m[key] = sub
+	return sub
+}
+
+// mergeMap deep-merges src into dst; on conflict src values win. Both are
+// map[string]any trees (mirrors how kube_proxy.config is built).
+func mergeMap(dst, src map[string]any) {
+	for k, v := range src {
+		if sm, ok := v.(map[string]any); ok {
+			if dm, ok := dst[k].(map[string]any); ok {
+				mergeMap(dm, sm)
+				continue
+			}
+		}
+		dst[k] = v
+	}
+}
+
+// kubeProxyArgPaths maps a kube-proxy component flag (without leading "--") to
+// its path inside kube_proxy. The top-level "mode" maps to kube_proxy.mode;
+// every other flag maps into the kube_proxy.config KubeProxyConfiguration.
+// Field names follow the upstream KubeProxyConfiguration API.
+var kubeProxyArgPaths = map[string][]string{
+	"proxy-mode":                        {"mode"},
+	"bind-address":                      {"config", "bindAddress"},
+	"cluster-cidr":                      {"config", "clusterCIDR"},
+	"healthz-bind-address":              {"config", "healthzBindAddress"},
+	"metrics-bind-address":              {"config", "metricsBindAddress"},
+	"hostname-override":                 {"config", "hostnameOverride"},
+	"nodeport-addresses":                {"config", "nodePortAddresses"},
+	"oom-score-adj":                     {"config", "oomScoreAdj"},
+	"profiling":                         {"config", "profiling"},
+	"sync-period":                       {"config", "syncPeriod"},
+	"masquerade-all":                    {"config", "iptables", "masqueradeAll"},
+	"masquerade-bit":                    {"config", "iptables", "masqueradeBit"},
+	"iptables-min-sync-period":          {"config", "iptables", "minSyncPeriod"},
+	"iptables-sync-period":              {"config", "iptables", "syncPeriod"},
+	"ipvs-scheduler":                    {"config", "ipvs", "scheduler"},
+	"ipvs-exclude-cidrs":                {"config", "ipvs", "excludeCIDRs"},
+	"ipvs-strict-arp":                   {"config", "ipvs", "strictARP"},
+	"ipvs-min-sync-period":              {"config", "ipvs", "minSyncPeriod"},
+	"ipvs-sync-period":                  {"config", "ipvs", "syncPeriod"},
+	"ipvs-tcp-timeout":                  {"config", "ipvs", "tcpTimeout"},
+	"ipvs-udp-timeout":                  {"config", "ipvs", "udpTimeout"},
+	"conntrack-max":                     {"config", "conntrack", "max"},
+	"conntrack-max-per-core":            {"config", "conntrack", "maxPerCore"},
+	"conntrack-min":                     {"config", "conntrack", "min"},
+	"conntrack-tcp-timeout-close-wait":  {"config", "conntrack", "tcpTimeoutCloseWait"},
+	"conntrack-tcp-timeout-established": {"config", "conntrack", "tcpTimeoutEstablished"},
+	"conntrack-tcp-timeout-syn-sent":    {"config", "conntrack", "tcpTimeoutSynSent"},
+	"conntrack-udp-timeout-established": {"config", "conntrack", "udpTimeoutEstablished"},
+	"conntrack-udp-timeout":             {"config", "conntrack", "udpTimeout"},
+}
+
+// kubeProxyArgSliceLeaves marks KubeProxyConfiguration leaf fields that take a
+// comma-separated string slice on the CLI (e.g. --nodeport-addresses) so the
+// value is stored as a []any instead of a bare string.
+var kubeProxyArgSliceLeaves = map[string]bool{
+	"nodePortAddresses": true,
+	"excludeCIDRs":      true,
+}
+
+// convertKubeProxyArgs maps kube-proxy component args into kp (the v4
+// kube_proxy section). Boolean flags (no "=value") become true; pure-integer
+// values are coerced to int; comma-separated values targeting a known slice
+// field become []string. Unsupported flags are reported and skipped.
+func (r *Result) convertKubeProxyArgs(args []string, kp map[string]any) {
+	for _, arg := range args {
+		flag, val, found := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+		if flag == "" {
+			r.warnf("kubernetes.kubeProxyArgs %q is malformed and dropped", arg)
+			continue
+		}
+		path, ok := kubeProxyArgPaths[flag]
+		if !ok {
+			r.warnf("kubernetes.kubeProxyArgs %q has no automatic v4 mapping (kube_proxy.config is a KubeProxyConfiguration); set it manually in kube_proxy.config", arg)
+			continue
+		}
+		var value any
+		switch {
+		case !found:
+			value = true
+		case kubeProxyArgSliceLeaves[path[len(path)-1]] && strings.Contains(val, ","):
+			parts := strings.Split(val, ",")
+			slice := make([]any, len(parts))
+			for i, p := range parts {
+				slice[i] = p
+			}
+			value = slice
+		case isInt(val):
+			value, _ = strconv.Atoi(val)
+		default:
+			value = val
+		}
+		setNested(kp, value, path...)
+	}
+}
+
+// etcdEnvArgKeys maps an etcd component flag (without leading "--") to the
+// etcd.env.<snake_key> consumed by the etcd.env template. Only the flags the
+// template actually renders are listed; everything else is reported and dropped.
+var etcdEnvArgKeys = map[string]string{
+	"data-dir":                  "data_dir",
+	"heartbeat-interval":        "heartbeat_interval",
+	"election-timeout":          "election_timeout",
+	"snapshot-count":            "snapshot_count",
+	"auto-compaction-retention": "compaction_retention",
+	"metrics":                   "metrics",
+	"quota-backend-bytes":       "quota_backend_bytes",
+	"max-request-bytes":         "max_request_bytes",
+	"max-snapshots":             "max_snapshots",
+	"max-wals":                  "max_wals",
+	"log-level":                 "log_level",
+	"initial-cluster-token":     "token",
+	"unsupported-arch":          "unsupported_arch",
+}
+
+// convertEtcdExtraArgs maps etcd component args into the etcd.env section of
+// the v4 config. Supported flags become etcd.env.<snake_key> (numeric values
+// coerced to int); unsupported flags are reported and dropped.
+func (r *Result) convertEtcdExtraArgs(args []string, etcd map[string]any) {
+	env := getOrCreateMap(etcd, "env")
+	for _, arg := range args {
+		flag, val, found := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+		snake, ok := etcdEnvArgKeys[flag]
+		if !ok {
+			r.warnf("etcd.extraArgs %q has no v4 etcd.env equivalent and is dropped", arg)
+			continue
+		}
+		if !found {
+			r.warnf("etcd.extraArgs %q has no value and is dropped", arg)
+			continue
+		}
+		if isInt(val) {
+			env[snake], _ = strconv.Atoi(val)
+			continue
+		}
+		env[snake] = val
+	}
+}
+
+// isInt reports whether s is a plain base-10 integer (no sign, no exponent).
+func isInt(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := strconv.Atoi(s)
+	return err == nil
 }
 
 // ConvertInventoryAndConfig converts v3 configuration YAML bytes into v4

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -260,7 +260,7 @@ func (r *Result) convertKubernetes(cluster *Cluster) map[string]any {
 	case "haproxy":
 		cpe["type"] = "haproxy"
 		if cluster.Spec.ControlPlaneEndpoint.Address != "" {
-			r.warnf("controlPlaneEndpoint.address %q has no direct equivalent when type is haproxy (v4 haproxy listens on 127.0.0.1); review kubernetes.control_plane_endpoint", cluster.Spec.ControlPlaneEndpoint.Address)
+			cpe["haproxy"] = map[string]any{"address": cluster.Spec.ControlPlaneEndpoint.Address}
 		}
 	default:
 		r.warnf("unsupported controlPlaneEndpoint.internalLoadbalancer %q, converted to type local", cluster.Spec.ControlPlaneEndpoint.InternalLoadbalancer)
@@ -322,7 +322,7 @@ func (r *Result) convertKubernetes(cluster *Cluster) map[string]any {
 		r.warnf("kubernetes.kubeProxyArgs has no v4 equivalent and is dropped")
 	}
 	if len(k3.KubeProxyConfiguration) > 0 {
-		r.warnf("kubernetes.kubeProxyConfiguration has no direct v4 equivalent; migrate entries to kubernetes.kube_proxy.config manually")
+		setNested(k, k3.KubeProxyConfiguration, "kube_proxy", "config")
 	}
 
 	// kubelet
@@ -336,16 +336,18 @@ func (r *Result) convertKubernetes(cluster *Cluster) map[string]any {
 	if len(kubelet) > 0 {
 		k["kubelet"] = kubelet
 	}
-	if len(k3.KubeletArgs) > 0 {
-		r.warnf("kubernetes.kubeletArgs has no v4 equivalent and is dropped")
+	if args := argsToMap(k3.KubeletArgs); len(args) > 0 {
+		setNested(k, args, "kubelet", "extra_args")
 	}
 	if len(k3.KubeletConfiguration) > 0 {
-		r.warnf("kubernetes.kubeletConfiguration has no direct v4 equivalent; migrate entries to kubernetes.kubelet manually")
+		child, ok := k["kubelet"].(map[string]any)
+		if !ok {
+			child = map[string]any{}
+			k["kubelet"] = child
+		}
+		r.convertKubeletConfiguration(k3.KubeletConfiguration, child)
 	}
 
-	if k3.ContainerRuntimeEndpoint != "" {
-		r.warnf("kubernetes.containerRuntimeEndpoint has no v4 equivalent and is dropped")
-	}
 	if len(k3.NodeFeatureDiscovery) > 0 {
 		r.warnf("kubernetes.nodeFeatureDiscovery has no v4 equivalent and is dropped")
 	}
@@ -445,8 +447,11 @@ func (r *Result) convertDNS(cluster *Cluster) map[string]any {
 	if len(d3.NodeLocalDNS) > 0 {
 		r.warnf("dns.nodelocaldns.externalZones have no direct v4 equivalent; migrate them manually")
 	}
-	if d3.DNSEtcHosts != "" || d3.NodeEtcHosts != "" {
-		r.warnf("dns.dnsEtcHosts/nodeEtcHosts have no direct v4 equivalent; review dns.coredns.dns_etc_hosts and node /etc/hosts handling manually")
+	if d3.DNSEtcHosts != "" {
+		setNested(dns, d3.DNSEtcHosts, "coredns", "dns_etc_hosts")
+	}
+	if d3.NodeEtcHosts != "" {
+		r.warnf("dns.nodeEtcHosts has no direct v4 equivalent; review node /etc/hosts handling manually")
 	}
 
 	if len(dns) == 0 {
@@ -523,14 +528,14 @@ func (r *Result) convertEtcd(cluster *Cluster) map[string]any {
 	if e3.KeepBackupNumber != 0 {
 		backup["keep_backup_number"] = e3.KeepBackupNumber
 	}
+	if e3.BackupScriptDir != "" {
+		backup["etcd_backup_script"] = e3.BackupScriptDir
+	}
 	if len(backup) > 0 {
 		etcd["backup"] = backup
 	}
 	if e3.BackupPeriod != 0 {
 		r.warnf("etcd.backupPeriod %d uses a different scheduling model in v4 (etcd.backup.on_calendar); review it manually", e3.BackupPeriod)
-	}
-	if e3.BackupScriptDir != "" {
-		r.warnf("etcd.backupScript %q has no direct v4 equivalent (etcd.backup.etcd_backup_script); review it manually", e3.BackupScriptDir)
 	}
 	if len(e3.ExtraArgs) > 0 {
 		r.warnf("etcd.extraArgs has no v4 equivalent and is dropped")
@@ -544,6 +549,9 @@ func (r *Result) convertCRI(cluster *Cluster) map[string]any {
 
 	if cm := cluster.Spec.Kubernetes.ContainerManager; cm != "" {
 		cri["container_manager"] = cm
+	}
+	if sock := cluster.Spec.Kubernetes.ContainerRuntimeEndpoint; sock != "" {
+		cri["cri_socket"] = sock
 	}
 
 	reg := cluster.Spec.Registry
@@ -724,6 +732,60 @@ func featureGatesArg(gates map[string]bool) string {
 		parts = append(parts, fmt.Sprintf("%s=%t", k, gates[k]))
 	}
 	return strings.Join(parts, ",")
+}
+
+// toInt coerces a YAML-decoded numeric value (int, int64, or float64) to int.
+// sigs.k8s.io/yaml decodes numbers as float64, so that case is the common one.
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return int(i), true
+		}
+	}
+	return 0, false
+}
+
+// convertKubeletConfiguration maps the v3 kubeletConfiguration (a
+// KubeletConfiguration object) into the v4 kubernetes.kubelet section. Known
+// scalar and feature-gates keys are written directly; remaining keys are
+// merged into kubernetes.kubelet.extra_config, which the kubeadm template folds
+// back into the generated KubeletConfiguration (init-kubernetes/templates/kubeadm).
+func (r *Result) convertKubeletConfiguration(cfg map[string]any, kubelet map[string]any) {
+	extra := map[string]any{}
+	for key, val := range cfg {
+		switch key {
+		case "maxPods":
+			if n, ok := toInt(val); ok {
+				kubelet["max_pods"] = n
+			}
+		case "podPidsLimit":
+			if n, ok := toInt(val); ok {
+				kubelet["pod_pids_limit"] = n
+			}
+		case "containerLogMaxSize":
+			kubelet["container_log_max_size"] = val
+		case "containerLogMaxFiles":
+			if n, ok := toInt(val); ok {
+				kubelet["container_log_max_files"] = n
+			}
+		case "featureGates":
+			if fg, ok := val.(map[string]any); ok {
+				kubelet["feature_gates"] = fg
+			}
+		default:
+			extra[key] = val
+		}
+	}
+	if len(extra) > 0 {
+		setNested(kubelet, extra, "extra_config")
+	}
 }
 
 func mergeUnique(lists ...[]string) []string {

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -1,0 +1,447 @@
+/*
+Copyright 2026 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package convert
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"sigs.k8s.io/yaml"
+)
+
+const sampleV3Config = `
+apiVersion: kubekey.kubesphere.io/v1alpha2
+kind: Cluster
+metadata:
+  name: sample
+spec:
+  hosts:
+  - {name: node1, address: 172.16.0.2, internalAddress: "172.16.0.2,fd85::2", port: 8022, user: ubuntu, password: "Qcloud@123", arch: amd64, labels: {disk: SSD}}
+  - {name: node2, address: 172.16.0.3, internalAddress: 172.16.0.3, privateKeyPath: "~/.ssh/id_rsa"}
+  - {name: node3, address: 172.16.0.4, user: root}
+  - {name: node4, address: 172.16.0.5}
+  roleGroups:
+    etcd: [node1]
+    master: [node1, 'node[2:3]']
+    worker: [node1, 'node[2:4]']
+    registry: [node1]
+  controlPlaneEndpoint:
+    internalLoadbalancer: haproxy
+    domain: lb.kubesphere.local
+    address: ""
+    port: 6443
+  system:
+    ntpServers: [ntp.aliyun.com]
+    timezone: "Asia/Shanghai"
+    rpms: [nfs-utils]
+  kubernetes:
+    version: v1.28.5
+    clusterName: cluster.local
+    dnsDomain: cluster.local
+    containerManager: containerd
+    autoRenewCerts: true
+    masqueradeAll: true
+    maxPods: 210
+    podPidsLimit: 10000
+    nodeCidrMaskSize: 24
+    proxyMode: ipvs
+    apiserverCertExtraSans: [192.168.8.8]
+    apiserverArgs: ["allow-privileged=true"]
+    featureGates: {CSIStorageCapacity: true}
+    nodelocaldns: false
+  etcd:
+    type: kubekey
+    dataDir: /var/lib/etcd-custom
+    heartbeatInterval: 200
+    electionTimeout: 4000
+  network:
+    plugin: calico
+    kubePodsCIDR: 10.233.64.0/18
+    kubeServiceCIDR: 10.233.0.0/18
+  storage:
+    openebs:
+      basePath: /data/openebs
+  registry:
+    registryMirrors: ["https://mirror.example.com"]
+    insecureRegistries: ["insecure.example.com"]
+    privateRegistry: "dockerhub.kubekey.local"
+    containerdDataDir: /data/containerd
+    auths:
+      "dockerhub.kubekey.local":
+        username: admin
+        password: secret
+        skipTLSVerify: true
+`
+
+// parse converts YAML bytes into a Cluster for tests.
+func parse(t *testing.T, data string) (*Cluster, error) {
+	t.Helper()
+	return ParseCluster([]byte(data))
+}
+
+func getNested(t *testing.T, obj map[string]any, fields ...string) any {
+	t.Helper()
+	var cur any = obj
+	for _, f := range fields {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = m[f]
+	}
+	return cur
+}
+
+func TestParseCluster(t *testing.T) {
+	c, err := parse(t, sampleV3Config)
+	if err != nil {
+		t.Fatalf("failed to parse sample: %v", err)
+	}
+	if c.APIVersion != V1Alpha2APIVersion {
+		t.Errorf("apiVersion = %q, want %q", c.APIVersion, V1Alpha2APIVersion)
+	}
+	if len(c.Spec.Hosts) != 4 {
+		t.Errorf("hosts = %d, want 4", len(c.Spec.Hosts))
+	}
+	if c.Spec.Kubernetes.Version != "v1.28.5" {
+		t.Errorf("kubernetes.version = %q", c.Spec.Kubernetes.Version)
+	}
+}
+
+func TestParseClusterRejectsUnknownKind(t *testing.T) {
+	_, err := parse(t, "apiVersion: kubekey.kubesphere.io/v1alpha2\nkind: Foo\n")
+	if err == nil || !strings.Contains(err.Error(), "unsupported kind") {
+		t.Fatalf("expected unsupported kind error, got %v", err)
+	}
+}
+
+func TestParseClusterRequiresHosts(t *testing.T) {
+	_, err := parse(t, "apiVersion: kubekey.kubesphere.io/v1alpha2\nkind: Cluster\n")
+	if err == nil || !strings.Contains(err.Error(), "no hosts") {
+		t.Fatalf("expected no hosts error, got %v", err)
+	}
+}
+
+func TestExpandRoleGroups(t *testing.T) {
+	roleGroups, err := expandRoleGroups(map[string][]string{
+		"etcd":   {"node1"},
+		"master": {"node1", "node[2:3]"},
+	}, []string{"node1", "node2", "node3"})
+	if err != nil {
+		t.Fatalf("expandRoleGroups failed: %v", err)
+	}
+	if got := strings.Join(roleGroups["etcd"], ","); got != "node1" {
+		t.Errorf("etcd = %q", got)
+	}
+	if got := strings.Join(roleGroups["master"], ","); got != "node1,node2,node3" {
+		t.Errorf("master = %q, want node1,node2,node3", got)
+	}
+}
+
+func TestExpandRoleGroupsUnknownHost(t *testing.T) {
+	_, err := expandRoleGroups(map[string][]string{"master": {"node9"}}, []string{"node1"})
+	if err == nil || !strings.Contains(err.Error(), "not in hosts list") {
+		t.Fatalf("expected unknown host error, got %v", err)
+	}
+}
+
+func TestConvertInventory(t *testing.T) {
+	c, err := parse(t, sampleV3Config)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+
+	inv := r.Inventory
+	if inv.Name != "sample" {
+		t.Errorf("inventory name = %q", inv.Name)
+	}
+	if len(inv.Spec.Hosts) != 4 {
+		t.Errorf("hosts = %d, want 4", len(inv.Spec.Hosts))
+	}
+
+	node1, ok := inv.Spec.Hosts["node1"]
+	if !ok {
+		t.Fatal("node1 missing from inventory")
+	}
+	node1YAML, err := yaml.Marshal(node1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"type: ssh", "host: 172.16.0.2", "port: 8022", "user: ubuntu",
+		"password: Qcloud@123", "internal_ipv4: 172.16.0.2", "internal_ipv6: fd85::2",
+		"arch: amd64", "disk: SSD",
+	} {
+		if !strings.Contains(string(node1YAML), want) {
+			t.Errorf("node1 vars missing %q, got:\n%s", want, node1YAML)
+		}
+	}
+
+	node2YAML, err := yaml.Marshal(inv.Spec.Hosts["node2"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(node2YAML), "private_key: ~/.ssh/id_rsa") {
+		t.Errorf("node2 missing private_key, got:\n%s", node2YAML)
+	}
+	if !strings.Contains(string(node2YAML), "port: 22") || !strings.Contains(string(node2YAML), "user: root") {
+		t.Errorf("node2 missing connector defaults, got:\n%s", node2YAML)
+	}
+
+	// groups
+	cp := inv.Spec.Groups[groupByControlPlane()]
+	if got := strings.Join(cp.Hosts, ","); got != "node1,node2,node3" {
+		t.Errorf("kube_control_plane = %q, want node1,node2,node3", got)
+	}
+	if got := strings.Join(inv.Spec.Groups["kube_worker"].Hosts, ","); got != "node1,node2,node3,node4" {
+		t.Errorf("kube_worker = %q", got)
+	}
+	if got := strings.Join(inv.Spec.Groups["etcd"].Hosts, ","); got != "node1" {
+		t.Errorf("etcd = %q", got)
+	}
+	if got := strings.Join(inv.Spec.Groups["image_registry"].Hosts, ","); got != "node1" {
+		t.Errorf("image_registry = %q", got)
+	}
+	if got := strings.Join(inv.Spec.Groups["k8s_cluster"].Groups, ","); got != "kube_control_plane,kube_worker" {
+		t.Errorf("k8s_cluster groups = %q", got)
+	}
+}
+
+func groupByControlPlane() string { return groupControlPlane }
+
+func TestConvertConfig(t *testing.T) {
+	c, err := parse(t, sampleV3Config)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	cfg := r.Config
+
+	if got := getNested(t, cfg, "kubernetes", "kube_version"); got != "v1.28.5" {
+		t.Errorf("kube_version = %v", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "control_plane_endpoint", "type"); got != "haproxy" {
+		t.Errorf("cpe.type = %v", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "control_plane_endpoint", "host"); got != "lb.kubesphere.local" {
+		t.Errorf("cpe.host = %v", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "certs", "renew"); got != true {
+		t.Errorf("certs.renew = %v", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kube_proxy", "config", "iptables", "masqueradeAll"); got != true {
+		t.Errorf("masqueradeAll = %v", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "max_pods"); got != 210 {
+		t.Errorf("kubelet.max_pods = %v", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "apiserver", "certSANs"); got == nil {
+		t.Error("apiserver.certSANs missing")
+	}
+	if got := getNested(t, cfg, "kubernetes", "apiserver", "extra_args", "feature-gates"); got != "CSIStorageCapacity=true" {
+		t.Errorf("feature-gates = %v", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "apiserver", "extra_args", "allow-privileged"); got != "true" {
+		t.Errorf("allow-privileged = %v", got)
+	}
+	if got := getNested(t, cfg, "dns", "nodelocaldns", "enabled"); got != false {
+		t.Errorf("dns.nodelocaldns.enabled = %v", got)
+	}
+	if got := getNested(t, cfg, "dns", "domain"); got != "cluster.local" {
+		t.Errorf("dns.domain = %v", got)
+	}
+	if got := getNested(t, cfg, "cni", "pod_cidr"); got != "10.233.64.0/18" {
+		t.Errorf("cni.pod_cidr = %v", got)
+	}
+	if got := getNested(t, cfg, "etcd", "deployment_type"); got != "internal" {
+		t.Errorf("etcd.deployment_type = %v", got)
+	}
+	if got := getNested(t, cfg, "etcd", "env", "data_dir"); got != "/var/lib/etcd-custom" {
+		t.Errorf("etcd.env.data_dir = %v", got)
+	}
+	if got := getNested(t, cfg, "cri", "registry", "mirrors"); got == nil {
+		t.Error("cri.registry.mirrors missing")
+	}
+	authsRaw := getNested(t, cfg, "cri", "registry", "auths")
+	var auths []map[string]any
+	switch list := authsRaw.(type) {
+	case []map[string]any:
+		auths = list
+	case []any:
+		for _, item := range list {
+			auths = append(auths, item.(map[string]any))
+		}
+	}
+	if len(auths) != 1 {
+		t.Fatalf("cri.registry.auths = %#v, want one entry", authsRaw)
+	}
+	auth0 := auths[0]
+	if auth0["registry"] != "dockerhub.kubekey.local" || auth0["username"] != "admin" || auth0["skip_tls_verify"] != true {
+		t.Errorf("auth0 = %#v", auth0)
+	}
+	if got := getNested(t, cfg, "image_registry", "auth", "registry"); got != "dockerhub.kubekey.local" {
+		t.Errorf("image_registry.auth.registry = %v", got)
+	}
+	if got := getNested(t, cfg, "storage_class", "local", "path"); got != "/data/openebs" {
+		t.Errorf("storage_class.local.path = %v", got)
+	}
+	if got := getNested(t, cfg, "native", "ntp", "servers"); got == nil {
+		t.Error("native.ntp.servers missing")
+	}
+	if got := getNested(t, cfg, "native", "timezone"); got != "Asia/Shanghai" {
+		t.Errorf("native.timezone = %v", got)
+	}
+}
+
+func TestConvertWarnings(t *testing.T) {
+	c, err := parse(t, sampleV3Config)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+
+	joined := strings.Join(r.Warnings, "\n")
+	for _, want := range []string{
+		"system.rpms/debs",            // unmapped system packages
+		"registry.privateRegistry",    // semantic difference warning
+		"kubernetes.disableKubeProxy", // not present in sample, checked below
+	} {
+		if want == "kubernetes.disableKubeProxy" {
+			continue
+		}
+		if !strings.Contains(joined, want) {
+			t.Errorf("warnings missing %q, got:\n%s", want, joined)
+		}
+	}
+}
+
+func TestConvertKubeVipEndpoint(t *testing.T) {
+	data := `
+apiVersion: kubekey.kubesphere.io/v1alpha2
+kind: Cluster
+metadata:
+  name: vip
+spec:
+  hosts:
+  - {name: node1, address: 172.16.0.2}
+  roleGroups:
+    master: [node1]
+    worker: [node1]
+    etcd: [node1]
+  controlPlaneEndpoint:
+    internalLoadbalancer: kubevip
+    domain: lb.kubesphere.local
+    address: 172.16.0.100
+    port: 6443
+    kubevip:
+      mode: BGP
+`
+	c, err := parse(t, data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if got := getNested(t, r.Config, "kubernetes", "control_plane_endpoint", "type"); got != "kube-vip" {
+		t.Errorf("cpe.type = %v", got)
+	}
+	if got := getNested(t, r.Config, "kubernetes", "control_plane_endpoint", "kube_vip", "address"); got != "172.16.0.100" {
+		t.Errorf("kube_vip.address = %v", got)
+	}
+	if got := getNested(t, r.Config, "kubernetes", "control_plane_endpoint", "kube_vip", "mode"); got != "BGP" {
+		t.Errorf("kube_vip.mode = %v", got)
+	}
+}
+
+func TestConvertEtcdExternal(t *testing.T) {
+	data := `
+apiVersion: kubekey.kubesphere.io/v1alpha2
+kind: Cluster
+metadata:
+  name: ext
+spec:
+  hosts:
+  - {name: node1, address: 172.16.0.2}
+  roleGroups:
+    master: [node1]
+    worker: [node1]
+  etcd:
+    type: external
+    external:
+      endpoints: ["https://192.168.1.1:2379"]
+`
+	c, err := parse(t, data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	if got := getNested(t, r.Config, "etcd", "deployment_type"); got != "external" {
+		t.Errorf("etcd.deployment_type = %v", got)
+	}
+	// No etcd roleGroup and type external: no missing-etcd warning expected.
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "no etcd roleGroup") {
+			t.Errorf("unexpected missing-etcd warning for external etcd: %q", w)
+		}
+	}
+}
+
+func TestConvertInventoryAndConfigOutput(t *testing.T) {
+	inventoryYAML, configYAML, _, err := ConvertInventoryAndConfig([]byte(sampleV3Config))
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	for _, want := range []string{"kind: Inventory", "apiVersion: kubekey.kubesphere.io/v1"} {
+		if !strings.Contains(string(inventoryYAML), want) {
+			t.Errorf("inventory yaml missing %q:\n%s", want, inventoryYAML)
+		}
+	}
+	for _, want := range []string{"kind: Config", "kube_version"} {
+		if !strings.Contains(string(configYAML), want) {
+			t.Errorf("config yaml missing %q:\n%s", want, configYAML)
+		}
+	}
+}
+
+func TestSplitInternalAddress(t *testing.T) {
+	ipv4, ipv6 := splitInternalAddress("10.0.0.1,fd00::1")
+	if ipv4 != "10.0.0.1" || ipv6 != "fd00::1" {
+		t.Errorf("splitInternalAddress dual = %q, %q", ipv4, ipv6)
+	}
+	ipv4, ipv6 = splitInternalAddress("10.0.0.1")
+	if ipv4 != "10.0.0.1" || ipv6 != "" {
+		t.Errorf("splitInternalAddress single = %q, %q", ipv4, ipv6)
+	}
+}
+
+var _ = errors.New // keep errors import for future assertions

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -433,6 +433,112 @@ func TestConvertInventoryAndConfigOutput(t *testing.T) {
 	}
 }
 
+func TestConvertMappedFields(t *testing.T) {
+	data := `
+apiVersion: kubekey.kubesphere.io/v1alpha2
+kind: Cluster
+metadata:
+  name: mapped
+spec:
+  hosts:
+  - {name: node1, address: 172.16.0.2}
+  roleGroups:
+    master: [node1]
+    worker: [node1]
+    etcd: [node1]
+  controlPlaneEndpoint:
+    internalLoadbalancer: haproxy
+    domain: lb.local
+    address: 127.0.0.2
+    port: 6443
+  kubernetes:
+    version: v1.28.5
+    containerManager: containerd
+    containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
+    kubeletArgs: ["max-pods=250", "read-only-port=0"]
+    kubeProxyConfiguration:
+      iptables:
+        masqueradeAll: true
+        masqueradeBit: 14
+      mode: ipvs
+    kubeletConfiguration:
+      maxPods: 300
+      podPidsLimit: 12000
+      clusterDomain: cluster.local
+      featureGates:
+        CSIVolumeHealth: true
+      evictionHard:
+        memory.available: 5%
+  etcd:
+    type: kubekey
+    backupScript: /opt/etcd-backup.sh
+  dns:
+    dnsEtcHosts: "10.0.0.1 example.com"
+`
+	c, err := parse(t, data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	cfg := r.Config
+
+	// kubernetes.kubeletArgs -> kubernetes.kubelet.extra_args (consumed by kubeadm template)
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "extra_args", "max-pods"); got != "250" {
+		t.Errorf("kubelet.extra_args[max-pods] = %v, want 250", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "extra_args", "read-only-port"); got != "0" {
+		t.Errorf("kubelet.extra_args[read-only-port] = %v, want 0", got)
+	}
+
+	// kubernetes.kubeProxyConfiguration -> kubernetes.kube_proxy.config
+	if got := getNested(t, cfg, "kubernetes", "kube_proxy", "config", "mode"); got != "ipvs" {
+		t.Errorf("kube_proxy.config.mode = %v, want ipvs", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kube_proxy", "config", "iptables", "masqueradeAll"); got != true {
+		t.Errorf("kube_proxy.config.iptables.masqueradeAll = %v, want true", got)
+	}
+
+	// kubernetes.kubeletConfiguration -> kubernetes.kubelet scalars + extra_config
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "max_pods"); got != 300 {
+		t.Errorf("kubelet.max_pods = %v, want 300", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "pod_pids_limit"); got != 12000 {
+		t.Errorf("kubelet.pod_pids_limit = %v, want 12000", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "extra_config", "clusterDomain"); got != "cluster.local" {
+		t.Errorf("kubelet.extra_config.clusterDomain = %v, want cluster.local", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "extra_config", "evictionHard", "memory.available"); got != "5%" {
+		t.Errorf("kubelet.extra_config.evictionHard.memory.available = %v, want 5%%", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kubelet", "feature_gates", "CSIVolumeHealth"); got != true {
+		t.Errorf("kubelet.feature_gates.CSIVolumeHealth = %v, want true", got)
+	}
+
+	// kubernetes.containerRuntimeEndpoint -> cri.cri_socket (consumed by kubeadm template)
+	if got := getNested(t, cfg, "cri", "cri_socket"); got != "unix:///run/containerd/containerd.sock" {
+		t.Errorf("cri.cri_socket = %v", got)
+	}
+
+	// controlPlaneEndpoint.address (haproxy) -> control_plane_endpoint.haproxy.address
+	if got := getNested(t, cfg, "kubernetes", "control_plane_endpoint", "haproxy", "address"); got != "127.0.0.2" {
+		t.Errorf("cpe.haproxy.address = %v, want 127.0.0.2", got)
+	}
+
+	// etcd.backupScript -> etcd.backup.etcd_backup_script
+	if got := getNested(t, cfg, "etcd", "backup", "etcd_backup_script"); got != "/opt/etcd-backup.sh" {
+		t.Errorf("etcd.backup.etcd_backup_script = %v", got)
+	}
+
+	// dns.dnsEtcHosts -> dns.coredns.dns_etc_hosts
+	if got := getNested(t, cfg, "dns", "coredns", "dns_etc_hosts"); got != "10.0.0.1 example.com" {
+		t.Errorf("dns.coredns.dns_etc_hosts = %v", got)
+	}
+}
+
 func TestSplitInternalAddress(t *testing.T) {
 	ipv4, ipv6 := splitInternalAddress("10.0.0.1,fd00::1")
 	if ipv4 != "10.0.0.1" || ipv6 != "fd00::1" {

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -550,4 +550,164 @@ func TestSplitInternalAddress(t *testing.T) {
 	}
 }
 
+func TestConvertKubeProxyArgs(t *testing.T) {
+	data := `
+apiVersion: kubekey.kubesphere.io/v1alpha2
+kind: Cluster
+metadata:
+  name: kp
+spec:
+  hosts:
+  - {name: node1, address: 172.16.0.2}
+  roleGroups:
+    master: [node1]
+    worker: [node1]
+    etcd: [node1]
+  controlPlaneEndpoint:
+    internalLoadbalancer: local
+    domain: lb.local
+  kubernetes:
+    version: v1.28.5
+    containerManager: containerd
+    kubeProxyArgs:
+      - "proxy-mode=iptables"
+      - "masquerade-all"
+      - "ipvs-scheduler=rr"
+      - "nodeport-addresses=10.0.0.0/16,10.1.0.0/16"
+      - "conntrack-max-per-core=2"
+      - "bogus-flag=1"
+`
+	c, err := parse(t, data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	cfg := r.Config
+
+	if got := getNested(t, cfg, "kubernetes", "kube_proxy", "mode"); got != "iptables" {
+		t.Errorf("kube_proxy.mode = %v, want iptables", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kube_proxy", "config", "iptables", "masqueradeAll"); got != true {
+		t.Errorf("kube_proxy.config.iptables.masqueradeAll = %v, want true", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kube_proxy", "config", "ipvs", "scheduler"); got != "rr" {
+		t.Errorf("kube_proxy.config.ipvs.scheduler = %v, want rr", got)
+	}
+	if got := getNested(t, cfg, "kubernetes", "kube_proxy", "config", "conntrack", "maxPerCore"); got != 2 {
+		t.Errorf("kube_proxy.config.conntrack.maxPerCore = %v, want 2", got)
+	}
+	// nodeport-addresses is a comma-separated slice -> []any
+	npRaw := getNested(t, cfg, "kubernetes", "kube_proxy", "config", "nodePortAddresses")
+	np, ok := npRaw.([]any)
+	if !ok {
+		t.Fatalf("kube_proxy.config.nodePortAddresses = %#v, want []any", npRaw)
+	}
+	if len(np) != 2 || np[0] != "10.0.0.0/16" || np[1] != "10.1.0.0/16" {
+		t.Errorf("kube_proxy.config.nodePortAddresses = %#v, want [10.0.0.0/16 10.1.0.0/16]", np)
+	}
+	// unsupported flag reported
+	joined := strings.Join(r.Warnings, "\n")
+	if !strings.Contains(joined, "bogus-flag") {
+		t.Errorf("expected warning for bogus-flag, got:\n%s", joined)
+	}
+}
+
+func TestConvertEtcdExtras(t *testing.T) {
+	data := `
+apiVersion: kubekey.kubesphere.io/v1alpha2
+kind: Cluster
+metadata:
+  name: etcd
+spec:
+  hosts:
+  - {name: node1, address: 172.16.0.2}
+  roleGroups:
+    master: [node1]
+    worker: [node1]
+    etcd: [node1]
+  controlPlaneEndpoint:
+    internalLoadbalancer: local
+    domain: lb.local
+  kubernetes:
+    version: v1.28.5
+    containerManager: containerd
+  etcd:
+    type: kubekey
+    extraArgs:
+      - "data-dir=/data/etcd"
+      - "heartbeat-interval=300"
+      - "quota-backend-bytes=8589934592"
+      - "listen-client-urls=https://0.0.0.0:2379"
+      - "bogus-flag=1"
+`
+	c, err := parse(t, data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	cfg := r.Config
+	if got := getNested(t, cfg, "etcd", "env", "data_dir"); got != "/data/etcd" {
+		t.Errorf("etcd.env.data_dir = %v, want /data/etcd", got)
+	}
+	if got := getNested(t, cfg, "etcd", "env", "heartbeat_interval"); got != 300 {
+		t.Errorf("etcd.env.heartbeat_interval = %v, want 300", got)
+	}
+	if got := getNested(t, cfg, "etcd", "env", "quota_backend_bytes"); got != 8589934592 {
+		t.Errorf("etcd.env.quota_backend_bytes = %v, want 8589934592", got)
+	}
+	joined := strings.Join(r.Warnings, "\n")
+	for _, want := range []string{"listen-client-urls", "bogus-flag"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected warning for %q, got:\n%s", want, joined)
+		}
+	}
+}
+
+func TestConvertEtcdBackupPeriod(t *testing.T) {
+	data := `
+apiVersion: kubekey.kubesphere.io/v1alpha2
+kind: Cluster
+metadata:
+  name: bp
+spec:
+  hosts:
+  - {name: node1, address: 172.16.0.2}
+  roleGroups:
+    master: [node1]
+    worker: [node1]
+    etcd: [node1]
+  controlPlaneEndpoint:
+    internalLoadbalancer: local
+    domain: lb.local
+  kubernetes:
+    version: v1.28.5
+    containerManager: containerd
+  etcd:
+    type: kubekey
+    backupPeriod: 30
+`
+	c, err := parse(t, data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	r, err := Convert(c)
+	if err != nil {
+		t.Fatalf("convert failed: %v", err)
+	}
+	cfg := r.Config
+	if got := getNested(t, cfg, "etcd", "backup", "on_calendar"); got != "*/30 * * * *" {
+		t.Errorf("etcd.backup.on_calendar = %v, want */30 * * * *", got)
+	}
+	joined := strings.Join(r.Warnings, "\n")
+	if !strings.Contains(joined, "auto-converted") || !strings.Contains(joined, "*/30 * * * *") {
+		t.Errorf("expected auto-convert warning, got:\n%s", joined)
+	}
+}
+
 var _ = errors.New // keep errors import for future assertions

--- a/pkg/convert/utils.go
+++ b/pkg/convert/utils.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package convert
+
+import (
+	"encoding/json"
+
+	"github.com/cockroachdb/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// toRawExtension serializes a vars map into a runtime.RawExtension.
+func toRawExtension(vars map[string]any) (runtime.RawExtension, error) {
+	raw, err := json.Marshal(vars)
+	if err != nil {
+		return runtime.RawExtension{}, errors.Wrap(err, "failed to marshal host vars")
+	}
+	return runtime.RawExtension{Raw: raw}, nil
+}
+
+// marshalYAML marshals an object to YAML via JSON so that json tags apply.
+func marshalYAML(obj any) ([]byte, error) {
+	return sigsyaml.Marshal(obj)
+}

--- a/pkg/convert/v1alpha2.go
+++ b/pkg/convert/v1alpha2.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2026 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package convert
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"sigs.k8s.io/yaml"
+)
+
+// V1Alpha2APIVersion is the apiVersion of KubeKey v3 cluster configuration files.
+const V1Alpha2APIVersion = "kubekey.kubesphere.io/v1alpha2"
+
+// v3 role group keys, normalized to lowercase.
+const (
+	v3RoleMaster        = "master"
+	v3RoleControlPlane  = "control-plane"
+	v3RoleControlPlane2 = "controlplane"
+	v3RoleWorker        = "worker"
+	v3RoleEtcd          = "etcd"
+	v3RoleRegistry      = "registry"
+)
+
+// Cluster is a minimal representation of the KubeKey v3 (v1alpha2) Cluster
+// configuration. Only fields needed for conversion are declared; unknown
+// fields are ignored by the YAML decoder.
+type Cluster struct {
+	APIVersion string      `json:"apiVersion"`
+	Kind       string      `json:"kind"`
+	Metadata   ClusterMeta `json:"metadata"`
+	Spec       ClusterSpec `json:"spec"`
+}
+
+// ClusterMeta holds the object name of the v3 cluster configuration.
+type ClusterMeta struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ClusterSpec mirrors cmd/kk/apis/kubekey/v1alpha2.ClusterSpec of the 3.x branch.
+type ClusterSpec struct {
+	Hosts                []HostCfg            `json:"hosts,omitempty"`
+	RoleGroups           map[string][]string  `json:"roleGroups,omitempty"`
+	ControlPlaneEndpoint ControlPlaneEndpoint `json:"controlPlaneEndpoint,omitempty"`
+	System               System               `json:"system,omitempty"`
+	Etcd                 EtcdCluster          `json:"etcd,omitempty"`
+	DNS                  DNS                  `json:"dns,omitempty"`
+	Kubernetes           Kubernetes           `json:"kubernetes,omitempty"`
+	Network              NetworkConfig        `json:"network,omitempty"`
+	Storage              StorageConfig        `json:"storage,omitempty"`
+	Registry             RegistryConfig       `json:"registry,omitempty"`
+	Addons               []Addon              `json:"addons,omitempty"`
+	KubeSphere           KubeSphere           `json:"kubesphere,omitempty"`
+}
+
+// HostCfg mirrors v1alpha2.HostCfg. Note that 3.x hosts have no roles field:
+// roles are expressed solely through roleGroups.
+type HostCfg struct {
+	Name            string            `json:"name,omitempty"`
+	Address         string            `json:"address,omitempty"`
+	InternalAddress string            `json:"internalAddress,omitempty"`
+	Port            int               `json:"port,omitempty"`
+	User            string            `json:"user,omitempty"`
+	Password        string            `json:"password,omitempty"`
+	PrivateKey      string            `json:"privateKey,omitempty"`
+	PrivateKeyPath  string            `json:"privateKeyPath,omitempty"`
+	Arch            string            `json:"arch,omitempty"`
+	Timeout         *int64            `json:"timeout,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+}
+
+// ControlPlaneEndpoint mirrors v1alpha2.ControlPlaneEndpoint.
+type ControlPlaneEndpoint struct {
+	InternalLoadbalancer string  `json:"internalLoadbalancer,omitempty"`
+	Domain               string  `json:"domain,omitempty"`
+	ExternalDNS          *bool   `json:"externalDNS,omitempty"`
+	Address              string  `json:"address,omitempty"`
+	Port                 int     `json:"port,omitempty"`
+	KubeVip              KubeVip `json:"kubevip,omitempty"`
+}
+
+// KubeVip mirrors v1alpha2.KubeVip.
+type KubeVip struct {
+	Mode string `json:"mode,omitempty"`
+}
+
+// System mirrors v1alpha2.System.
+type System struct {
+	NtpServers         []string `json:"ntpServers,omitempty"`
+	Timezone           string   `json:"timezone,omitempty"`
+	Rpms               []string `json:"rpms,omitempty"`
+	Debs               []string `json:"debs,omitempty"`
+	PreInstall         []any    `json:"preInstall,omitempty"`
+	PostClusterInstall []any    `json:"postClusterInstall,omitempty"`
+	PostInstall        []any    `json:"postInstall,omitempty"`
+	SkipConfigureOS    bool     `json:"skipConfigureOS,omitempty"`
+}
+
+// RegistryConfig mirrors v1alpha2.RegistryConfig.
+type RegistryConfig struct {
+	Type               string         `json:"type,omitempty"`
+	RegistryMirrors    []string       `json:"registryMirrors,omitempty"`
+	InsecureRegistries []string       `json:"insecureRegistries,omitempty"`
+	PrivateRegistry    string         `json:"privateRegistry,omitempty"`
+	ContainerdDataDir  string         `json:"containerdDataDir,omitempty"`
+	DockerDataDir      string         `json:"dockerDataDir,omitempty"`
+	RegistryDataDir    string         `json:"registryDataDir,omitempty"`
+	NamespaceOverride  string         `json:"namespaceOverride,omitempty"`
+	BridgeIP           string         `json:"bridgeIP,omitempty"`
+	Auths              map[string]any `json:"auths,omitempty"`
+	NamespaceRewrite   map[string]any `json:"namespaceRewrite,omitempty"`
+	RemoteMirrors      map[string]any `json:"remoteMirrors,omitempty"`
+}
+
+// KubeSphere mirrors v1alpha2.KubeSphere.
+type KubeSphere struct {
+	Enabled        bool   `json:"enabled,omitempty"`
+	Version        string `json:"version,omitempty"`
+	Configurations string `json:"configurations,omitempty"`
+}
+
+// Kubernetes mirrors v1alpha2.Kubernetes.
+type Kubernetes struct {
+	Type                     string          `json:"type,omitempty"`
+	Version                  string          `json:"version,omitempty"`
+	ClusterName              string          `json:"clusterName,omitempty"`
+	DNSDomain                string          `json:"dnsDomain,omitempty"`
+	DisableKubeProxy         bool            `json:"disableKubeProxy,omitempty"`
+	MasqueradeAll            bool            `json:"masqueradeAll,omitempty"`
+	MaxPods                  int             `json:"maxPods,omitempty"`
+	PodPidsLimit             int             `json:"podPidsLimit,omitempty"`
+	NodeCidrMaskSize         int             `json:"nodeCidrMaskSize,omitempty"`
+	NodeCidrMaskSizeIPv6     int             `json:"nodeCidrMaskSizeIPv6,omitempty"`
+	ApiserverCertExtraSans   []string        `json:"apiserverCertExtraSans,omitempty"`
+	ProxyMode                string          `json:"proxyMode,omitempty"`
+	AutoRenewCerts           *bool           `json:"autoRenewCerts,omitempty"`
+	Nodelocaldns             *bool           `json:"nodelocaldns,omitempty"`
+	ContainerManager         string          `json:"containerManager,omitempty"`
+	ContainerRuntimeEndpoint string          `json:"containerRuntimeEndpoint,omitempty"`
+	NodeFeatureDiscovery     map[string]any  `json:"nodeFeatureDiscovery,omitempty"`
+	Kata                     map[string]any  `json:"kata,omitempty"`
+	ApiServerArgs            []string        `json:"apiserverArgs,omitempty"`
+	ControllerManagerArgs    []string        `json:"controllerManagerArgs,omitempty"`
+	SchedulerArgs            []string        `json:"schedulerArgs,omitempty"`
+	KubeletArgs              []string        `json:"kubeletArgs,omitempty"`
+	KubeProxyArgs            []string        `json:"kubeProxyArgs,omitempty"`
+	FeatureGates             map[string]bool `json:"featureGates,omitempty"`
+	KubeletConfiguration     map[string]any  `json:"kubeletConfiguration,omitempty"`
+	KubeProxyConfiguration   map[string]any  `json:"kubeProxyConfiguration,omitempty"`
+	Audit                    map[string]any  `json:"audit,omitempty"`
+	NvidiaRuntime            *bool           `json:"nvidiaRuntime,omitempty"`
+}
+
+// NetworkConfig mirrors v1alpha2.NetworkConfig.
+type NetworkConfig struct {
+	Plugin          string         `json:"plugin,omitempty"`
+	KubePodsCIDR    string         `json:"kubePodsCIDR,omitempty"`
+	KubeServiceCIDR string         `json:"kubeServiceCIDR,omitempty"`
+	Calico          CalicoCfg      `json:"calico,omitempty"`
+	Flannel         map[string]any `json:"flannel,omitempty"`
+	Kubeovn         map[string]any `json:"kubeovn,omitempty"`
+	MultusCNI       map[string]any `json:"multusCNI,omitempty"`
+	Hybridnet       map[string]any `json:"hybridnet,omitempty"`
+}
+
+// CalicoCfg mirrors v1alpha2.CalicoCfg.
+type CalicoCfg struct {
+	IPIPMode              string         `json:"ipipMode,omitempty"`
+	IPAutoDetectionMethod string         `json:"ipAutoDetectionMethod,omitempty"`
+	VXLANMode             string         `json:"vxlanMode,omitempty"`
+	VethMTU               int            `json:"vethMTU,omitempty"`
+	Ipv4NatOutgoing       *bool          `json:"ipv4NatOutgoing,omitempty"`
+	Ipv6NatOutgoing       *bool          `json:"ipv6NatOutgoing,omitempty"`
+	DefaultIPPOOL         *bool          `json:"defaultIPPOOL,omitempty"`
+	Typha                 map[string]any `json:"typha,omitempty"`
+	Controller            map[string]any `json:"controller,omitempty"`
+}
+
+// EtcdCluster mirrors v1alpha2.EtcdCluster.
+type EtcdCluster struct {
+	Type                    string         `json:"type,omitempty"`
+	External                map[string]any `json:"external,omitempty"`
+	Port                    *int           `json:"port,omitempty"`
+	PeerPort                *int           `json:"peerPort,omitempty"`
+	ExtraArgs               []string       `json:"extraArgs,omitempty"`
+	BackupDir               string         `json:"backupDir,omitempty"`
+	BackupPeriod            int            `json:"backupPeriod,omitempty"`
+	KeepBackupNumber        int            `json:"keepBackupNumber,omitempty"`
+	BackupScriptDir         string         `json:"backupScript,omitempty"`
+	DataDir                 *string        `json:"dataDir,omitempty"`
+	HeartbeatInterval       *int           `json:"heartbeatInterval,omitempty"`
+	ElectionTimeout         *int           `json:"electionTimeout,omitempty"`
+	SnapshotCount           *int           `json:"snapshotCount,omitempty"`
+	AutoCompactionRetention *int           `json:"autoCompactionRetention,omitempty"`
+	Metrics                 *string        `json:"metrics,omitempty"`
+	QuotaBackendBytes       *int64         `json:"quotaBackendBytes,omitempty"`
+	MaxRequestBytes         *int64         `json:"maxRequestBytes,omitempty"`
+	MaxSnapshots            *int           `json:"maxSnapshots,omitempty"`
+	MaxWals                 *int           `json:"maxWals,omitempty"`
+	LogLevel                *string        `json:"logLevel,omitempty"`
+}
+
+// StorageConfig mirrors v1alpha2.StorageConfig.
+type StorageConfig struct {
+	OpenEBS OpenEBSCfg `json:"openebs,omitempty"`
+}
+
+// OpenEBSCfg mirrors v1alpha2.OpenEBSCfg.
+type OpenEBSCfg struct {
+	BasePath string `json:"basePath,omitempty"`
+}
+
+// DNS mirrors v1alpha2.DNS.
+type DNS struct {
+	DNSEtcHosts  string         `json:"dnsEtcHosts,omitempty"`
+	NodeEtcHosts string         `json:"nodeEtcHosts,omitempty"`
+	CoreDNS      map[string]any `json:"coredns,omitempty"`
+	NodeLocalDNS map[string]any `json:"nodelocaldns,omitempty"`
+}
+
+// Addon mirrors v1alpha2.Addon.
+type Addon struct {
+	Name      string         `json:"name,omitempty"`
+	Namespace string         `json:"namespace,omitempty"`
+	Repo      map[string]any `json:"repo,omitempty"`
+	Values    string         `json:"values,omitempty"`
+}
+
+// ParseCluster parses a KubeKey v3 (v1alpha2) cluster configuration from YAML bytes.
+func ParseCluster(data []byte) (*Cluster, error) {
+	c := &Cluster{}
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal v3 cluster configuration")
+	}
+	if c.Kind != "" && c.Kind != "Cluster" {
+		return nil, errors.Errorf("unsupported kind %q, expected \"Cluster\"", c.Kind)
+	}
+	if c.APIVersion != "" && c.APIVersion != V1Alpha2APIVersion {
+		return nil, errors.Errorf("unsupported apiVersion %q, expected %q", c.APIVersion, V1Alpha2APIVersion)
+	}
+	if len(c.Spec.Hosts) == 0 {
+		return nil, errors.New("no hosts found in spec.hosts")
+	}
+	return c, nil
+}
+
+// expandRoleGroups resolves v3 roleGroups into per-role host name lists.
+// It expands the node[1:5] range shorthand and verifies that every referenced
+// host exists in the hosts list. Returned keys are v3 role names.
+func expandRoleGroups(roleGroups map[string][]string, knownHosts []string) (map[string][]string, error) {
+	hostSet := make(map[string]struct{}, len(knownHosts))
+	for _, h := range knownHosts {
+		hostSet[h] = struct{}{}
+	}
+
+	result := make(map[string][]string)
+	for role, hosts := range roleGroups {
+		expanded := make([]string, 0, len(hosts))
+		for _, entry := range hosts {
+			if strings.Contains(entry, "[") && strings.Contains(entry, "]") && strings.Contains(entry, ":") {
+				rangeHosts, err := expandHostsRange(entry, hostSet, role)
+				if err != nil {
+					return nil, err
+				}
+				expanded = append(expanded, rangeHosts...)
+				continue
+			}
+			if _, ok := hostSet[entry]; !ok {
+				return nil, errors.Errorf("[%s] is in [%s] group, but not in hosts list", entry, role)
+			}
+			expanded = append(expanded, entry)
+		}
+		result[strings.ToLower(role)] = expanded
+	}
+	return result, nil
+}
+
+var hostsRangeRegexp = regexp.MustCompile(`\[(\d+)\:(\d+)\]`)
+
+// expandHostsRange expands "node[1:3]" into ["node1", "node2", "node3"],
+// mirroring v1alpha2.getHostsRange.
+func expandHostsRange(rangeStr string, hostSet map[string]struct{}, group string) ([]string, error) {
+	suffix := hostsRangeRegexp.FindStringSubmatch(rangeStr)
+	if suffix == nil {
+		return nil, errors.Errorf("invalid host range %q in roleGroups/%s, expected format name[start:end]", rangeStr, group)
+	}
+	prefix := strings.Split(rangeStr, suffix[0])[0]
+	start, err := strconv.Atoi(suffix[1])
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid range start in %q", rangeStr)
+	}
+	end, err := strconv.Atoi(suffix[2])
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid range end in %q", rangeStr)
+	}
+	hosts := make([]string, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		name := fmt.Sprintf("%s%d", prefix, i)
+		if _, ok := hostSet[name]; !ok {
+			return nil, errors.Errorf("[%s] is in [%s] group, but not in hosts list", name, group)
+		}
+		hosts = append(hosts, name)
+	}
+	return hosts, nil
+}
+
+// splitInternalAddress splits a v3 internalAddress ("10.0.0.1,fd00::1" or a
+// single address) into ipv4 and ipv6 parts.
+func splitInternalAddress(internalAddress string) (ipv4, ipv6 string) {
+	parts := strings.Split(internalAddress, ",")
+	ipv4 = strings.TrimSpace(parts[0])
+	if len(parts) > 1 {
+		ipv6 = strings.TrimSpace(parts[1])
+	}
+	return ipv4, ipv6
+}


### PR DESCRIPTION
### What type of PR is this?

/kind feature

## What does this PR do

Add `kk create convert` to migrate a KubeKey v3 (v1alpha2) cluster config into v4 `inventory.yaml` and `config.yaml`.
fixed: https://github.com/kubesphere/kubekey/issues/3148

### Background / Motivation

KubeKey 4.x defines clusters via `inventory.yaml` (hosts/groups, the Inventory CRD) plus `config.yaml` (the Config CRD, whose spec is an unstructured map). This replaces the 3.x `Cluster` v1alpha2 layout (spec.hosts + roleGroups + controlPlaneEndpoint + kubernetes/network/etcd/storage/registry/system). Users adopting v4 must rewrite existing 3.x manifests by hand — a tedious, error-prone process (role groups → group membership, dual-stack addresses, control-plane endpoint type, CNI/etcd/CRI sub-structures all differ). A built-in converter lowers that migration friction.

### Implementation

- New package `pkg/convert` parses the minimal subset of 3.x `Cluster` v1alpha2 needed for conversion (`ParseCluster`), normalizes role groups (including `node[i:j]` ranges), and maps them to v4 structured types plus an unstructured `config.yaml` map (`ConvertInventoryAndConfig`). Fields that have no clean 1:1 v4 equivalent (e.g. KubeSphere enablement, advanced DNS, multus) are reported as stderr warnings rather than silently dropped.
- New builtin subcommand `kk create convert`: `--input <file>` (required) reads the 3.x config; `-o/--output <dir>` writes `inventory.yaml` + `config.yaml` to a directory, or prints both documents to stdout (separated by `---`) when omitted.

### Key Changes

| File | What changed |
|---|---|
| `pkg/convert/v1alpha2.go` | Minimal structs mirroring 3.x `Cluster` v1alpha2 + `ParseCluster`/`expandRoleGroups`/`splitInternalAddress` |
| `pkg/convert/convert.go` | Core v3→v4 mapping: inventory (connectors/groups) + config (kubernetes/cni/dns/etcd/cri/storage_class/native) |
| `pkg/convert/utils.go` | YAML / `runtime.RawExtension` helpers |
| `pkg/convert/convert_test.go` | Unit tests: parsing/rejection, role-group range expansion, inventory + config mapping, difficulty-field warnings, kube-vip endpoint, external etcd |
| `cmd/kk/app/options/builtin/convert.go` | `ConvertOptions` + `Flags()` + `Run()` |
| `cmd/kk/app/builtin/create.go` | Register the `convert` subcommand under `kk create` |

## Impact

- **Affected modules**: `pkg/convert` (new), `cmd/kk/app/builtin` (new subcommand)
- **API changes**: N/A (new command only)
- **Database / state changes**: N/A
- **Config changes**: N/A (new CLI behavior; no existing config altered)
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Unit tests pass (`go test ./pkg/convert/...`)
- [ ] Integration / E2E tests pass (`<command>`)
- [x] Manual verification

### Steps to verify

1. `make kk` to build the `kk` binary
2. `./_output/bin/kk create convert --input <3.x-config.yaml> -o ./out`
3. Inspect `./out/inventory.yaml` and `./out/config.yaml` for correctness
4. Run without `-o` to print both documents to stdout, separated by `---`

### Test coverage

`pkg/convert/convert_test.go` covers parsing and kind rejection, role-group range expansion, inventory + config mapping, difficulty-field warnings, kube-vip control-plane endpoint, and external etcd.

## Rollback

Plain revert of the commit; no state or config to restore.

### Does this PR introduce a user-facing change?

```release-note
Add `kk create convert` subcommand to convert a KubeKey v3 (v1alpha2) cluster configuration into v4 `inventory.yaml` and `config.yaml`.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [x] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

- Conversion is "map core fields fully + warn on hard-to-map fields" by design. KubeSphere enablement, advanced DNS, and multus are intentionally surfaced as warnings rather than auto-generated, since their v4 equivalents require extra decisions the converter cannot make safely.
- 3.x `HostCfg` carries no role/taint info; roles come only from `roleGroups`, which this converter expands (including `node[i:j]` ranges) into v4 groups.
