### PR TITLE
fix(project): skip empty YAML docs in vars_files and role defaults

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -327,7 +327,13 @@ func (f *project) dealVarsFiles(p *kkprojectv1.Play, basePlaybook string) error 
 		if err := yaml.Unmarshal(data, &node); err != nil {
 			return errors.Wrap(err, "failed to failed to unmarshal YAML")
 		}
-		if node.Kind != yaml.DocumentNode || len(node.Content) != 1 {
+		// An empty YAML document (only comments / blank lines) decodes to a node
+		// with Kind=0 (not DocumentNode) and len(Content)==0. Treat it as a no-op
+		// so placeholder files like a comment-only defaults/main.yaml don't error.
+		if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {
+			return nil
+		}
+		if len(node.Content) != 1 {
 			return errors.Errorf("unsupport vars_files format. it should be single map file")
 		}
 		// combine map node
@@ -406,7 +412,13 @@ func (f *project) combineRoleVars(role *kkprojectv1.Role, content []byte) error 
 	if err := yaml.Unmarshal(content, &node); err != nil {
 		return errors.Wrap(err, "failed to unmarshal YAML")
 	}
-	if node.Kind != yaml.DocumentNode || len(node.Content) != 1 {
+	// An empty YAML document (only comments / blank lines) decodes to a node
+	// with Kind=0 (not DocumentNode) and len(Content)==0. Treat it as a no-op
+	// so placeholder files like a comment-only defaults/main.yaml don't error.
+	if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {
+		return nil
+	}
+	if len(node.Content) != 1 {
 		return errors.Errorf("unsupport vars_files format. it should be single map file")
 	}
 	// combine map node


### PR DESCRIPTION
### What type of PR is this?
/kind bug

## What does this PR do

fix(project): skip empty YAML docs in vars_files and role defaults

### Background / Motivation

A role `defaults/main.yaml` that contains only comments (or is otherwise
empty) currently fails loading with `unsupport vars_files format. it
should be single map file`. The same error fires for any `vars_files:`
entry that resolves to an empty file.

`gopkg.in/yaml.v3` decodes an empty document (comments / blank lines /
zero bytes) to a node with `Kind=0` (not `DocumentNode`) and
`len(Content)==0`. The guards in `dealVarsFiles` and `combineRoleVars`
require `Kind==yaml.DocumentNode && len(Content)==1`, so empty docs are
rejected even though they legitimately define no variables.

This bit downstream consumers that want placeholder roles (e.g. a
`_shared` role whose only purpose is to be referenced from other roles)
or `vars_files:` entries that start as a comment skeleton.

### Implementation

Split the existing single `len(Content) != 1` guard into two checks:

1. If the decoded node has no document content (`Kind != DocumentNode ||
   len(Content) == 0`), treat it as a no-op and return `nil`. This
   covers all empty-document shapes (`# only comments`, blank lines,
   zero bytes).
2. If the node is a document but does not have exactly one content node,
   keep the existing error — this still rejects multi-document YAML
   (`---`) and other malformed shapes.

Both `dealVarsFiles` (handles `vars_files:` entries) and
`combineRoleVars` (handles `roles/<role>/defaults/main.yaml` and the
`defaults/main/*.yaml` directory) are updated in lockstep so the
behavior stays consistent across the two entry points.

Explicit empty-map `{}` is unaffected — it still parses as a valid
`DocumentNode` with a single `MappingNode` content and is appended as
an empty map (which downstream deep-merges into nothing), matching the
existing skip-empty-file semantics just below the guard.

### Key Changes

| File | What changed |
|---|---|
| `pkg/project/project.go` | `dealVarsFiles` (L330) and `combineRoleVars` (L410): treat empty YAML documents as a no-op instead of erroring with `unsupport vars_files format`. |

## Impact

- **Affected modules**: `pkg/project` (project / playbook loading)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A
- **Dependency changes**: N/A

## Breaking Changes

None. Only the previously-broken empty-document shape now loads
silently; valid single-map documents, multi-document YAML, and parse
errors all retain their existing behavior.

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Manual verification
- [x] Local build pass (`go build ./pkg/project/...`)
- [x] Local vet pass (`go vet ./pkg/project/...`)
- [ ] Unit tests pass
- [ ] Integration / E2E tests pass

### Steps to verify

1. `go build ./pkg/project/...` — compiles cleanly.
2. `go vet ./pkg/project/...` — no warnings.
3. Create a role with a comment-only `defaults/main.yaml` and load it:
   the role loads successfully instead of failing with
   `unsupport vars_files format. it should be single map file`.
4. Add a `vars_files:` entry that resolves to a comment-only YAML
   file: the play loads successfully.
5. Regression — a malformed multi-document YAML (`---` + `---`) still
   fails with the same error.
6. Regression — an explicit empty-map `{}` file still loads (deep-merges
   as no-op, identical to before).

### Test coverage

No new unit tests added. Per the project's testing convention, test
code is maintained separately and not bundled with feature/fix PRs.

## Rollback

Plain revert of the single commit.

```release-note
None
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build` — see go build / go vet above)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

The fix has to touch both `dealVarsFiles` and `combineRoleVars` — they
share the same `unsupport vars_files format` error message and the
same `len(Content) != 1` guard. Patching only one would leave an
inconsistency where role defaults accept them but `vars_files:` entries
don't, which would be worse than the original bug.

The empty-document branch is intentionally explicit (a separate
`len(Content) == 0` check returning `nil`) rather than relaxing the
guard to `<= 1`, so multi-document YAML still errors as before.