### PR TITLE
fix(docker): downgrade default docker version to 23.0.5 for k8s 1.26

### DIFF
--- a/builtin/core/defaults/config/v1.26.yaml
+++ b/builtin/core/defaults/config/v1.26.yaml
@@ -66,7 +66,7 @@ spec:
     crictl_version: v1.26.0
     # ========== Docker Runtime ==========
     # Docker binary version.
-    #docker_version: 23.0.6
+    #docker_version: 23.0.5
     # cridockerd version (required for Kubernetes 1.24+).
     # cridockerd_version: v0.3.7
     # ========== Containerd Runtime ==========

--- a/builtin/core/roles/defaults/templates/manifests.yaml
+++ b/builtin/core/roles/defaults/templates/manifests.yaml
@@ -130,8 +130,8 @@
     {{- if $default_crictl_version | has "v1.26.0" | not }}
     {{- $default_crictl_version = append $default_crictl_version "v1.26.0" }}
     {{- end }}
-    {{- if $default_docker_version | has "23.0.6" | not }}
-    {{- $default_docker_version = append $default_docker_version "23.0.6" }}
+    {{- if $default_docker_version | has "23.0.5" | not }}
+    {{- $default_docker_version = append $default_docker_version "23.0.5" }}
     {{- end }}
     {{- if $default_cridockerd_version | has "v0.3.7" | not }}
     {{- $default_cridockerd_version = append $default_cridockerd_version "v0.3.7" }}

--- a/builtin/core/roles/defaults/vars/v1.26.yaml
+++ b/builtin/core/roles/defaults/vars/v1.26.yaml
@@ -33,7 +33,7 @@ cri:
   crictl_version: v1.26.0
   # ========== cri: docker ==========
   # docker binary
-  docker_version: 23.0.6
+  docker_version: 23.0.5
   # cridockerd. Required when kube_version is greater than 1.24
   cridockerd_version: v0.3.7
   # ========== cri: containerd ==========


### PR DESCRIPTION
### What type of PR is this?
/kind bug

## What does this PR do

Downgrade the default docker version for Kubernetes 1.26 from 23.0.6 to 23.0.5.

### Background / Motivation

The aarch64 `docker-23.0.6.tgz` on `mirrors.aliyun.com` is a broken 0-byte file (HTTP 200 but `content-length: 0`). When deploying a Kubernetes 1.26 cluster with the docker runtime on arm64 nodes, the download step fetches this broken archive and the docker binary cannot be installed. The aarch64 `docker-23.0.5.tgz` is intact on the mirror, so downgrading the default version to 23.0.5 restores arm64 docker-runtime deployments.

### Implementation

Change the default `docker_version` for Kubernetes 1.26 in three places that must stay in sync:

- `builtin/core/roles/defaults/vars/v1.26.yaml` — the actual default value consumed at runtime
- `builtin/core/roles/defaults/templates/manifests.yaml` — the v1.26 branch of the default docker version list used for artifact/manifest rendering
- `builtin/core/defaults/config/v1.26.yaml` — the commented example value in the sample config

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/defaults/vars/v1.26.yaml` | `docker_version` 23.0.6 → 23.0.5 |
| `builtin/core/roles/defaults/templates/manifests.yaml` | v1.26 branch default docker version 23.0.6 → 23.0.5 |
| `builtin/core/defaults/config/v1.26.yaml` | commented example `docker_version` 23.0.6 → 23.0.5 |

## Impact

- **Affected modules**: builtin core defaults (docker runtime for Kubernetes 1.26)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: default `cri.docker.docker_version` for Kubernetes 1.26 changed from 23.0.6 to 23.0.5
- **Dependency changes**: N/A

## Breaking Changes

None

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [ ] Unit tests pass
- [ ] Integration / E2E tests pass
- [x] Manual verification

### Steps to verify

1. Check the aarch64 docker packages on `mirrors.aliyun.com`: `docker-23.0.6.tgz` is a broken 0-byte file, `docker-23.0.5.tgz` is intact (~61MB)
2. Render the manifests for Kubernetes 1.26 and confirm the default docker version is 23.0.5

### Test coverage

No new tests; this is a default value change in YAML defaults. The three files are kept in sync manually.

## Rollback

Revert the commit to restore docker 23.0.6 as the default for Kubernetes 1.26.

### Does this PR introduce a user-facing change?

```release-note
Downgrade the default docker version for Kubernetes 1.26 from 23.0.6 to 23.0.5 to fix arm64 deployments where the 23.0.6 archive on mirrors.aliyun.com is broken.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

The three files must stay in sync when the default docker version changes. The `manifests.yaml` entry is the v1.26 branch of the default docker version list used for artifact rendering. This is a YAML-only change, so no Go build is required.
