### PR TITLE
feat(native): make OS package list configurable via native.packages

### DIFF
--- a/builtin/core/roles/defaults/defaults/main/02-native.yaml
+++ b/builtin/core/roles/defaults/defaults/main/02-native.yaml
@@ -23,3 +23,25 @@ native:
   #   [hostname of the node being installed] -> corresponding node IP
   localDNS:
     - /etc/hosts
+  # OS packages installed on every node during initialization, declared per package
+  # manager with their real distribution package names.
+  # Additional packages are appended automatically when required:
+  #   - nftables when kubernetes.kube_proxy.mode is "nftables"
+  #   - when the inventory defines a non-empty "nfs" group: nfs-kernel-server (deb)
+  #     or nfs-utils (rpm) on the nodes of that group, and nfs-common (deb) or
+  #     nfs-utils (rpm) on all other nodes
+  packages:
+    debs:
+      - socat
+      - conntrack
+      - ipset
+      - ebtables
+      - chrony
+      - ipvsadm
+    rpms:
+      - socat
+      - conntrack-tools
+      - ipset
+      - ebtables
+      - chrony
+      - ipvsadm

--- a/builtin/core/roles/native/repository/tasks/install_package.yaml
+++ b/builtin/core/roles/native/repository/tasks/install_package.yaml
@@ -12,39 +12,17 @@
 - name: Repository | Initialize Debian-based repository and install required system packages
   command: |
     now=$(date +"%Y%m%d%H%M%S")
-    PKGS="socat conntrack ipset ebtables chrony ipvsadm{{ if .kubernetes.kube_proxy.mode | default "iptables" | eq "nftables" }} nftables{{ end }}{{ if .groups.nfs | default list | has .inventory_hostname }} nfs-kernel-server{{ end }}"
+    # nftables is appended when kube-proxy runs in nftables mode. When the inventory
+    # defines a non-empty "nfs" group, the NFS server package is installed on the
+    # nodes of that group and the NFS client package on all other nodes.
+    PKGS="{{ .native.packages.debs | default list | join " " }}{{ if .kubernetes.kube_proxy.mode | default "iptables" | eq "nftables" }} nftables{{ end }}{{ if .groups.nfs | default list | has .inventory_hostname }} nfs-kernel-server{{ else if .groups.nfs | default list | empty | not }} nfs-common{{ end }}"
     PKGS_TO_INSTALL=""
     for pkg in $PKGS; do
-      if [ -n "$pkg" ]; then
-        case "$pkg" in
-          socat)
-            command -v socat >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL socat"
-            ;;
-          conntrack)
-            command -v conntrack >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL conntrack"
-            ;;
-          ipset)
-            ipset list >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ipset"
-            ;;
-          ebtables)
-            ebtables -L >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ebtables"
-            ;;
-          chrony)
-            [ "$(systemctl show -p LoadState --value chrony.service 2>/dev/null)" = "loaded" ] \
-              || PKGS_TO_INSTALL="$PKGS_TO_INSTALL chrony"
-            ;;
-          ipvsadm)
-            ipvsadm -Ln >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ipvsadm"
-            ;;
-          nftables)
-            nft --version >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL nftables"
-            ;;
-          nfs-kernel-server)
-            [ "$(systemctl show -p LoadState --value nfs-server.service 2>/dev/null)" = "loaded" ] \
-              || PKGS_TO_INSTALL="$PKGS_TO_INSTALL nfs-kernel-server"
-            ;;
-        esac
-      fi
+      [ -n "$pkg" ] || continue
+      # native.packages.debs holds real Debian package names, so the dpkg status
+      # database is authoritative and no binary-name probe is needed.
+      dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q "install ok installed" \
+        || PKGS_TO_INSTALL="$PKGS_TO_INSTALL $pkg"
     done
     if [ -f "{{ .tmp_dir }}/repository.iso" ]; then
       # Backup current APT sources
@@ -76,39 +54,17 @@
 - name: Repository | Initialize RHEL-based repository and install required system packages
   command: |
     BACKUP_FILE="/etc/yum.repos.d.kubekey.bak-$(date +%Y%m%d%H%M%S)"
-    PKGS="socat conntrack ipset ebtables chrony ipvsadm{{ if .kubernetes.kube_proxy.mode | default "iptables" | eq "nftables" }} nftables{{ end }}{{ if .groups.nfs | default list | has .inventory_hostname }} nfs-kernel-server{{ end }}"
+    # nftables is appended when kube-proxy runs in nftables mode. When the inventory
+    # defines a non-empty "nfs" group, nfs-utils is installed on every node: the RPM
+    # provides both the NFS server and the NFS client, so no per-node split is needed.
+    PKGS="{{ .native.packages.rpms | default list | join " " }}{{ if .kubernetes.kube_proxy.mode | default "iptables" | eq "nftables" }} nftables{{ end }}{{ if .groups.nfs | default list | empty | not }} nfs-utils{{ end }}"
     PKGS_TO_INSTALL=""
     for pkg in $PKGS; do
-      if [ -n "$pkg" ]; then
-        case "$pkg" in
-          socat)
-            command -v socat >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL socat"
-            ;;
-          conntrack)
-            command -v conntrack >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL conntrack"
-            ;;
-          ipset)
-            ipset list >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ipset"
-            ;;
-          ebtables)
-            ebtables -L >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ebtables"
-            ;;
-          chrony)
-            [ "$(systemctl show -p LoadState --value chronyd.service 2>/dev/null)" = "loaded" ] \
-              || PKGS_TO_INSTALL="$PKGS_TO_INSTALL chrony"
-            ;;
-          ipvsadm)
-            ipvsadm -Ln >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ipvsadm"
-            ;;
-          nftables)
-            nft --version >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL nftables"
-            ;;
-          nfs-kernel-server)
-            [ "$(systemctl show -p LoadState --value nfs-server.service 2>/dev/null)" = "loaded" ] \
-              || PKGS_TO_INSTALL="$PKGS_TO_INSTALL nfs-kernel-server"
-            ;;
-        esac      
-      fi
+      [ -n "$pkg" ] || continue
+      # native.packages.rpms holds real RPM package names, so the rpm database is
+      # authoritative and no binary-name probe is needed.
+      rpm -q --quiet "$pkg" 2>/dev/null \
+        || PKGS_TO_INSTALL="$PKGS_TO_INSTALL $pkg"
     done
     if [ -f "{{ .tmp_dir }}/repository.iso" ]; then
       # Backup current YUM repositories

--- a/docs/en/installation/README.md
+++ b/docs/en/installation/README.md
@@ -16,7 +16,10 @@ This document explains how to install a Kubernetes cluster using KubeKey.
 
 Kubernetes requires the following OS dependencies to be pre-installed:
 
-`socat` `conntrack` `ipset` `ebtables` `chrony` `ipvsadm`
+- Debian/Ubuntu: `socat` `conntrack` `ipset` `ebtables` `chrony` `ipvsadm`
+- RHEL/CentOS: `socat` `conntrack-tools` `ipset` `ebtables` `chrony` `ipvsadm`
+
+KubeKey installs these packages automatically during node initialization. To customize the lists, set `native.packages.debs` or `native.packages.rpms` in the config file; see [Config Reference](../reference/config.md).
 
 KubeKey provides pre-compiled dependency packages for some Linux distributions, available at [iso-latest](https://github.com/kubesphere/kubekey/releases/tag/iso-latest).
 For supported distributions and build methods, see [Dependency Packages](../dependency-packages/README.md).

--- a/docs/en/reference/config.md
+++ b/docs/en/reference/config.md
@@ -445,6 +445,28 @@ native:
   #   [hostname of the node being installed] -> corresponding node IP
   localDNS:
     - /etc/hosts
+  # OS packages installed on every node during initialization, declared per package
+  # manager with their real distribution package names
+  # Additional packages are appended automatically when required:
+  #   - nftables when kubernetes.kube_proxy.mode is "nftables"
+  #   - when the inventory defines a non-empty "nfs" group: nfs-kernel-server (deb)
+  #     or nfs-utils (rpm) on the nodes of that group, and nfs-common (deb) or
+  #     nfs-utils (rpm) on all other nodes
+  packages:
+    debs:
+      - socat
+      - conntrack
+      - ipset
+      - ebtables
+      - chrony
+      - ipvsadm
+    rpms:
+      - socat
+      - conntrack-tools
+      - ipset
+      - ebtables
+      - chrony
+      - ipvsadm
 ```
 
 ### Parameter Descriptions
@@ -457,6 +479,8 @@ native:
 | `native.nfs.share_dir` | NFS shared directories, used by nodes marked with the `nfs` role. |
 | `native.set_hostname` | Whether to automatically set the node hostname according to the inventory definition during installation. |
 | `native.localDNS` | List of local DNS resolution files (e.g., `/etc/hosts`), used to provide temporary domain name resolution during installation. |
+| `native.packages.debs` | Debian/Ubuntu packages installed on every node during initialization, using real `.deb` package names. `nftables` is appended automatically when `kubernetes.kube_proxy.mode` is `nftables`. When the inventory defines a non-empty `nfs` group, `nfs-kernel-server` is appended on the nodes of that group and `nfs-common` on all other nodes. |
+| `native.packages.rpms` | RHEL/CentOS packages installed on every node during initialization, using real RPM package names (e.g. `conntrack-tools`). `nftables` is appended automatically when `kubernetes.kube_proxy.mode` is `nftables`. When the inventory defines a non-empty `nfs` group, `nfs-utils` is appended on every node, as it provides both the NFS server and the NFS client. |
 
 ---
 

--- a/docs/zh/installation/README.md
+++ b/docs/zh/installation/README.md
@@ -16,7 +16,10 @@
 
 Kubernetes 要求操作系统预装以下依赖：
 
-`socat` `conntrack` `ipset` `ebtables` `chrony` `ipvsadm`
+- Debian/Ubuntu：`socat` `conntrack` `ipset` `ebtables` `chrony` `ipvsadm`
+- RHEL/CentOS：`socat` `conntrack-tools` `ipset` `ebtables` `chrony` `ipvsadm`
+
+KubeKey 会在节点初始化时自动安装上述软件包。如需自定义清单，可在配置文件中设置 `native.packages.debs` 或 `native.packages.rpms`，参见[配置参考](../reference/config.md)。
 
 KubeKey 已为部分 Linux 发行版制作了预编译的依赖包，可在 [iso-latest](https://github.com/kubesphere/kubekey/releases/tag/iso-latest) 获取。
 支持的具体发行版与构建方式详见 [依赖包管理](../dependency-packages/README.md)。

--- a/docs/zh/reference/config.md
+++ b/docs/zh/reference/config.md
@@ -443,6 +443,26 @@ native:
   #   [当前安装节点的主机名] -> 对应节点 IP
   localDNS:
     - /etc/hosts
+  # 初始化时在每个节点安装的操作系统软件包，按包管理器分别声明，使用发行版真实包名
+  # 以下软件包会在满足条件时自动追加：
+  #   - kubernetes.kube_proxy.mode 为 "nftables" 时追加 nftables
+  #   - inventory 中定义了非空的 "nfs" 组时：该组节点追加 nfs-kernel-server（deb）
+  #     或 nfs-utils（rpm），其余节点追加 nfs-common（deb）或 nfs-utils（rpm）
+  packages:
+    debs:
+      - socat
+      - conntrack
+      - ipset
+      - ebtables
+      - chrony
+      - ipvsadm
+    rpms:
+      - socat
+      - conntrack-tools
+      - ipset
+      - ebtables
+      - chrony
+      - ipvsadm
 ```
 
 ### 参数说明
@@ -455,6 +475,8 @@ native:
 | `native.nfs.share_dir` | NFS 共享目录，供标记了 `nfs` 角色的节点使用。 |
 | `native.set_hostname` | 安装时是否根据 inventory 中的定义自动设置节点主机名。 |
 | `native.localDNS` | 本地 DNS 解析文件列表（如 `/etc/hosts`），用于在安装期间提供临时域名解析。 |
+| `native.packages.debs` | 初始化时在每个节点安装的 Debian/Ubuntu 软件包，使用真实 `.deb` 包名。当 `kubernetes.kube_proxy.mode` 为 `nftables` 时会自动追加 `nftables`；当 inventory 中定义了非空的 `nfs` 组时，该组节点追加 `nfs-kernel-server`，其余节点追加 `nfs-common`。 |
+| `native.packages.rpms` | 初始化时在每个节点安装的 RHEL/CentOS 软件包，使用真实 RPM 包名（如 `conntrack-tools`）。当 `kubernetes.kube_proxy.mode` 为 `nftables` 时会自动追加 `nftables`；当 inventory 中定义了非空的 `nfs` 组时，所有节点追加 `nfs-utils`（该包同时提供 NFS 服务端与客户端）。 |
 
 ---
 


### PR DESCRIPTION
### What type of PR is this?

/kind feature

## What does this PR do

Make the OS packages installed during node initialization configurable through `native.packages`, and fix the package names used by the RHEL branch.

### Background / Motivation

The package list was hardcoded in `install_package.yaml` — `socat conntrack ipset ebtables chrony ipvsadm`, duplicated in the Debian and the RHEL task — so users could neither inspect it nor change it.

Two further problems came with it:

1. The RHEL task reused Debian package names. `conntrack` and `nfs-kernel-server` do not exist in RHEL repositories; the correct names are `conntrack-tools` and `nfs-utils`. KubeKey's own offline ISO list (`hack/gen-repository-iso/packages.yaml`, consumed as `.common[] + .rpms[]` / `.common[] + .debs[]`) already used the correct RPM names, so the runtime list had been out of sync with the ISO contents it ships.
2. The "already installed" check was a `case` statement with 8 branches, each using a different probe (`command -v`, `ipset list`, `ebtables -L`, `systemctl show -p LoadState`, `nft --version`), duplicated in both tasks. Any package outside that `case` — including every user-defined package — was silently dropped from the install list. The `chrony` branch probed `chronyd.service`, a unit name that does not exist on Debian (it is `chrony.service`), so `chrony` was reinstalled on every run.

### Implementation

1. The list is exposed as `native.packages.debs` and `native.packages.rpms`, declared per package manager with real distribution package names.
2. Both `PKGS` lines render from the corresponding parameter, so each distribution installs names that actually exist there.
3. The probe is reduced to a single query against the native package database (`dpkg-query -W -f='${Status}' | grep "install ok installed"` on Debian, `rpm -q --quiet` on RHEL). Once the configured names are real, the package database is authoritative and no binary-name fallback is required — which also means arbitrary user packages now work.
4. Conditional packages: `nftables` is appended when `kubernetes.kube_proxy.mode` is `nftables`; when the inventory defines a non-empty `nfs` group, the NFS server package is installed on that group's nodes (`nfs-kernel-server` / `nfs-utils`) and the NFS client package on all other nodes (`nfs-common` / `nfs-utils`), so workloads on those nodes can mount NFS volumes. On RPM, `nfs-utils` ships both roles, so no per-node split is needed.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/defaults/defaults/main/02-native.yaml` | Added `native.packages.debs` / `native.packages.rpms` holding the previous defaults, with real package names per distribution |
| `builtin/core/roles/native/repository/tasks/install_package.yaml` | Both `PKGS` lines render from the new parameters; the 8-branch `case` probe is replaced by a single package-manager query; conditional `nftables` / NFS handling updated |
| `docs/en/reference/config.md`, `docs/zh/reference/config.md` | Documented the two parameters, their defaults and the conditional packages |
| `docs/en/installation/README.md`, `docs/zh/installation/README.md` | Split the OS dependency list per distribution |

## Impact

- **Affected modules**: `builtin/core` (native role, node initialization)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: New `native.packages.debs` / `native.packages.rpms`; defaults equal the previously hardcoded list, with `conntrack-tools` instead of `conntrack` on the RPM side
- **Dependency changes**: N/A

## Breaking Changes

None. Debian behaviour is unchanged. On RHEL, the packages passed to `yum` are now names that exist (`conntrack-tools`, `nfs-utils` instead of `conntrack`, `nfs-kernel-server`).

### Which issue(s) this PR fixes:

Fixes #

## Testing

### Verification performed

- [x] Local build passes (`make kk`)
- [ ] Integration / E2E tests pass
- [x] Manual verification

### Steps to verify

1. `make kk`, then run a config that triggers the native role and inspect the rendered `PKGS` line.
2. Render both `PKGS` templates through `pkg/converter/tmpl` for four cases: no `nfs` group, an `nfs` node, a non-`nfs` node, and `kube_proxy.mode=nftables`.
3. Expected: the base list only, plus `nfs-kernel-server` on an `nfs` node, plus `nfs-common` on the others, plus `nftables` when the proxy mode is `nftables`.
4. On a real host, confirm already-installed packages are skipped and only missing ones reach apt/yum.

### Test coverage

Template rendering was verified for both branches across 5 scenarios (no `nfs` group; `nfs` node; k8s node; each of the latter with `nftables`), plus the case where only one of `debs` / `rpms` is configured. Both YAML files parse, and both rendered scripts pass `sh -n`. No unit test is added: the logic lives in embedded YAML playbooks and the repository has no harness for role task templates.

## Rollback

Plain revert. The change is confined to a defaults file and one task file, so `git revert` restores the previous hardcoded list.

### Does this PR introduce a user-facing change?

```release-note
Add `native.packages.debs` and `native.packages.rpms` to customize the OS packages installed during node initialization. On RHEL, `conntrack-tools` and `nfs-utils` are now installed instead of the previously incorrect `conntrack` and `nfs-kernel-server`. When the inventory defines an `nfs` group, the NFS client package is installed on the remaining nodes.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [x] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make kk`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs

```

## Notes for Reviewer

- Removing the `case` probe is what makes `native.packages.*` work for arbitrary packages; the trade-off is that package-specific semantic probes are gone, so package presence is judged by the package database only.
- `builtin/capkk/roles/init/init-os/tasks/init_repository.yaml` carries the same hardcoded list (4 occurrences). It is intentionally left untouched here.
- Pre-existing gap, not addressed here: the Debian offline ISO ships `nfs-common` but not `nfs-kernel-server`, so an `nfs` node installed from that ISO would still fail to obtain the server package.
