### PR TITLE
feat(download): add opt-in static containerd binary download

### DIFF
--- a/builtin/core/roles/defaults/defaults/main/04-cri.yaml
+++ b/builtin/core/roles/defaults/defaults/main/04-cri.yaml
@@ -41,6 +41,10 @@ cri:
   containerd:
     # How to handle /etc/containerd/config.toml when already installed: empty (default) skips, "merge" merges with existing file, "override" overwrites
     config_policy: ""
+    # Download the statically linked containerd binary instead of the default dynamically linked one.
+    # Useful on older distros (e.g. Rocky Linux 8) whose glibc predates what recent containerd releases require.
+    # Only set this for a containerd_version that publishes a "containerd-static-*" release asset.
+    static_binary: false
     config:
       root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
       version: 2

--- a/builtin/core/roles/defaults/defaults/main/10-download.yaml
+++ b/builtin/core/roles/defaults/defaults/main/10-download.yaml
@@ -44,7 +44,9 @@ download:
       github.com/Mirantis/cri-dockerd/releases/download/{{ "{{ .version }}" }}/cri-dockerd-{{ "{{ .version | default \"\" | trimPrefix \"v\" }}" }}.{{ "{{ .arch }}" }}.tgz
     containerd: >-
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}
-      github.com/containerd/containerd/releases/download/{{ "{{ .version }}" }}/containerd-{{ "{{ .version | default \"\" | trimPrefix \"v\" }}" }}-linux-{{ "{{ .arch }}" }}.tar.gz
+      github.com/containerd/containerd/releases/download/{{ "{{ .version }}" }}/containerd-
+      {{- .cri.containerd.static_binary | default false | ternary "static-" "" -}}
+      {{ "{{ .version | default \"\" | trimPrefix \"v\" }}" }}-linux-{{ "{{ .arch }}" }}.tar.gz
     runc: >-
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}
       github.com/opencontainers/runc/releases/download/{{ "{{ .version }}" }}/runc.{{ "{{ .arch }}" }}

--- a/docs/en/reference/config.md
+++ b/docs/en/reference/config.md
@@ -817,6 +817,10 @@ cri:
     # Policy for updating the containerd config file and systemd service when the runtime is already installed.
     # Empty (default): skip the update; "merge": merge with the existing config (node-side keys take precedence); "override": overwrite.
     config_policy: ""
+    # Download the statically linked containerd binary instead of the default dynamically linked one.
+    # Useful on older distros (e.g. Rocky Linux 8) whose glibc predates what recent containerd releases require.
+    # Only set this for a containerd_version that publishes a "containerd-static-*" release asset.
+    static_binary: false
     config:
       # containerd data root directory
       root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
@@ -883,6 +887,7 @@ cri:
 | `cri.docker.daemon.exec-opts` | Docker exec options list, e.g., cgroup driver. |
 | `cri.containerd.config` | containerd configuration, mapped to `/etc/containerd/config.toml`. |
 | `cri.containerd.config_policy` | Policy for updating the containerd config file (`/etc/containerd/config.toml`) and systemd service when the runtime is already installed: empty (default) skips the update; `merge` merges with the existing config (node-side existing keys take precedence); `override` overwrites. Binary installation and certificate sync are not affected by this policy. |
+| `cri.containerd.static_binary` | Whether to download the statically linked containerd binary (`containerd-static-*`) instead of the default dynamically linked one. Useful on older distros whose glibc predates what recent containerd releases require. Requires the target containerd version to actually publish a static release asset. |
 | `cri.docker.daemon_policy` | Same as `cri.containerd.config_policy`, but applies to the Docker daemon (`/etc/docker/daemon.json`) and its systemd service. |
 | `cri.containerd.config.root` | containerd data persistence root directory. |
 | `cri.containerd.config.version` | containerd configuration file version. |
@@ -1230,7 +1235,9 @@ download:
     # containerd binary package
     containerd: >-
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}
-      github.com/containerd/containerd/releases/download/{{ "{{ .version }}" }}/containerd-{{ "{{ .version | default \"\" | trimPrefix \"v\" }}" }}-linux-{{ "{{ .arch }}" }}.tar.gz
+      github.com/containerd/containerd/releases/download/{{ "{{ .version }}" }}/containerd-
+      {{- .cri.containerd.static_binary | default false | ternary "static-" "" -}}
+      {{ "{{ .version | default \"\" | trimPrefix \"v\" }}" }}-linux-{{ "{{ .arch }}" }}.tar.gz
     # runc binary
     runc: >-
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}

--- a/docs/zh/reference/config.md
+++ b/docs/zh/reference/config.md
@@ -815,6 +815,10 @@ cri:
     # 已安装 containerd 时，更新配置文件（/etc/containerd/config.toml）与 systemd 服务的策略。
     # 空（默认）：跳过更新；"merge"：与现有配置合并（节点侧已有键优先）；"override"：覆盖。
     config_policy: ""
+    # 下载静态链接的 containerd 二进制包，而非默认的动态链接版本。
+    # 适用于 glibc 版本低于最新 containerd 发行版要求的旧发行版（如 Rocky Linux 8）。
+    # 仅当目标 containerd_version 确实发布了 "containerd-static-*" 产物时才应开启此项。
+    static_binary: false
     config:
       # containerd 数据根目录
       root: "{{ .cri.containerd.data_root | default \"/var/lib/containerd\" }}"
@@ -881,6 +885,7 @@ cri:
 | `cri.docker.daemon.exec-opts` | Docker exec 选项列表，例如 cgroup 驱动。 |
 | `cri.containerd.config` | containerd 配置，映射为 `/etc/containerd/config.toml`。 |
 | `cri.containerd.config_policy` | 已安装 containerd 时，更新配置文件（/etc/containerd/config.toml）与 systemd 服务的策略：空（默认）跳过更新；`merge` 与现有配置合并（节点侧已有键优先）；`override` 覆盖。该策略不影响二进制安装与证书同步。 |
+| `cri.containerd.static_binary` | 是否下载静态链接的 containerd 二进制包（`containerd-static-*`），而非默认的动态链接版本。适用于 glibc 版本低于最新 containerd 发行版要求的旧发行版。要求目标 containerd 版本确实发布了静态构建的产物。 |
 | `cri.docker.daemon_policy` | 与 `cri.containerd.config_policy` 相同，但作用于 Docker daemon（/etc/docker/daemon.json）及其 systemd 服务。 |
 | `cri.containerd.config.root` | containerd 数据持久化根目录。 |
 | `cri.containerd.config.version` | containerd 配置文件版本。 |
@@ -1228,7 +1233,9 @@ download:
     # containerd 二进制包
     containerd: >-
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}
-      github.com/containerd/containerd/releases/download/{{ "{{ .version }}" }}/containerd-{{ "{{ .version | default \"\" | trimPrefix \"v\" }}" }}-linux-{{ "{{ .arch }}" }}.tar.gz
+      github.com/containerd/containerd/releases/download/{{ "{{ .version }}" }}/containerd-
+      {{- .cri.containerd.static_binary | default false | ternary "static-" "" -}}
+      {{ "{{ .version | default \"\" | trimPrefix \"v\" }}" }}-linux-{{ "{{ .arch }}" }}.tar.gz
     # runc 二进制
     runc: >-
       {{- .zone | eq "cn" | ternary (tpl "https://{{ .download.cn_host}}/" .) "https://" -}}

--- a/pkg/converter/tmpl/template_test.go
+++ b/pkg/converter/tmpl/template_test.go
@@ -185,6 +185,70 @@ func TestDockerRegistryArtifactURLUsesMirrorHost(t *testing.T) {
 	}
 }
 
+// TestContainerdArtifactURLStaticBinary renders the real containerd artifact_url
+// template the same way pkg/modules/http_get_file does: first as the defaults
+// file's own self-referential template (resolving cri.containerd.static_binary
+// and zone), then through tpl with the download item (version/arch). When
+// cri.containerd.static_binary is true the URL must point at the
+// "containerd-static-*" release asset instead of the default dynamically
+// linked "containerd-*" asset, since the dynamic build requires a newer glibc
+// than some supported distros (e.g. Rocky Linux 8) ship.
+func TestContainerdArtifactURLStaticBinary(t *testing.T) {
+	raw, err := os.ReadFile("../../../builtin/core/roles/defaults/defaults/main/10-download.yaml")
+	assert.NoError(t, err)
+
+	var defaults map[string]any
+	assert.NoError(t, yaml.Unmarshal(raw, &defaults))
+
+	download, ok := defaults["download"].(map[string]any)
+	assert.True(t, ok)
+	artifactURL, ok := download["artifact_url"].(map[string]any)
+	assert.True(t, ok)
+	tmplStr, ok := artifactURL["containerd"].(string)
+	assert.True(t, ok)
+
+	testcases := []struct {
+		name         string
+		staticBinary bool
+		expected     string
+	}{
+		{
+			name:         "dynamic binary by default",
+			staticBinary: false,
+			expected:     "https://github.com/containerd/containerd/releases/download/v2.3.4/containerd-2.3.4-linux-amd64.tar.gz",
+		},
+		{
+			name:         "static binary when opted in",
+			staticBinary: true,
+			expected:     "https://github.com/containerd/containerd/releases/download/v2.3.4/containerd-static-2.3.4-linux-amd64.tar.gz",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			variable := map[string]any{
+				"zone": "",
+				"download": map[string]any{
+					"cn_host": download["cn_host"],
+				},
+				"cri": map[string]any{
+					"containerd": map[string]any{
+						"static_binary": tc.staticBinary,
+					},
+				},
+			}
+
+			rendered, err := Parse(variable, tmplStr)
+			assert.NoError(t, err)
+
+			final, err := Parse(map[string]any{"version": "v2.3.4", "arch": "amd64"}, string(rendered))
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.expected, string(final))
+		})
+	}
+}
+
 func TestParseBool(t *testing.T) {
 	testcases := []struct {
 		name      string

--- a/pkg/converter/tmpl/template_test.go
+++ b/pkg/converter/tmpl/template_test.go
@@ -146,14 +146,13 @@ func TestKubeVipTemplatesRenderDefaults(t *testing.T) {
 	})
 }
 
-// TestDockerRegistryArtifactURLUsesMirrorHost renders the real docker_registry
-// artifact_url template the same way pkg/modules/http_get_file does: first as
-// the defaults file's own self-referential template, then through tpl with the
-// download item. docker-registry-*.tgz is a KubeKey-repackaged asset that only
-// exists on the cn_host mirror, so the resulting URL must route through
-// cn_host regardless of zone; falling back to a bare "https://docker.io/..."
-// host for non-cn zones 404s (docker.io redirects to www.docker.com).
-func TestDockerRegistryArtifactURLUsesMirrorHost(t *testing.T) {
+// downloadArtifactURLTemplate reads the real 10-download.yaml defaults file
+// and returns the raw artifact_url template string for the given key
+// (e.g. "docker_registry", "containerd"), along with the sibling
+// download.cn_host value templates commonly need.
+func downloadArtifactURLTemplate(t *testing.T, key string) (tmplStr string, cnHost any) {
+	t.Helper()
+
 	raw, err := os.ReadFile("../../../builtin/core/roles/defaults/defaults/main/10-download.yaml")
 	assert.NoError(t, err)
 
@@ -164,14 +163,27 @@ func TestDockerRegistryArtifactURLUsesMirrorHost(t *testing.T) {
 	assert.True(t, ok)
 	artifactURL, ok := download["artifact_url"].(map[string]any)
 	assert.True(t, ok)
-	tmplStr, ok := artifactURL["docker_registry"].(string)
+	tmplStr, ok = artifactURL[key].(string)
 	assert.True(t, ok)
+
+	return tmplStr, download["cn_host"]
+}
+
+// TestDockerRegistryArtifactURLUsesMirrorHost renders the real docker_registry
+// artifact_url template the same way pkg/modules/http_get_file does: first as
+// the defaults file's own self-referential template, then through tpl with the
+// download item. docker-registry-*.tgz is a KubeKey-repackaged asset that only
+// exists on the cn_host mirror, so the resulting URL must route through
+// cn_host regardless of zone; falling back to a bare "https://docker.io/..."
+// host for non-cn zones 404s (docker.io redirects to www.docker.com).
+func TestDockerRegistryArtifactURLUsesMirrorHost(t *testing.T) {
+	tmplStr, cnHost := downloadArtifactURLTemplate(t, "docker_registry")
 
 	for _, zone := range []string{"", "cn"} {
 		variable := map[string]any{
 			"zone": zone,
 			"download": map[string]any{
-				"cn_host": download["cn_host"],
+				"cn_host": cnHost,
 			},
 		}
 
@@ -194,18 +206,7 @@ func TestDockerRegistryArtifactURLUsesMirrorHost(t *testing.T) {
 // linked "containerd-*" asset, since the dynamic build requires a newer glibc
 // than some supported distros (e.g. Rocky Linux 8) ship.
 func TestContainerdArtifactURLStaticBinary(t *testing.T) {
-	raw, err := os.ReadFile("../../../builtin/core/roles/defaults/defaults/main/10-download.yaml")
-	assert.NoError(t, err)
-
-	var defaults map[string]any
-	assert.NoError(t, yaml.Unmarshal(raw, &defaults))
-
-	download, ok := defaults["download"].(map[string]any)
-	assert.True(t, ok)
-	artifactURL, ok := download["artifact_url"].(map[string]any)
-	assert.True(t, ok)
-	tmplStr, ok := artifactURL["containerd"].(string)
-	assert.True(t, ok)
+	tmplStr, cnHost := downloadArtifactURLTemplate(t, "containerd")
 
 	testcases := []struct {
 		name         string
@@ -229,7 +230,7 @@ func TestContainerdArtifactURLStaticBinary(t *testing.T) {
 			variable := map[string]any{
 				"zone": "",
 				"download": map[string]any{
-					"cn_host": download["cn_host"],
+					"cn_host": cnHost,
 				},
 				"cri": map[string]any{
 					"containerd": map[string]any{


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug
/kind feature

## What does this PR do

Adds an opt-in `cri.containerd.static_binary` config flag that switches the containerd download URL to the statically linked `containerd-static-*` release asset instead of the default dynamically linked one.

### Background / Motivation

containerd v2.3.4 (the current default for Kubernetes 1.35/1.36/1.37) is downloaded as a dynamically linked binary that requires glibc >= 2.35. On older distros such as Rocky Linux 8.10 (glibc 2.28), containerd fails to start with `GLIBC_2.32' not found`. Issue reporters confirmed that manually overriding `spec.download.artifact_url.containerd` to point at containerd's statically linked release asset fixes this, since the static build has no glibc dependency, but there was no documented, supported way to opt into this without hand-crafting the full download URL.

### Implementation

Added `cri.containerd.static_binary: false` to `builtin/core/roles/defaults/defaults/main/04-cri.yaml`, and updated the `download.artifact_url.containerd` template in `builtin/core/roles/defaults/defaults/main/10-download.yaml` to insert a `static-` segment into the generated URL when the flag is true. Chose a first-class config field over relying solely on the existing full-URL-override escape hatch, since it's self-documenting and matches how other CRI runtime behaviors (e.g. `config_policy`) are already exposed. The flag defaults to `false`, so the rendered URL is byte-identical to before for existing users. Mirrored the change into `docs/en/reference/config.md` and `docs/zh/reference/config.md`, which hand-maintain a verbatim copy of these defaults files.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/defaults/defaults/main/04-cri.yaml` | Added `cri.containerd.static_binary` config field (default `false`) |
| `builtin/core/roles/defaults/defaults/main/10-download.yaml` | `download.artifact_url.containerd` template now inserts `static-` when the flag is enabled |
| `docs/en/reference/config.md`, `docs/zh/reference/config.md` | Mirrored the new field/template and added a parameter table row |
| `pkg/converter/tmpl/template_test.go` | Added `TestContainerdArtifactURLStaticBinary` covering both flag states |

## Impact

- **Affected modules**: `builtin/core` defaults (config surface only); `pkg/converter/tmpl` (test only)
- **API changes**: New optional config field `cri.containerd.static_binary` (bool, default `false`). No existing fields changed.
- **Database / state changes**: N/A
- **Config changes**: New optional field `cri.containerd.static_binary`, defaults to `false` (no behavior change unless explicitly set)
- **Dependency changes**: N/A

## Breaking Changes

None. The new field defaults to `false`, so the generated containerd download URL is unchanged for all existing configs.

### Which issue(s) this PR fixes:
Fixes #

## Testing

### Verification performed

- [x] Unit tests pass (`go test ./pkg/converter/... ./...`)
- [ ] Integration / E2E tests pass (not run — see notes below)
- [x] Manual verification (traced config-load ordering; did not perform a live download or on-Rocky-Linux-8 deployment)

### Steps to verify

1. `go test ./pkg/converter/tmpl/... -run TestContainerdArtifactURLStaticBinary -v`
2. Set `cri.containerd.static_binary: true` in a cluster config and run `kk create cluster` (or inspect the rendered `download.artifact_url.containerd` value) to confirm the URL points at `containerd-static-<version>-linux-<arch>.tar.gz`.
3. Expected result: with the flag unset/false, the URL is unchanged (`containerd-<version>-linux-<arch>.tar.gz`); with it true, the URL uses the static asset name.

### Test coverage

Added `TestContainerdArtifactURLStaticBinary` in `pkg/converter/tmpl/template_test.go`, modeled on the existing `TestDockerRegistryArtifactURLUsesMirrorHost`, rendering the real `10-download.yaml` template through the same two-pass flow `pkg/modules/http_get_file` uses in production. Confirmed the test fails against the pre-fix template and passes after.

## Rollback

Plain `git revert`. No data or state changes to unwind; the field is opt-in and defaults to `false`.

### Does this PR introduce a user-facing change?

```release-note
Added an opt-in `cri.containerd.static_binary` config option to download the statically linked containerd binary instead of the default dynamically linked one, for compatibility with older distros (e.g. Rocky Linux 8) whose glibc predates what recent containerd releases require. Defaults to `false`; no behavior change unless explicitly enabled.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [ ] All commits are GPG-signed (GitHub shows Verified)
- [x] Tests added or updated
- [x] Docs / CHANGELOG updated (if needed)
- [x] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

```docs
- [Config reference (EN)]: docs/en/reference/config.md
- [Config reference (ZH)]: docs/zh/reference/config.md
```

## Notes for Reviewer

Validation is limited to URL-generation logic (unit test, `go build`, `go test ./...`, `golangci-lint`) plus a manual trace of the config-load ordering (`04-cri.yaml` loads before `10-download.yaml`, so the new field is guaranteed to be resolved before the template that references it renders). I did not perform a live download or deploy to an actual old-glibc host (e.g. Rocky Linux 8) to confirm the static binary starts cleanly there — only that the correct URL is generated. Also note: not every containerd version publishes a `containerd-static-*` release asset, so this flag should only be enabled for versions that do (documented in the field's comment).

Fixes #3244