### PR TITLE
fix(dns): raise nodelocaldns memory limit to 400Mi

### DIFF
--- a/builtin/core/roles/kubernetes/init-kubernetes/templates/dns/nodelocaldns.yaml
+++ b/builtin/core/roles/kubernetes/init-kubernetes/templates/dns/nodelocaldns.yaml
@@ -43,7 +43,7 @@ spec:
         image: {{ .dns.nodelocaldns.image.registry }}/{{ .dns.nodelocaldns.image.repository }}:{{ .dns.nodelocaldns.image.tag }}
         resources:
           limits:
-            memory: 200Mi
+            memory: 400Mi
           requests:
             cpu: 100m
             memory: 70Mi


### PR DESCRIPTION
### What type of PR is this?

/kind bug

## What does this PR do

Raise the `node-cache` container memory limit in the nodelocaldns DaemonSet from `200Mi` to `400Mi`.

### Background / Motivation

`node-cache` is capped at `200Mi`, which is below the cache capacity declared by the Corefile in the same template. That Corefile defines four server blocks, and each block owns an independent `cache` instance. Note that `cache 30` sets the TTL override, not the capacity — capacity stays at the plugin default of 9984 success plus 9984 denial entries per block, so the four blocks declare roughly 240MB in total before the Go runtime, goroutines and sockets are counted.

The container therefore reaches its own cgroup limit under moderate query load. A node deployed with these defaults showed repeated events of this form:

```
Memory cgroup out of memory: Killed process 55158 (node-cache) total-vm:892140kB,
  anon-rss:165400kB, file-rss:164kB, shmem-rss:0kB, UID:0 pgtables:524kB oom_score_adj:999
memory: usage 204800kB, limit 204800kB, failcnt 14555306
memory+swap: usage 0kB, limit 9007199254740988kB, failcnt 0
```

Three consecutive kills carried three different container IDs, i.e. kubelet restarted the container each time and the new one hit the same limit; the restart back-off eventually settled at 300s. `memory+swap` usage was zero, so the anonymous memory was fully unreclaimable, and `workingset_refault` was approximately equal to `pgsteal` — reclaim was pure thrashing rather than actual relief.

kubelet does not evict the pod in this situation: eviction is driven by node-level `memory.available`, while here the container is hitting its own cgroup limit, so the pod loops on restart back-off instead of recovering.

The blast radius is wider than that of a regular pod because `node-cache` runs with `hostNetwork: true`. Per the upstream Kubernetes documentation on NodeLocal DNSCache, a container terminated by the OOM killer does not clean up the packet filter rules it installed at startup; on every restart there is a window during which DNS queries are forwarded to a local pod that is not serving, producing repeated short DNS outages on the node rather than a single restart.

### Implementation

Raise the limit to `400Mi` so it sits above the cache capacity declared by the template. `requests.memory` is deliberately left at `70Mi` to keep the change minimal and avoid altering scheduling behaviour on existing clusters.

### Key Changes

| File | What changed |
|---|---|
| `builtin/core/roles/kubernetes/init-kubernetes/templates/dns/nodelocaldns.yaml` | `resources.limits.memory` of the `node-cache` container: `200Mi` → `400Mi` |

## Impact

- **Affected modules**: `kubernetes/init-kubernetes` role (DNS template)
- **API changes**: N/A
- **Database / state changes**: N/A
- **Config changes**: N/A — the value is hardcoded in the built-in template; no new configuration item is introduced
- **Dependency changes**: N/A

## Breaking Changes

None. The limit is only raised and `requests` is unchanged, so the pod QoS class stays `Burstable`. Existing clusters pick up the new value on the next apply of this template.

Fixes #

## Testing

### Verification performed

- [ ] Unit tests pass (`go test -tags builtin -count=1 ./test/builtin/core/...`)
- [ ] Integration / E2E tests pass
- [ ] Manual verification

### Steps to verify

1. `make kk` and deploy a cluster using the built-in playbooks.
2. `kubectl -n kube-system get ds nodelocaldns -o jsonpath='{.spec.template.spec.containers[0].resources}'`
3. Expected: `{"limits":{"memory":"400Mi"},"requests":{"cpu":"100m","memory":"70Mi"}}`

### Test coverage

No test in the repository asserts template literal values, so this is a static verification only:

- `git diff` is a single line — `memory: 200Mi` → `memory: 400Mi`, indentation unchanged.
- Go template markers in the file are identical to `origin/main` (66 opening markers, identical histogram hash), i.e. the templating layer is untouched.
- The `containers[0]` block parses as YAML both before and after; the only difference in the parsed result is `limits.memory`.

Cluster-level verification is planned separately and is not included here.

## Rollback

Revert this commit; the previous `200Mi` limit is restored on the next apply of the template.

### Does this PR introduce a user-facing change?

```release-note
Raise the nodelocaldns `node-cache` container memory limit from `200Mi` to `400Mi`, so the container no longer exceeds its cgroup limit and enters a repeated OOMKill loop that causes short DNS outages on the node.
```

## Checklist

- [x] Code self-reviewed, no debug code or commented-out dead code
- [x] No secrets, tokens, or `.env` files committed
- [x] Commit message follows Conventional Commits
- [x] All commits have DCO sign-off (`Signed-off-by`)
- [x] All commits are GPG-signed (GitHub shows Verified)
- [ ] Tests added or updated
- [ ] Docs / CHANGELOG updated (if needed)
- [ ] Local lint and build pass (`make build`)
- [x] Breaking changes marked above

### Additional documentation, usage docs, etc.:

N/A

## Notes for Reviewer

`requests.memory: 70Mi` is intentionally untouched. Raising it too was considered — a higher request lowers the chance of the pod being an early OOM target on a memory-pressured node, since `oom_score_adj` is derived from the request — but that changes scheduling behaviour and is out of scope for this fix. Happy to follow up separately if you would prefer both values adjusted together.
